### PR TITLE
fix(hugo): use .Site.Data instead of hugo.Data

### DIFF
--- a/themes/beaver/layouts/partials/blog/json-ld.html
+++ b/themes/beaver/layouts/partials/blog/json-ld.html
@@ -14,7 +14,7 @@
       "datePublished": "{{ with .Params.created_at }}{{ . }}{{ else }}{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}{{ end }}",
       "dateModified": "{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}",
       "mainEntityOfPage": "{{ .Permalink }}",
-      "publisher": {{ hugo.Data.company | jsonify }},
+      "publisher": {{ with .Site.Data.company }}{{ . | jsonify }}{{ else }}{"@type":"Organization","name":"JetThoughts","url":"https://jetthoughts.com/"}{{ end }},
       {{ with (.Resources.Get .Params.metatags.image) }}
         "image": {
           "@type": "ImageObject",

--- a/themes/beaver/layouts/partials/components/testimonial.html
+++ b/themes/beaver/layouts/partials/components/testimonial.html
@@ -32,7 +32,7 @@
 {{- $rating := .rating | default "4.8" -}}
 {{- $rating_text := .rating_text | default "Based on client reviews" -}}
 {{- $node_id := .node_id | default "testimonials" -}}
-{{- $testimonialsData := hugo.Data.testimonials -}}
+{{- $testimonialsData := .Site.Data.testimonials -}}
 
 {{- $nonCriticalCSS := resources.Get "css/vendors/swiper.min.css" | fingerprint "md5" -}}
 <link fetchpriority="low" rel="preload" href="{{ $nonCriticalCSS.RelPermalink }}" as="style" onload="this.onload=null;this.rel='stylesheet'">

--- a/themes/beaver/layouts/partials/data/authors-cached.html
+++ b/themes/beaver/layouts/partials/data/authors-cached.html
@@ -1,3 +1,3 @@
 {{/* Cached authors data access - invalidates when authors.yaml changes */}}
-{{ $authorsHash := hugo.Data.authors | jsonify | md5 }}
+{{ $authorsHash := .Site.Data.authors | jsonify | md5 }}
 {{ return partialCached "data/authors-content.html" . $authorsHash }}

--- a/themes/beaver/layouts/partials/data/company-cached.html
+++ b/themes/beaver/layouts/partials/data/company-cached.html
@@ -1,3 +1,3 @@
 {{/* Cached company data access - invalidates when company.yaml changes */}}
-{{ $companyHash := hugo.Data.company | jsonify | md5 }}
+{{ $companyHash := .Site.Data.company | jsonify | md5 }}
 {{ return partialCached "data/company-content.html" . $companyHash }}

--- a/themes/beaver/layouts/partials/data/testimonials-cached.html
+++ b/themes/beaver/layouts/partials/data/testimonials-cached.html
@@ -1,3 +1,3 @@
 {{/* Cached testimonials data access - invalidates when testimonials.yaml changes */}}
-{{ $testimonialsHash := hugo.Data.testimonials | jsonify | md5 }}
+{{ $testimonialsHash := .Site.Data.testimonials | jsonify | md5 }}
 {{ return partialCached "data/testimonials-content.html" . $testimonialsHash }}

--- a/themes/beaver/layouts/partials/homepage/companies.html
+++ b/themes/beaver/layouts/partials/homepage/companies.html
@@ -1,5 +1,5 @@
 <ul class="client-logos">
-  {{ range $index, $tech := hugo.Data.companies }}
+  {{ range $index, $tech := .Site.Data.companies }}
     <li class="client-logo">
       {{ $image := resources.Get $tech.image }}
       {{ if $image }}

--- a/themes/beaver/layouts/partials/page/testimonials.html
+++ b/themes/beaver/layouts/partials/page/testimonials.html
@@ -70,7 +70,7 @@
   }
 </style>
 
-{{ $testimonialsData := hugo.Data.testimonials }}
+{{ $testimonialsData := .Site.Data.testimonials }}
 
 <div>
   <div style="text-align: center;">

--- a/themes/beaver/layouts/partials/technologies.html
+++ b/themes/beaver/layouts/partials/technologies.html
@@ -8,7 +8,7 @@
     </div>
 
     <div class="container">
-    {{ range $index, $tech := hugo.Data.technologies }}
+    {{ range $index, $tech := .Site.Data.technologies }}
         <div class="item">
             {{ partial "svg" $tech.icon }}
             <div>{{ $tech.name }}</div>


### PR DESCRIPTION
## Summary
- Replaces `hugo.Data` with `.Site.Data` across 8 template partials
- `hugo.Data` does not exist in Hugo 0.149.1 — the `hugo` template function only exposes version/environment info, not data file access
- The broken migration was introduced in cf7369a0d; `.Site.Data` is the correct context-based accessor
- Adds fallback guard in `json-ld.html` publisher field

## Test plan
- [ ] Hugo build completes without `can't evaluate field Data in type interface {}` errors
- [ ] JSON-LD, companies, testimonials, technologies, and authors data render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)