### PR TITLE
chore: add Stitch cover image metadata

### DIFF
--- a/.stitch/metadata.covers.json
+++ b/.stitch/metadata.covers.json
@@ -1,0 +1,16 @@
+{
+  "name": "projects/3224353017067976684",
+  "projectId": "3224353017067976684",
+  "title": "JetThoughts Blog Covers",
+  "visibility": "PRIVATE",
+  "projectType": "PROJECT_DESIGN",
+  "deviceType": "DESKTOP",
+  "designTheme": {
+    "colorMode": "DARK",
+    "font": "SPACE_GROTESK",
+    "roundness": "ROUND_FOUR",
+    "customColor": "#cc342d",
+    "saturation": 3
+  },
+  "screens": {}
+}


### PR DESCRIPTION
## Summary

Adds cover image metadata entries to `.stitch/metadata.covers.json` for tracking generated blog post cover images.

## Changes

- Added 16 lines of cover image metadata to `.stitch/metadata.covers.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Added project cover design metadata configuration file with settings for dark color mode, custom typography, corner roundness adjustments, accent color, and saturation level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->