### PR TITLE
refactor(seo): replace generic "Learn More" links with descriptive anchor text

### DIFF
--- a/themes/beaver/layouts/home.html
+++ b/themes/beaver/layouts/home.html
@@ -166,7 +166,7 @@
                                           target="_self"
                                           class="fl-button">
                                           <span class="fl-button-text"
-                                            >Learn More</span
+                                            >Explore Use Cases</span
                                           >
                                         </a>
                                       </div>
@@ -373,7 +373,7 @@
                                           href="{{ relURL "services/fractional-cto/" }}"
                                           role="button"
                                           target="_self">
-                                          Learn More
+                                          Fractional CTO Services
                                           <i
                                             class="pp-button-icon pp-button-icon-right far fa-long-arrow-right"></i>
                                         </a>
@@ -427,7 +427,7 @@
                                           href="{{ relURL "services/app-web-development/" }}"
                                           role="button"
                                           target="_self">
-                                          Learn More
+                                          App &amp; Web Development
                                           <i
                                             class="pp-button-icon pp-button-icon-right far fa-long-arrow-right"></i>
                                         </a>
@@ -481,7 +481,7 @@
                                           href="{{ relURL "services/software-qa-cat/" }}"
                                           role="button"
                                           target="_self">
-                                          Learn More
+                                          Software QA &amp; Testing
                                           <i
                                             class="pp-button-icon pp-button-icon-right far fa-long-arrow-right"></i>
                                         </a>
@@ -556,7 +556,7 @@
                                           href="{{ relURL "services/fractional-product-management/" }}"
                                           role="button"
                                           target="_self">
-                                          Learn More
+                                          Fractional Product Management
                                           <i
                                             class="pp-button-icon pp-button-icon-right far fa-long-arrow-right"></i>
                                         </a>
@@ -610,7 +610,7 @@
                                           href="{{ relURL "services/outsourced-developer-staffing/" }}"
                                           role="button"
                                           target="_self">
-                                          Learn More
+                                          Developer Staffing Services
                                           <i
                                             class="pp-button-icon pp-button-icon-right far fa-long-arrow-right"></i>
                                         </a>
@@ -664,7 +664,7 @@
                                           href="{{ relURL "services/talent-recruiting-training/" }}"
                                           role="button"
                                           target="_self">
-                                          Learn More
+                                          Talent Recruiting &amp; Training
                                           <i
                                             class="pp-button-icon pp-button-icon-right far fa-long-arrow-right"></i>
                                         </a>


### PR DESCRIPTION
## Summary

- Replace 7 generic "Learn More" link texts on the homepage with descriptive, service-specific anchor text
- Improves SEO by providing meaningful link context for crawlers
- Improves accessibility by giving screen reader users clear link destinations

## Changes

| Before | After |
|--------|-------|
| Learn More | Explore Use Cases |
| Learn More | Fractional CTO Services |
| Learn More | App & Web Development |
| Learn More | Software QA & Testing |
| Learn More | Fractional Product Management |
| Learn More | Developer Staffing Services |
| Learn More | Talent Recruiting & Training |

## Why

Generic "Learn More" anchor text is flagged by Lighthouse SEO audits as non-descriptive. Descriptive link text helps search engines understand page relationships and helps users (especially those using assistive technology) understand where links lead without additional context.

## Test Plan

- [ ] Run `bin/hugo-build` — zero build errors
- [ ] Verify homepage renders correctly with new link text
- [ ] Run Lighthouse SEO audit — confirm no "Links do not have descriptive text" warnings