### PR TITLE
improvements to img resizers markup

### DIFF
--- a/themes/beaver/layouts/partials/img/404.html
+++ b/themes/beaver/layouts/partials/img/404.html
@@ -4,17 +4,17 @@
 
 {{ $originalWidth := $image.Width }}
 {{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
-{{ $srcset := printf "%s %dw, " $imageWebP.RelPermalink $originalWidth }}
+{{ $srcset := "" }}
 {{ range $widths }}
-{{ if le . $originalWidth }}
+{{ if lt . $originalWidth }}
 {{ $resized := $image.Resize (printf "%dx webp q75" .) }}
 {{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
 {{ end }}
 {{ end }}
-{{ $srcset = chomp (replace $srcset ", " ", ") }}
+{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
 
 <img loading="lazy" decoding="async" class="fl-photo-img size-full"
      src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
-     itemprop="image" height="{{ $image.Height }}" width="{{ $image.Width }}" title="{{ $title }}"
+     itemprop="image" width="{{ $image.Width }}" height="{{ $image.Height }}"title="{{ $title }}"
      srcset="{{ $srcset }}"
-     sizes="(max-width: 802px) 100vw, 802px" />
+     sizes="(max-width: 802px) 100vw, 802px">

--- a/themes/beaver/layouts/partials/img/careers.html
+++ b/themes/beaver/layouts/partials/img/careers.html
@@ -4,17 +4,17 @@
 
 {{ $originalWidth := $image.Width }}
 {{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
-{{ $srcset := printf "%s %dw, " $imageWebP.RelPermalink $originalWidth }}
+{{ $srcset := "" }}
 {{ range $widths }}
-{{ if le . $originalWidth }}
+{{ if lt . $originalWidth }}
 {{ $resized := $image.Resize (printf "%dx webp q75" .) }}
 {{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
 {{ end }}
 {{ end }}
-{{ $srcset = chomp (replace $srcset ", " ", ") }}
+{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
 
 <img loading="lazy" decoding="async" class="fl-photo-img size-full"
      src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
-     itemprop="image" height="{{ $image.Height }}" width="{{ $image.Width }}" title="{{ $title }}"
+     itemprop="image" width="{{ $image.Width }}" height="{{ $image.Height }}" title="{{ $title }}"
      srcset="{{ $srcset }}"
-     sizes="(max-width: 1920px) 100vw, 1920px" />
+     sizes="(max-width: 1920px) 100vw, 1920px">

--- a/themes/beaver/layouts/partials/img/client-logo.html
+++ b/themes/beaver/layouts/partials/img/client-logo.html
@@ -1,21 +1,21 @@
 {{ $image := .image }}
 {{ $title := .title }}
-{{ $widths := slice 450 300 }}
+{{ $widths := slice 300 450 }}
 
 {{ $originalWidth := $image.Width }}
 {{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
-{{ $srcset := printf "%s %dw, " $imageWebP.RelPermalink $originalWidth }}
+{{ $srcset := "" }}
 {{ range $widths }}
-{{ if le . $originalWidth }}
+{{ if lt . $originalWidth }}
 {{ $resized := $image.Resize (printf "%dx webp q75" .) }}
 {{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
 {{ end }}
 {{ end }}
-{{ $srcset = chomp (replace $srcset ", " ", ") }}
+{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
 
 <img loading="lazy" decoding="async" class="attachment-full size-full pp-post-img"
      src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
-     itemprop="image" height="{{ $image.Height }}" width="{{ $image.Width }}" title="{{ $title }}"
+     itemprop="image" width="{{ $image.Width }}" height="{{ $image.Height }}" title="{{ $title }}"
      srcset="{{ $srcset }}"
-     sizes="(max-width: 450px) 100vw, 450px" />
+     sizes="(max-width: 450px) 100vw, 450px">
 

--- a/themes/beaver/layouts/partials/img/hero-big.html
+++ b/themes/beaver/layouts/partials/img/hero-big.html
@@ -4,17 +4,17 @@
 
 {{ $originalWidth := $image.Width }}
 {{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
-{{ $srcset := printf "%s %dw, " $imageWebP.RelPermalink $originalWidth }}
+{{ $srcset := "" }}
 {{ range $widths }}
-{{ if le . $originalWidth }}
+{{ if lt . $originalWidth }}
 {{ $resized := $image.Resize (printf "%dx webp q75" .) }}
 {{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
 {{ end }}
 {{ end }}
-{{ $srcset = chomp (replace $srcset ", " ", ") }}
+{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
 
 <img fetchpriority="high" decoding="async" class="fl-photo-img size-full"
      src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
-     itemprop="image" height="{{ $image.Height }}" width="{{ $image.Width }}" title="{{ $title }}"
+     itemprop="image" width="{{ $image.Width }}" height="{{ $image.Height }}" title="{{ $title }}"
      srcset="{{ $srcset }}"
-     sizes="(max-width: 2360px) 100vw, 2360px" />
+     sizes="(max-width: 2360px) 100vw, 2360px">

--- a/themes/beaver/layouts/partials/img/hero.html
+++ b/themes/beaver/layouts/partials/img/hero.html
@@ -4,17 +4,17 @@
 
 {{ $originalWidth := $image.Width }}
 {{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
-{{ $srcset := printf "%s %dw, " $imageWebP.RelPermalink $originalWidth }}
+{{ $srcset := "" }}
 {{ range $widths }}
-{{ if le . $originalWidth }}
+{{ if lt . $originalWidth }}
 {{ $resized := $image.Resize (printf "%dx webp q75" .) }}
 {{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
 {{ end }}
 {{ end }}
-{{ $srcset = chomp (replace $srcset ", " ", ") }}
+{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
 
 <img loading="lazy" decoding="async" class="fl-photo-img size-full"
      src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
-     itemprop="image" height="{{ $image.Height }}" width="{{ $image.Width }}" title="{{ $title }}"
+     itemprop="image" width="{{ $image.Width }}" height="{{ $image.Height }}" title="{{ $title }}"
      srcset="{{ $srcset }}"
-     sizes="(max-width: 1920px) 100vw, 1920px" />
+     sizes="(max-width: 1920px) 100vw, 1920px">

--- a/themes/beaver/layouts/partials/img/testimonial.html
+++ b/themes/beaver/layouts/partials/img/testimonial.html
@@ -1,20 +1,20 @@
 {{ $image := .image }}
 {{ $title := .title }}
-{{ $widths := slice 300 150 }}
+{{ $widths := slice 150 300 }}
 
 {{ $originalWidth := $image.Width }}
 {{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
-{{ $srcset := printf "%s %dw, " $imageWebP.RelPermalink $originalWidth }}
+{{ $srcset := "" }}
 {{ range $widths }}
-{{ if le . $originalWidth }}
+{{ if lt . $originalWidth }}
 {{ $resized := $image.Resize (printf "%dx webp q75" .) }}
 {{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
 {{ end }}
 {{ end }}
-{{ $srcset = chomp (replace $srcset ", " ", ") }}
+{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
 
 <img loading="lazy" decoding="async" class="fl-photo-img size-full"
      src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
-     itemprop="image" height="{{ $image.Height }}" width="{{ $image.Width }}" title="{{ $title }}"
+     itemprop="image" width="{{ $image.Width }}" height="{{ $image.Height }}" title="{{ $title }}"
      srcset="{{ $srcset }}"
-     sizes="(max-width: 528px) 100vw, 528px" />
+     sizes="(max-width: 528px) 100vw, 528px">


### PR DESCRIPTION
1. I found some edge case when image width has one size that is same as original, the markup will show two times.
2. Removed not needed closing tag.
3. Add sizes in ascending order in one template.


Small changes to make images purrfect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved logic for generating responsive image sources across multiple templates, ensuring that only resized images smaller than the original width are included.
	- Simplified construction of the `srcset` attribute for better performance and responsiveness.

- **Bug Fixes**
	- Corrected the closing format of `<img>` tags to standard format, enhancing HTML validity.

These changes collectively enhance the user experience by improving image loading performance and ensuring optimal display across different screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->