### PR TITLE
Docs: replace .Site.Data examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,3 +107,6 @@ Follow official methodology from `/knowledge/`:
 **Coverage**: Full codebase indexed (830+ files, 4,184+ semantic chunks)
 **Design System**: JetVelocity — obsidian dark, Ruby red (#cc342d), neon purple (#a855f7). See `.stitch/design.md`
 **ICP**: Non-technical founder burned by a devshop. See `docs/90-99-content-strategy/strategy-analysis/90.10-icp-primary-website-target.md`
+
+## Tooling Preference
+- Use `bun` for JS dependency installs and scripts; do not use `npm`.

--- a/docs/components/best-practices.md
+++ b/docs/components/best-practices.md
@@ -297,7 +297,7 @@
 {{ end }}
 
 {{/* From data files */}}
-{{ with .Site.Data.content.blocks }}
+{{ with hugo.Data.content.blocks }}
   {{ $content_data = merge $content_data (index . $.block_id) }}
 {{ end }}
 
@@ -558,7 +558,7 @@ grep -r "c-content-block" themes/beaver/layouts/ | wc -l >> reports/component-us
 #### Site Data Integration
 ```go
 {{/* ✅ Good: Flexible data source handling */}}
-{{ range .Site.Data.services.services }}
+{{ range hugo.Data.services.services }}
   {{ partial "components/service-card.html" (dict
     "icon" .icon
     "title" .name
@@ -582,7 +582,7 @@ grep -r "c-content-block" themes/beaver/layouts/ | wc -l >> reports/component-us
 #### Data Mapping Patterns
 ```go
 {{/* ✅ Good: Clear data transformation */}}
-{{ $service_data := index .Site.Data.services.services 0 }}
+{{ $service_data := index hugo.Data.services.services 0 }}
 {{ partial "components/service-card.html" (dict
   "icon" $service_data.icon
   "title" $service_data.name           // Map 'name' to 'title'
@@ -834,8 +834,8 @@ curl http://localhost:1313/services/ | grep "service-card"
 #### Data Validation
 ```go
 {{/* ✅ Good: Validate required data */}}
-{{- if and .Site.Data.testimonials .Site.Data.testimonials.testimonials -}}
-  {{ range .Site.Data.testimonials.testimonials }}
+{{- if and hugo.Data.testimonials hugo.Data.testimonials.testimonials -}}
+  {{ range hugo.Data.testimonials.testimonials }}
     <!-- Render testimonials -->
   {{ end }}
 {{- else -}}

--- a/docs/components/components-guide.md
+++ b/docs/components/components-guide.md
@@ -236,7 +236,7 @@ node_id       string  // FL-Builder node ID (defaults to "testimonials")
 - **Badge Integration**: Company badges (GoodFirms, Clutch, Glassdoor, etc.)
 - **Star Ratings**: Visual star images with scores
 - **Swiper Carousel**: Dynamic testimonial slider
-- **Data Integration**: Reads from `.Site.Data.testimonials` or `.Site.Params.testimonials`
+- **Data Integration**: Reads from `hugo.Data.testimonials` or `.Site.Params.testimonials`
 - **CSS Loading**: Non-critical CSS with preload optimization
 - **Responsive Layout**: Flex container with mobile column layout
 
@@ -258,7 +258,7 @@ node_id       string  // FL-Builder node ID (defaults to "testimonials")
 {{/* Service grid pattern */}}
 <div class="fl-row">
   <div class="fl-col-group">
-    {{ range .Site.Data.services.services }}
+    {{ range hugo.Data.services.services }}
       {{ partial "components/service-card.html" . }}
     {{ end }}
   </div>
@@ -283,7 +283,7 @@ node_id       string  // FL-Builder node ID (defaults to "testimonials")
 ### 3. Data Integration
 ```go
 {{/* Service data integration */}}
-{{ $service := index .Site.Data.services.services 0 }}
+{{ $service := index hugo.Data.services.services 0 }}
 {{ partial "components/service-card.html" (dict
   "icon" $service.icon
   "title" $service.title

--- a/docs/components/migration-guide.md
+++ b/docs/components/migration-guide.md
@@ -391,12 +391,12 @@ grep -r "text-align.*center" themes/beaver/assets/css/ # Identified alignment pa
 2. **Data Source Integration**
    ```go
    {{/* Service data integration */}}
-   {{ range .Site.Data.services.services }}
+   {{ range hugo.Data.services.services }}
      {{ partial "components/service-card.html" . }}
    {{ end }}
 
    {{/* Use case data integration */}}
-   {{ $use_case_data := .Site.Data.menu.menu_custom.use_cases }}
+   {{ $use_case_data := hugo.Data.menu.menu_custom.use_cases }}
    {{ $page_data := .Page.Params }}
    {{ partial "components/use-case-card.html" (dict
      "icon" $use_case_data.icon
@@ -485,7 +485,7 @@ grep -r "text-align.*center" themes/beaver/assets/css/ # Identified alignment pa
 
 **Solution**: Create data mapping layer
 ```go
-{{ $service_data := index .Site.Data.services.services 0 }}
+{{ $service_data := index hugo.Data.services.services 0 }}
 {{ partial "components/service-card.html" (dict
   "icon" $service_data.icon
   "title" $service_data.name           // Map 'name' to 'title'

--- a/docs/components/service-card.md
+++ b/docs/components/service-card.md
@@ -56,7 +56,7 @@ The Service Card component displays service offerings with icons, descriptions, 
 ### Data Integration
 ```go
 {{/* Using site data */}}
-{{ range .Site.Data.services.services }}
+{{ range hugo.Data.services.services }}
   {{ partial "components/service-card.html" . }}
 {{ end }}
 ```
@@ -131,7 +131,7 @@ The Service Card component displays service offerings with icons, descriptions, 
 ### Homepage Service Grid
 **File**: `themes/beaver/layouts/partials/homepage/services.html`
 ```go
-{{ range .Site.Data.services.services }}
+{{ range hugo.Data.services.services }}
   {{ if .featured }}
     {{ partial "components/service-card.html" (dict
       "icon" .icon


### PR DESCRIPTION
## Summary\n- replace deprecated .Site.Data references in docs examples with hugo.Data\n- add bun tooling preference to CLAUDE.md\n\n## Testing\n- not run (PostCSS missing locally)