### PR TITLE
fix(css): restore JT brand red CTA buttons + pin bun

### DIFF
--- a/.github/actions/setup-hugo/action.yml
+++ b/.github/actions/setup-hugo/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - uses: oven-sh/setup-bun@v2
       with:
-        bun-version: latest
+        bun-version: 1.3.13
 
     - name: Cache Bun dependencies
       uses: actions/cache@v5

--- a/.github/workflows/_hugo.yml
+++ b/.github/workflows/_hugo.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.13
       - run: bun install --frozen-lockfile
 
       # Use Bun as the "node" runtime for Hugo's PostCSS pipeline.

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -27,6 +27,14 @@ const purgecss = createPurgeCss({
       "jt-active",
 
       "comment-link",
+
+      // Brand CTA buttons — MUST NEVER be purged. These rules live in
+      // navigation.css and define the JT Ruby red (#cc342d) override
+      // for .btn-primary and a.fl-button (homepage hero, Contact Us nav,
+      // free-consultation CTAs). PurgeCSS in CI has been observed
+      // removing them despite hugo_stats.json containing the class —
+      // explicit safelist guards against that drift.
+      "btn", "btn-primary", "fl-button", "fl-button-wrap", "action-button",
     ],
 
     deep: [


### PR DESCRIPTION
## Symptom

Production homepage CTA buttons rendered as default **blue pills** instead of JT Ruby red (#cc342d) rectangular brand buttons. User reported \"we lost previous design.\"

## Investigation chain

1. Initial suspicion: PR #335 Beasties merge. Confirmed via reproduction: PR #335 CI workflow never invoked `bin/inline-critical`, so deployed CSS bundle was unchanged. Reverted (#336) for safety; no impact on the broken state — symptom persists.
2. Comparing production CSS bundle (`df726d1a...css`, 222507 bytes) against local build (`42f525ea...css`, 225143 bytes) showed local is 2636 bytes larger and contains rules production is missing.
3. The missing rule lives in `themes/beaver/assets/css/navigation.css`:
   ```css
   a.fl-button, a.fl-button:visited, .fl-button-wrap a {
     background-color: #cc342d !important;
     border-radius: 8px !important;
     ...
   }
   ```
   This is the JT brand red override that paints all FL-builder CTAs site-wide. Local build preserves it (verified in inlined `<style>` block). Production strips it.
4. The rule went through PostCSS + PurgeCSS in both builds. CI's PurgeCSS removed it; local's didn't. Likely cause: hugo_stats.json read-timing race against Hugo's incremental writes — when PostCSS processes the inline navigation.css bundle, the stats file may not yet contain `fl-button` class on CI, even though it does locally.

## Fixes (two layered)

**1. `postcss.config.js`** — Add brand CTA class names to `safelist.standard`:
- `btn`, `btn-primary` (pagination Next, page nav, header Contact Us)
- `fl-button`, `fl-button-wrap` (homepage hero, every Beaver Builder CTA)
- `action-button` (Use Cases tab CTAs)

Standard safelist matches classes regardless of hugo_stats.json content — these rules are now unconditionally preserved.

**2. `bun-version: 1.3.13`** (both `_hugo.yml` and `setup-hugo/action.yml`) — Replace `latest` with a known-good pin. `latest` is time-dependent and contributed to non-deterministic CI builds across deploys of the same git SHA.

## Verification

- [x] Local production build preserves `#cc342d` red rule in inlined `<style>` block
- [x] CSS bundle hash unchanged (`42f525ea`) — confirms safelist addition didn't break unrelated rules
- [ ] CI build on this PR produces same bundle (in progress)
- [ ] After merge: production deploy restores red brand buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)