### PR TITLE
fix(css): greedy safelist for fl-button to fully restore brand red

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -42,7 +42,12 @@ const purgecss = createPurgeCss({
     ],
 
     greedy: [
-      /^swiper-/, /^is-/, /^has-/, /^js-/, /^fl-builder-content/, /^fl-col/, /^fl-node/, /^technologies-component/, /^footer-component/, /^use-cases/
+      /^swiper-/, /^is-/, /^has-/, /^js-/, /^fl-builder-content/, /^fl-col/, /^fl-node/, /^technologies-component/, /^footer-component/, /^use-cases/,
+      // Brand CTA buttons — preserve any selector mentioning these classes.
+      // Standard safelist didn't catch tag+class compound selectors like
+      // `a.fl-button` on CI (produced blue pills instead of Ruby red).
+      // Greedy preserves rules where ANY class in the selector matches.
+      /^fl-button/, /^btn/, /^action-button/
     ]
   },
   // Enhanced PurgeCSS options for better optimization


### PR DESCRIPTION
## Follow-up to #337 — incomplete fix

After #337 merged, production showed mixed state:
- Header \"Contact Us\" button: red ✓ (`.btn.btn-primary` rule survived)
- Hero \"Talk to an Expert\", card \"Explore Use Cases\": still blue pill ✗ (`a.fl-button` rule still purged)

Root cause: PurgeCSS's `safelist.standard` treats class-only selectors (`.btn.btn-primary`) and tag+class compound selectors (`a.fl-button`) differently. Adding `fl-button` to `standard` was enough to preserve `.fl-button { ... }` rules but NOT `a.fl-button { ... }` rules.

## Fix

Move `fl-button`, `btn`, `action-button` from `safelist.standard` to `safelist.greedy`. Greedy preserves any rule whose selector mentions one of these classes regardless of tag prefix or compound structure.

Patterns added to greedy:
- `/^fl-button/`
- `/^btn/`
- `/^action-button/`

## Verification

Local build inlined navigation `<style>` now contains:
```css
.fl-button-wrap a, a.fl-button, a.fl-button:visited {
  background-color: #cc342d !important;
  border-radius: 8px !important;
  ...
}
```

This rule was missing from production after #337 (despite `fl-button` in standard safelist). After this PR, it survives PurgeCSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)