### PR TITLE
fix(ci): update actions-hugo from feat branch to v3 release

### DIFF
--- a/.github/actions/setup-hugo/action.yml
+++ b/.github/actions/setup-hugo/action.yml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: jetthoughts/actions-hugo@feat/node24
+    - uses: jetthoughts/actions-hugo@v3
       with:
         hugo-version: ${{ inputs.hugo-version }}
         extended: true

--- a/.github/workflows/_hugo.yml
+++ b/.github/workflows/_hugo.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Hugo
-        uses: jetthoughts/actions-hugo@feat/node24
+        uses: jetthoughts/actions-hugo@v3
         with:
           hugo-version: 0.160.1
           extended: true


### PR DESCRIPTION
## Summary

- Update `jetthoughts/actions-hugo` reference from `@feat/node24` to `@v3` in both CI configuration files
- Pins Hugo setup action to the stable release tag instead of a feature branch

## Changed Files

- `.github/actions/setup-hugo/action.yml` — reusable composite action
- `.github/workflows/_hugo.yml` — Hugo build workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Hugo build setup action to use a stable versioned release (v3) instead of a development branch, ensuring more consistent and reliable builds across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->