### PR TITLE
perf: inline critical CSS to fix mobile PageSpeed

### DIFF
--- a/themes/beaver/layouts/baseof.html
+++ b/themes/beaver/layouts/baseof.html
@@ -22,10 +22,10 @@
     <meta name="theme-color" content="#ffffff" />
 
     {{- $navigationResources := slice (resources.Get "css/navigation.css") -}}
-    {{ partialCached "assets/css-processor.html" (dict "resources" $navigationResources "bundleName" "navigation" "context" .) "navigation" }}
+    {{ partialCached "assets/css-inline.html" (dict "resources" $navigationResources "bundleName" "navigation") "navigation" }}
 
     {{- $componentsResources := slice (resources.Get "css/components.css") -}}
-    {{ partialCached "assets/css-processor.html" (dict "resources" $componentsResources "bundleName" "components" "context" .) "components" }}
+    {{ partialCached "assets/css-inline.html" (dict "resources" $componentsResources "bundleName" "components") "components" }}
 
     {{/* Enhanced SEO Schema Markup */}}
     {{ partial "seo/enhanced-organization-schema.html" . }}

--- a/themes/beaver/layouts/partials/assets/css-inline.html
+++ b/themes/beaver/layouts/partials/assets/css-inline.html
@@ -1,0 +1,10 @@
+{{/* Inline CSS processor - outputs <style> tag instead of <link> to eliminate render-blocking requests */}}
+{{- $resources := .resources -}}
+{{- $bundleName := .bundleName -}}
+{{- $bundle := $resources | resources.Concat (printf "css/%s.css" $bundleName) | postCSS -}}
+
+{{- if hugo.IsProduction -}}
+  {{- $bundle = $bundle | minify -}}
+{{- end -}}
+
+<style>{{ $bundle.Content | safeCSS }}</style>


### PR DESCRIPTION
## Summary
- Inline navigation CSS (5.3 KiB) and components CSS (1.8 KiB) as `<style>` tags instead of external `<link>` sheets
- Eliminates 2 of 3 render-blocking CSS requests flagged by mobile PageSpeed Insights
- Estimated savings: ~150ms on mobile LCP/FCP

## What changed
- New `css-inline.html` partial — same PostCSS pipeline but outputs `<style>` instead of `<link>`
- `baseof.html` — switched navigation and components from `css-processor` to `css-inline`

## Test plan
- [x] `bin/hugo-build` passes
- [x] `bin/rake test:critical` — 81 screenshots compared, 0 visual failures
- [ ] Run mobile PageSpeed on surge preview to verify render-blocking reduction
- [ ] Verify navigation and components styles render correctly on mobile


🤖 Generated with [Claude Code](https://claude.com/claude-code)