### PR TITLE
[ux] Headline for Mobile is too big

### DIFF
--- a/themes/beaver/assets/css/style.css
+++ b/themes/beaver/assets/css/style.css
@@ -31,6 +31,17 @@
   line-height: 92px;
   font-weight: 700;
   margin: 0 0 32px !important;
+
+  @media (max-width: 1024px) {
+    font-size: 42px;
+    line-height: 52px;
+  }
+
+  @media (max-width: 768px) {
+    font-size: 32px;
+    line-height: 38px;
+    margin-bottom: 24px;
+  }
 }
 
 .blog h2 {


### PR DESCRIPTION
Optionally can change font-size, margins etc for blog entry.

Optionally can design blog with new simpler template, and desintegrate it from main website. (of course with links to main website in navbar).


![Image](https://github.com/user-attachments/assets/1ecb5a2f-b89d-49ff-8287-532907c86768)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented responsive design adjustments for improved readability on smaller devices.
	- Added media queries for better text presentation on screens up to 1024px and 768px.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->