### PR TITLE
Fix case when cover link has 2 level cdn

### DIFF
--- a/bin/upload_assets_to_github
+++ b/bin/upload_assets_to_github
@@ -41,9 +41,12 @@ class ImageDownloader
   def remove_cdn(url)
     parts = url.split("https")
     encoded_url = 'https' + parts.last
+    max_iterations = 10
+    iterations = 0
 
-    while encoded_url.include?('%')
+    while encoded_url.include?('%') && iterations < max_iterations
       encoded_url = URI.decode_www_form_component(encoded_url)
+      iterations += 1
     end
 
     encoded_url

--- a/bin/upload_assets_to_github
+++ b/bin/upload_assets_to_github
@@ -39,12 +39,14 @@ class ImageDownloader
   end
 
   def remove_cdn(url)
-    if url.include?('cdn-cgi')
-      decoded_url = URI.decode_www_form_component(url.split('/https%3A').last)
-      'https:' + decoded_url
-    else
-      url
+    parts = url.split("https")
+    encoded_url = 'https' + parts.last
+
+    while encoded_url.include?('%')
+      encoded_url = URI.decode_www_form_component(encoded_url)
     end
+
+    encoded_url
   end
 end
 


### PR DESCRIPTION
Fix cases when link has 2 CDN:

"https://media.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fmedia.dev.to%2Fcdn-cgi%2Fimage%2Fwidth%3D1000%2Cheight%3D420%2Cfit%3Dcover%2Cgravity%3Dauto%2Cformat%3Dauto%2Fhttps%253A%252F%252Fdev-to-uploads.s3.amazonaws.com%252Fuploads%252Farticles%252Fe5v2rr5n6hpl385pt5f3.png"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved URL handling for image downloads, ensuring better processing of percent-encoded characters.

- **Bug Fixes**
	- Streamlined logic for URL reconstruction, enhancing reliability in image downloading.

- **Refactor**
	- Simplified the `remove_cdn` method for better performance without altering the overall functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes https://github.com/jetthoughts/jetthoughts.github.io/issues/171