### PR TITLE
fix(homepage): align button title attributes with visible text

### DIFF
--- a/themes/beaver/layouts/home.html
+++ b/themes/beaver/layouts/home.html
@@ -368,7 +368,7 @@
                                       <div
                                         class="pp-infobox-button pp-button-wrap">
                                         <a
-                                          title="Fractional CTO"
+                                          title="Fractional CTO Services"
                                           class="pp-more-link pp-button"
                                           href="{{ relURL "services/fractional-cto/" }}"
                                           role="button"
@@ -422,7 +422,7 @@
                                       <div
                                         class="pp-infobox-button pp-button-wrap">
                                         <a
-                                          title="App/Web Development"
+                                          title="App & Web Development"
                                           class="pp-more-link pp-button"
                                           href="{{ relURL "services/app-web-development/" }}"
                                           role="button"
@@ -476,7 +476,7 @@
                                       <div
                                         class="pp-infobox-button pp-button-wrap">
                                         <a
-                                          title="Software QA & CAT"
+                                          title="Software QA & Testing"
                                           class="pp-more-link pp-button"
                                           href="{{ relURL "services/software-qa-cat/" }}"
                                           role="button"
@@ -605,7 +605,7 @@
                                       <div
                                         class="pp-infobox-button pp-button-wrap">
                                         <a
-                                          title="Outsourced Developer Staffing"
+                                          title="Developer Staffing Services"
                                           class="pp-more-link pp-button"
                                           href="{{ relURL "services/outsourced-developer-staffing/" }}"
                                           role="button"
@@ -659,7 +659,7 @@
                                       <div
                                         class="pp-infobox-button pp-button-wrap">
                                         <a
-                                          title="Talent Recruiting and Training"
+                                          title="Talent Recruiting & Training"
                                           class="pp-more-link pp-button"
                                           href="{{ relURL "services/talent-recruiting-training/" }}"
                                           role="button"


### PR DESCRIPTION
## Summary

Fixes title attribute mismatches on all six service CTA buttons found during code review of the original branch.

## Changes

| Button | title (before) | title (after) |
|---|---|---|
| Fractional CTO | `Fractional CTO` | `Fractional CTO Services` |
| App & Web Dev | `App/Web Development` | `App & Web Development` |
| Software QA | `Software QA & CAT` | `Software QA & Testing` |
| Fractional PM | *(already matched)* | -- |
| Dev Staffing | `Outsourced Developer Staffing` | `Developer Staffing Services` |
| Recruiting | `Talent Recruiting and Training` | `Talent Recruiting & Training` |

## Why

Mismatched title attributes create confusing tooltips for mouse users and incorrect accessible names for screen readers. They also send mixed signals to search engines crawling link text.