### PR TITLE
fix: use sha256 for SRI fingerprinting instead of unsupported md5

### DIFF
--- a/themes/beaver/layouts/partials/assets/css-processor.html
+++ b/themes/beaver/layouts/partials/assets/css-processor.html
@@ -1,7 +1,7 @@
 {{/* Unified CSS processor - maintains backward compatibility */}}
 {{- $resources := .resources -}}
 {{- $bundleName := .bundleName -}}
-{{- $bundle := $resources | resources.Concat (printf "css/%s.css" $bundleName) | postCSS | fingerprint "md5" -}}
+{{- $bundle := $resources | resources.Concat (printf "css/%s.css" $bundleName) | postCSS | fingerprint "sha256" -}}
 
 {{- if hugo.IsProduction -}}
   {{- $bundle = $bundle | minify | resources.PostProcess -}}

--- a/themes/beaver/layouts/partials/assets/js-processor.html
+++ b/themes/beaver/layouts/partials/assets/js-processor.html
@@ -23,7 +23,7 @@
   {{- $processed := $bundle | js.Build (dict "minify" hugo.IsProduction) -}}
   
   {{/* Step 3: Fingerprint for cache busting */}}
-  {{- $processed = $processed | fingerprint "md5" -}}
+  {{- $processed = $processed | fingerprint "sha256" -}}
   
   {{/* Step 4: PostProcess for production */}}
   {{- if hugo.IsProduction -}}


### PR DESCRIPTION
Browsers reject MD5 integrity attributes. Changed both CSS and JS processors to use SHA-256, which is required for Subresource Integrity validation.

**Changes:**
- `css-processor.html`: `fingerprint "md5"` → `fingerprint "sha256"`
- `js-processor.html`: `fingerprint "md5"` → `fingerprint "sha256"`

**Fixes:** Lighthouse errors about invalid hash algorithm in integrity attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated asset fingerprinting algorithm for CSS and JavaScript resources, resulting in new generated asset URLs and cache invalidation on deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->