### PR TITLE
fix: serve blog post cover images via CDN proxy

### DIFF
--- a/docs/workflows/cdn-image-proxy.md
+++ b/docs/workflows/cdn-image-proxy.md
@@ -42,6 +42,7 @@ Gate in templates: `{{ if site.Params.cdn.enabled }}`
 | `partials/blog/img-cropped.html` | Retina thumbnail via wsrv.nl |
 | `partials/seo/enhanced-meta-tags.html` | OG image (1200×630) via wsrv.nl |
 | `_shortcodes/img.html` | Direct image via wsrv.nl |
+| `single.html` | Blog post cover image srcset (640/960/1920w webp) via wsrv.nl |
 
 **Note:** Root `layouts/` overrides `themes/beaver/layouts/`. Both `enhanced-meta-tags.html` copies must stay in sync.
 
@@ -53,10 +54,19 @@ Gate in templates: `{{ if site.Params.cdn.enabled }}`
 - `&q=N` — quality (80 content, 85 OG, 90 thumbnails)
 - `&fit=cover` — crop to exact dimensions (OG images)
 
+## Building with CDN Enabled
+
+To test the production CDN build locally:
+
+```bash
+ENVIRONMENT=production bin/hugo-build
+```
+
+This uses `config/production/hugo.toml` which sets `params.cdn.enabled = true`. Verify CDN URLs appear in the output HTML (look for `wsrv.nl` in image src attributes). The processed image count should drop from ~8000 to ~177.
+
 ## Not Yet Covered
 
 Non-blog image templates (assets from `assets/`/`static/`, unaffected by blog media cleanup):
 
 - `partials/img/generic.html` (hero, homepage, testimonials)
 - `partials/img/resize.html`
-- `partials/page/cover_image.html`

--- a/themes/beaver/layouts/partials/page/cover_image.html
+++ b/themes/beaver/layouts/partials/page/cover_image.html
@@ -1,11 +1,19 @@
 {{ if . }}
-  {{ $coverImage := .Fit "512x512 jpeg" }}
-
-  {{ with $coverImage }}
+  {{ if site.Params.cdn.enabled }}
+    {{/* CDN proxy — no Hugo image processing needed */}}
     <meta content="{{ .Permalink }}" property="og:image" />
     <meta content="{{ .Width }}" property="og:image:width" />
     <meta content="{{ .Height }}" property="og:image:height" />
     <meta content="summary_large_image" name="twitter:card" />
     <meta content="{{ .Permalink }}" name="twitter:image" />
+  {{ else }}
+    {{ $coverImage := .Fit "512x512 jpeg" }}
+    {{ with $coverImage }}
+      <meta content="{{ .Permalink }}" property="og:image" />
+      <meta content="{{ .Width }}" property="og:image:width" />
+      <meta content="{{ .Height }}" property="og:image:height" />
+      <meta content="summary_large_image" name="twitter:card" />
+      <meta content="{{ .Permalink }}" name="twitter:image" />
+    {{ end }}
   {{ end }}
 {{ end }}

--- a/themes/beaver/layouts/partials/page/cover_image.html
+++ b/themes/beaver/layouts/partials/page/cover_image.html
@@ -1,6 +1,5 @@
 {{ if . }}
   {{ if site.Params.cdn.enabled }}
-    {{/* CDN proxy — no Hugo image processing needed */}}
     <meta content="{{ .Permalink }}" property="og:image" />
     <meta content="{{ .Width }}" property="og:image:width" />
     <meta content="{{ .Height }}" property="og:image:height" />

--- a/themes/beaver/layouts/single.html
+++ b/themes/beaver/layouts/single.html
@@ -89,11 +89,27 @@
                on mobile the text comes first because that's what
                keeps founders reading at 11pm. */}}
           {{ with .Resources.GetMatch "cover.*" }}
-            {{ $w640  := .Resize "640x webp q85" }}
-            {{ $w960  := .Resize "960x webp q85" }}
-            {{ $w1920 := .Resize "1920x webp q82" }}
             <style>.post-cover-figure { display: block; } @media (max-width: 688px) { .post-cover-figure { display: none; } }</style>
             <figure class="post-cover-figure" style="margin: 0 0 1.25rem; max-width: 43rem;">
+            {{ if site.Params.cdn.enabled }}
+              {{ $src640  := partial "cdn/url" (dict "page" $ "resource" . "params" "w=640&output=webp&q=85") }}
+              {{ $src960  := partial "cdn/url" (dict "page" $ "resource" . "params" "w=960&output=webp&q=85") }}
+              {{ $src1920 := partial "cdn/url" (dict "page" $ "resource" . "params" "w=1920&output=webp&q=82") }}
+              <img
+                class="post-cover"
+                src="{{ $src960 }}"
+                srcset="{{ $src640 }} 640w, {{ $src960 }} 960w, {{ $src1920 }} 1920w"
+                sizes="(max-width: 688px) 100vw, 688px"
+                alt="{{ $.Params.cover_image_alt | default $.Title }}"
+                width="{{ .Width }}"
+                height="{{ .Height }}"
+                loading="eager"
+                fetchpriority="high"
+                style="width: 100%; height: auto; border-radius: 8px; display: block; box-shadow: 0 1px 6px rgba(0,0,0,0.10);" />
+            {{ else }}
+              {{ $w640  := .Resize "640x webp q85" }}
+              {{ $w960  := .Resize "960x webp q85" }}
+              {{ $w1920 := .Resize "1920x webp q82" }}
               <img
                 class="post-cover"
                 src="{{ $w960.Permalink }}"
@@ -105,6 +121,7 @@
                 loading="eager"
                 fetchpriority="high"
                 style="width: 100%; height: auto; border-radius: 8px; display: block; box-shadow: 0 1px 6px rgba(0,0,0,0.10);" />
+            {{ end }}
               {{ with $.Params.cover_image_caption }}
                 <figcaption style="font-size: 0.875rem; color: rgba(33,37,41,0.65); text-align: center; margin-top: 0.75rem; font-style: italic;">{{ . | safeHTML }}</figcaption>
               {{ end }}


### PR DESCRIPTION
## Summary
- Blog post cover images on single pages were returning 404 in production because `single.html` used Hugo image processing instead of CDN URLs
- The CI pipeline deletes processed images from `public/blog/` after build, so Hugo-generated `.webp` URLs don't exist on GitHub Pages
- Added `site.Params.cdn.enabled` gate to `single.html` cover image block and `cover_image.html` partial, matching the pattern already used in `render-image.html` and `img-cropped.html`

## Test plan
- [ ] `ENVIRONMENT=production bin/hugo-build` succeeds with ~177 processed images (not ~8000)
- [ ] Verify `wsrv.nl` URLs in generated HTML: `grep post-cover _dest/public-dev/blog/*/index.html`
- [ ] CDN URLs return HTTP 200: `curl -sI "https://wsrv.nl/?url=raw.githubusercontent.com/jetthoughts/jetthoughts.github.io/master/content/blog/rails-8-1-active-job-continuations-end-lost-background-jobs/cover.png&w=960&output=webp&q=85"`
- [ ] Development build (`bin/hugo-build`) still uses local Hugo image processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog post cover images now support optional CDN proxy delivery, automatically serving optimized WebP images at multiple resolutions (640px, 960px, 1920px) to improve performance and reduce server-side image processing overhead.

* **Documentation**
  * Updated documentation with comprehensive instructions for configuring and enabling CDN image proxy in production builds, including detailed verification steps and configuration examples for local testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->