### PR TITLE
make generic image resizer

### DIFF
--- a/themes/beaver/layouts/partials/img/404.html
+++ b/themes/beaver/layouts/partials/img/404.html
@@ -1,20 +1,3 @@
 {{ $image := .image }}
 {{ $title := .title }}
-{{ $widths := slice 300 768 802 }}
-
-{{ $originalWidth := $image.Width }}
-{{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
-{{ $srcset := "" }}
-{{ range $widths }}
-{{ if lt . $originalWidth }}
-{{ $resized := $image.Resize (printf "%dx webp q75" .) }}
-{{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
-{{ end }}
-{{ end }}
-{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
-
-<img loading="lazy" decoding="async" class="fl-photo-img size-full"
-     src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
-     itemprop="image" width="{{ $image.Width }}" height="{{ $image.Height }}"title="{{ $title }}"
-     srcset="{{ $srcset }}"
-     sizes="(max-width: 802px) 100vw, 802px">
+{{ partial "img/generic.html" (dict "image" $image "title" $title "widths" (slice 300 768 802) "sizes" "(max-width: 802px) 100vw, 802px" "attributes" "loading=\"lazy\" decoding=\"async\" itemprop=\"image\"") }}

--- a/themes/beaver/layouts/partials/img/careers.html
+++ b/themes/beaver/layouts/partials/img/careers.html
@@ -1,20 +1,3 @@
 {{ $image := .image }}
 {{ $title := .title }}
-{{ $widths := slice 300 768 1024 1210 }}
-
-{{ $originalWidth := $image.Width }}
-{{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
-{{ $srcset := "" }}
-{{ range $widths }}
-{{ if lt . $originalWidth }}
-{{ $resized := $image.Resize (printf "%dx webp q75" .) }}
-{{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
-{{ end }}
-{{ end }}
-{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
-
-<img loading="lazy" decoding="async" class="fl-photo-img size-full"
-     src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
-     itemprop="image" width="{{ $image.Width }}" height="{{ $image.Height }}" title="{{ $title }}"
-     srcset="{{ $srcset }}"
-     sizes="(max-width: 1920px) 100vw, 1920px">
+{{ partial "img/generic.html" (dict "image" $image "title" $title "widths" (slice 300 768 1024 1210) "sizes" "(max-width: 1920px) 100vw, 1920px" "attributes" "loading=\"lazy\" decoding=\"async\" itemprop=\"image\"") }}

--- a/themes/beaver/layouts/partials/img/client-logo.html
+++ b/themes/beaver/layouts/partials/img/client-logo.html
@@ -1,21 +1,3 @@
 {{ $image := .image }}
 {{ $title := .title }}
-{{ $widths := slice 300 450 }}
-
-{{ $originalWidth := $image.Width }}
-{{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
-{{ $srcset := "" }}
-{{ range $widths }}
-{{ if lt . $originalWidth }}
-{{ $resized := $image.Resize (printf "%dx webp q75" .) }}
-{{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
-{{ end }}
-{{ end }}
-{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
-
-<img loading="lazy" decoding="async" class="attachment-full size-full pp-post-img"
-     src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
-     itemprop="image" width="{{ $image.Width }}" height="{{ $image.Height }}" title="{{ $title }}"
-     srcset="{{ $srcset }}"
-     sizes="(max-width: 450px) 100vw, 450px">
-
+{{ partial "img/generic.html" (dict "image" $image "title" $title "widths" (slice 300 450) "sizes" "(max-width: 450px) 100vw, 450px" "attributes" "loading=\"lazy\" decoding=\"async\" itemprop=\"image\"") }}

--- a/themes/beaver/layouts/partials/img/generic.html
+++ b/themes/beaver/layouts/partials/img/generic.html
@@ -1,0 +1,20 @@
+{{ $image := .image }}
+{{ $title := .title }}
+{{ $widths := .widths }}
+{{ $sizes := .sizes }}
+{{ $attributes := .attributes | default "" }}
+
+{{ $originalWidth := $image.Width }}
+{{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
+{{ $srcset := "" }}
+{{ range $widths }}
+{{ if lt . $originalWidth }}
+{{ $resized := $image.Resize (printf "%dx webp q75" .) }}
+{{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
+{{ end }}
+{{ end }}
+{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
+
+<img {{ $attributes }} src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
+width="{{ $image.Width }}" height="{{ $image.Height }}" title="{{ $title }}"
+srcset="{{ $srcset }}" sizes="{{ $sizes }}">

--- a/themes/beaver/layouts/partials/img/hero-big.html
+++ b/themes/beaver/layouts/partials/img/hero-big.html
@@ -1,20 +1,3 @@
 {{ $image := .image }}
 {{ $title := .title }}
-{{ $widths := slice 300 600 768 1024 1536 2048 }}
-
-{{ $originalWidth := $image.Width }}
-{{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
-{{ $srcset := "" }}
-{{ range $widths }}
-{{ if lt . $originalWidth }}
-{{ $resized := $image.Resize (printf "%dx webp q75" .) }}
-{{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
-{{ end }}
-{{ end }}
-{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
-
-<img fetchpriority="high" decoding="async" class="fl-photo-img size-full"
-     src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
-     itemprop="image" width="{{ $image.Width }}" height="{{ $image.Height }}" title="{{ $title }}"
-     srcset="{{ $srcset }}"
-     sizes="(max-width: 2360px) 100vw, 2360px">
+{{ partial "img/generic.html" (dict "image" $image "title" $title "widths" (slice 300 600 768 1024 1536 2048) "sizes" "(max-width: 2360px) 100vw, 2360px" "attributes" "fetchpriority=\"high\" decoding=\"async\" itemprop=\"image\"") }}

--- a/themes/beaver/layouts/partials/img/hero.html
+++ b/themes/beaver/layouts/partials/img/hero.html
@@ -1,20 +1,3 @@
 {{ $image := .image }}
 {{ $title := .title }}
-{{ $widths := slice 300 600 768 1024 1536 }}
-
-{{ $originalWidth := $image.Width }}
-{{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
-{{ $srcset := "" }}
-{{ range $widths }}
-{{ if lt . $originalWidth }}
-{{ $resized := $image.Resize (printf "%dx webp q75" .) }}
-{{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
-{{ end }}
-{{ end }}
-{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
-
-<img loading="lazy" decoding="async" class="fl-photo-img size-full"
-     src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
-     itemprop="image" width="{{ $image.Width }}" height="{{ $image.Height }}" title="{{ $title }}"
-     srcset="{{ $srcset }}"
-     sizes="(max-width: 1920px) 100vw, 1920px">
+{{ partial "img/generic.html" (dict "image" $image "title" $title "widths" (slice 300 600 768 1024 1536) "sizes" "(max-width: 1920px) 100vw, 1920px" "attributes" "loading=\"lazy\" decoding=\"async\" itemprop=\"image\"") }}

--- a/themes/beaver/layouts/partials/img/testimonial.html
+++ b/themes/beaver/layouts/partials/img/testimonial.html
@@ -1,20 +1,3 @@
 {{ $image := .image }}
 {{ $title := .title }}
-{{ $widths := slice 150 300 }}
-
-{{ $originalWidth := $image.Width }}
-{{ $imageWebP := $image.Resize (printf "%dx webp q75" $originalWidth) }}
-{{ $srcset := "" }}
-{{ range $widths }}
-{{ if lt . $originalWidth }}
-{{ $resized := $image.Resize (printf "%dx webp q75" .) }}
-{{ $srcset = printf "%s%s %dw, " $srcset $resized.RelPermalink . }}
-{{ end }}
-{{ end }}
-{{ $srcset = printf "%s%s %dw" $srcset $imageWebP.RelPermalink $originalWidth }}
-
-<img loading="lazy" decoding="async" class="fl-photo-img size-full"
-     src="{{ $imageWebP.RelPermalink }}" alt="{{ $title }}"
-     itemprop="image" width="{{ $image.Width }}" height="{{ $image.Height }}" title="{{ $title }}"
-     srcset="{{ $srcset }}"
-     sizes="(max-width: 528px) 100vw, 528px">
+{{ partial "img/generic.html" (dict "image" $image "title" $title "widths" (slice 150 300) "sizes" "(max-width: 528px) 100vw, 528px" "attributes" "loading=\"lazy\" decoding=\"async\" itemprop=\"image\"") }}


### PR DESCRIPTION
Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new partial template for image rendering (`img/generic.html`), enhancing responsive design and maintainability.
	- Simplified image handling in various templates (404, careers, client logo, hero, testimonial) by delegating logic to the new partial.

- **Refactor**
	- Refactored image rendering logic across multiple templates to improve code structure and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->