### PR TITLE
[UX] Cleanup "See more posts" for blog index page

### DIFF
--- a/themes/beaver/assets/css/navigation.css
+++ b/themes/beaver/assets/css/navigation.css
@@ -9,6 +9,8 @@
   white-space: nowrap;
   display: inline-block;
   vertical-align: top;
+  min-width: 100px;
+  text-align: center;
 }
 
 .btn-primary {

--- a/themes/beaver/assets/css/pagination.css
+++ b/themes/beaver/assets/css/pagination.css
@@ -1,8 +1,8 @@
 .pagination {
   display: flex;
-  padding-left: 0;
   list-style: none;
-  margin-top: 5rem;
+  padding: 0;
+  margin: 50px 0 0;
 }
 
 .page-link {

--- a/themes/beaver/layouts/partials/pagination.html
+++ b/themes/beaver/layouts/partials/pagination.html
@@ -5,8 +5,8 @@
 
       {{- with .Next }}
         <li class="page-item">
-          <a aria-label="Next" class="page-link" href="{{ .URL }}" role="button"
-            >See more posts »</a
+          <a aria-label="Next" class="btn btn-primary" href="{{ .URL }}" role="button"
+            >Next</a
           >
         </li>
       {{- end }}


### PR DESCRIPTION
For now we have pretty ugly version: ![Image](https://github.com/user-attachments/assets/b2504e1c-dd31-4aa1-a197-21c030c0207f)


will be great to have style like on other pages


![Image](https://github.com/user-attachments/assets/73700889-b718-4c4d-a4d8-d52078e721d4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced button styles with a minimum width and centered text for improved usability.
	- Updated pagination "Next" button with new styling and text.

- **Bug Fixes**
	- Streamlined pagination layout by adjusting padding and margin properties for better spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->