### PR TITLE
refactor(css): WP1.1 sprint 4 — blog-list collision fix, --color-dark token + 404-literal tokenization

### DIFF
--- a/docs/projects/2509-css-migration/TASK-TRACKER.md
+++ b/docs/projects/2509-css-migration/TASK-TRACKER.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Real-time work package status tracking for CSS duplication elimination goal
 **Update Frequency**: After each work package completion or status change
-**Last Updated**: 2025-01-27
+**Last Updated**: 2026-07-12
 **Current Phase**: Phase 1 - Critical CSS Inline Consolidation
 
 ---
@@ -67,6 +67,11 @@ tasks:
         (25 stacks across 8 critical files) replaced with var(--font-system-ui);
         @import wired into the 3 no-base bundles (careers, single-careers,
         single-use-cases) that never defined the variable
+  - [x] Extract --color-dark (#121212) — defined in foundations/css-variables.css
+        (sprint 4, 2026-07-12); 404 of 648 literals tokenized across 32 files;
+        47 literals kept by design (KEEP LITERAL comments in-file), ~157 sit in
+        orphan files queued for deletion, ~19 in the inline components tree
+        (deferred). variables/colors.css duplicate def is dead (bundled nowhere).
   - [ ] Extract --color-primary, --color-secondary, --color-text
   - [ ] Extract --border-radius-default, --spacing-unit
   - [x] Dedup the identical 35-line Bootstrap :root block copied across
@@ -547,6 +552,83 @@ fcp_metrics:
 ---
 
 ## 🔄 UPDATE LOG
+
+### 2026-07-12 (sprint 4)
+- **Landed** (branch css-migration/wp1.1-sprint-4, one bundled PR, 6 commits):
+  1. fbd38c63 — blog-list bundleName collision fixed via shared partial
+     assets/blog-list-css-resources.html. CORRECTION to the sprint-3 log:
+     taxonomy pages DO generate — 383 /blog/tags/* pages render through root
+     list.html; both templates raced for the "blog-list" concat name and
+     blog/list.html's slice always won (verified in scratch builds AND live
+     site), so sprint 3's css-variables wiring for "taxonomy list" was
+     silently ineffective. Fix is deterministic-by-construction; compiled
+     output byte-identical (all 19 bundle hashes unchanged).
+  2. a621f8f6 — LIVE BUG: single-service bundle shipped 17 unresolved
+     var(--font-system-ui) (sprint-1 no-base sweep missed services/single.html);
+     foundation wired in, +1 :root rule, everything else byte-identical.
+  3. 9c264fa3 — --color-dark:#121212 defined in foundations/css-variables.css
+     (canonical home; the variables/colors.css copy is bundled NOWHERE — dead
+     file, delete candidate). Made already-shipped var(--color-dark) consumers
+     (free-consultation gform/accordion rules) resolve; reviewer traced every
+     consumer selector against rendered HTML — no visible change.
+  4. e25d9f00 — blog-list bundle wired with the foundation (its
+     services-layout/homepage-layout consumers were invalid at computed-value
+     time; consumer markup renders on none of the bundle's pages).
+  5. 48bb2c71 — #121212→var(--color-dark): 384 swaps across 29 files (19 live
+     layout/bundle files whole-file + 10 critical/* minus reboot generics).
+  6. 662b59cb — batch 3: skin/theme-main/navigation scoped lines (20 swaps);
+     the site-wide inline navigation bundle now carries the def, so
+     --color-dark resolves on every page.
+- **Totals**: 404/648 literals tokenized. Kept by design (all carry KEEP
+  LITERAL comments in-file): 25 reboot-generic body/h1 color rules in
+  critical/*, 10 fl-button dedup-twin border-colors (8 critical + skin
+  L2401/2411), 6 invisible-border border-colors (skin woo L1077/1105,
+  theme-main L1227/1288/3167/3233), 2 shadow-token defs (theme-main --jt-*),
+  2 bare-textarea selector parts, skin/theme-main/navigation body+h1 generics.
+  ~157 literals sit in 13 ORPHAN files (delete, don't tokenize — follow-up),
+  ~19 in the inline components tree (deferred), forms.css 7 (dead import).
+- **Gate method (option-a, evolved)**: per commit — production build to
+  scratch + SYMMETRIC rule-level diff (normalize var↔literal both sides,
+  strip the def, require empty diff + equal rule counts per bundle; inline
+  bundles extracted from compiled HTML and diffed the same way). Caught three
+  masking classes the visual suites alone would miss:
+  (a) dedup-twin rule RE-appearance when only one of two byte-identical
+      same-selector rules in a bundle is tokenized (590↔homepage-critical,
+      e966db44↔single-careers) → tokenize bundles atomically;
+  (b) minifier border shorthand/longhand merge-product churn when
+      border-color goes var() on style:none invisible borders → keep literal;
+  (c) cssnano merge-hoist on reboot-generic body/h1 rules (sprint-3 class).
+- **Pre-existing build nondeterminism documented (visually inert)**: inline
+  components bundle flickers dead rules (.c-content-block__paragraph pair)
+  between builds — the class exists only in dead templates so hugo_stats.json
+  omits it while stale postcss cache sometimes preserves it; no
+  [[build.cachebusters]] for hugo_stats.json configured. Benign per-build HTML
+  noise: sw.js?v= stamp, taxonomy term-title casing races (CrewAI vs Crewai —
+  live tag-page titles are nondeterministic), sitemap order. Sprint-start
+  3-failure macOS flake (mobile 404/blog text shift) was a cold-worktree
+  first-run flake; re-run green.
+- **Quality**: per commit — rule-level gate + bin/rake test:critical 46/46 +
+  bin/dtest 46/46 + standing reviewer approval with independent re-derivation.
+  Zero rollbacks.
+- **New follow-ups**:
+  - Cleanup PR: delete 13 orphan CSS files (fl-use-cases-layout,
+    beaver-grid-layout, fl-clients-alt-bundle, fl-services-layout,
+    fl-homepage-layout, fl-contact-layout, fl-clients-bundle,
+    fl-careers-layout, fl-about-layout, fl-clients-layout,
+    fl-component-layout, utilities.css, fl-service-detail-layout) + dead
+    aggregators (critical.css, _consolidated-layouts.css) + dead
+    page/service-template.html + dead variables/colors.css + dead partials
+    (homepage/services.html, homepage/clients.html, components/cta-block.html)
+    + dead .c-content-block__paragraph rules + commented-out forms import.
+  - Add [[build.cachebusters]] (hugo_stats.json → css).
+  - Inline components tree tokenization if components.css gets the foundation.
+  - Decide: repoint theme-main --jt-text-color/--jt-text-primary and
+    bem-home-page-minimal --cta-button-bg at var(--color-dark) (deliberate).
+  - fl-common-modules.css Bootstrap reboot purge ASSESSED & DEFERRED: block
+    ~L425-540 + second body reboot ~L560; @imported by 28 files; rules are
+    live-in-cascade (overridden, not dead) — needs per-page computed-style
+    proof (h1 size, body color) per bundle; own sprint.
+  - WP1.2 (reset utilities) not started.
 
 ### 2026-07-11 (sprint 3)
 - **Landed**: orphaned use-cases-critical.css deleted (265 lines); 8 invalid

--- a/themes/beaver/assets/css/2949-layout.css
+++ b/themes/beaver/assets/css/2949-layout.css
@@ -5060,7 +5060,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -5072,7 +5072,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: var(--font-system-ui);
   font-weight: 700;
 }
@@ -5095,7 +5095,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -5146,7 +5146,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -5211,7 +5211,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -5237,7 +5237,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content {

--- a/themes/beaver/assets/css/3021-layout.css
+++ b/themes/beaver/assets/css/3021-layout.css
@@ -2354,12 +2354,12 @@ img.mfp-img {
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs .pp-tabs-label {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs .pp-tabs-label.pp-tab-active, .fl-node-vbmpyhxt6i7k .pp-tabs .pp-tabs-label.pp-tab-active:hover, .fl-node-vbmpyhxt6i7k .pp-tabs .pp-tabs-label:hover, .fl-node-vbmpyhxt6i7k .pp-tabs .pp-tabs-label:focus {
   background-color: #F5F6F8;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs .pp-tabs-label .pp-tab-description {
@@ -2377,7 +2377,7 @@ img.mfp-img {
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs .pp-tabs-label.pp-tab-active .pp-toggle-icon {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-horizontal.pp-tabs-default .pp-tabs-label.pp-tab-active {
@@ -2390,7 +2390,7 @@ img.mfp-img {
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-style-1 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-style-2 .pp-tabs-label.pp-tab-active .pp-tab-label-inner:after {
@@ -2402,20 +2402,20 @@ img.mfp-img {
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-style-3 .pp-tabs-label:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-style-3 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
   background-color: ;
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-style-4 .pp-tabs-label:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-style-4 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
   background-color: ;
 }
 
@@ -2428,7 +2428,7 @@ img.mfp-img {
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-style-5 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-style-6 .pp-tabs-label:first-child.pp-tab-active ~ .pp-tabs-label:last-child::before {
@@ -2458,11 +2458,11 @@ img.mfp-img {
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-style-6 .pp-tabs-label, .fl-node-vbmpyhxt6i7k .pp-tabs-style-6 .pp-tabs-label.pp-tab-active, .fl-node-vbmpyhxt6i7k .pp-tabs-style-6 .pp-tabs-label.pp-tab-active:hover, .fl-node-vbmpyhxt6i7k .pp-tabs .pp-tabs-style-6 .pp-tabs-label:hover {
   background-color: transparent !important;
-  color: #121212 !important;
+  color: var(--color-dark) !important;
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-style-6 .pp-tabs-label:last-child:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-style-7 .pp-tabs-label .pp-tab-label-inner {
@@ -2486,7 +2486,7 @@ img.mfp-img {
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-style-8 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vbmpyhxt6i7k .pp-tabs-horizontal.pp-tabs-style-8 .pp-tabs-label {
@@ -2504,7 +2504,7 @@ img.mfp-img {
   }
 
   .fl-node-vbmpyhxt6i7k .pp-tabs-vertical.pp-tabs-style-6 .pp-tabs-label.pp-tab-active {
-    border-bottom: 4px solid #121212;
+    border-bottom: 4px solid var(--color-dark);
   }
 
   .fl-node-vbmpyhxt6i7k .pp-tabs-vertical.pp-tabs-style-7 .pp-tabs-label .pp-tab-label-inner {
@@ -3203,7 +3203,7 @@ img.mfp-img {
 }
 
 .fl-node-407srhqm5lpn .pp-infobox .pp-more-link {
-  color: #121212;
+  color: var(--color-dark);
   background-color: rgba(255, 0, 0, 0);
   text-decoration: none;
   text-align: center;
@@ -3217,7 +3217,7 @@ img.mfp-img {
 
 .fl-node-407srhqm5lpn .pp-infobox .pp-more-link .pp-button-icon {
   font-size: 22px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-407srhqm5lpn .pp-infobox .pp-more-link:hover .pp-button-icon {
@@ -3454,7 +3454,7 @@ img.mfp-img {
 }
 
 .fl-node-elrvqkjsa13p .pp-infobox .pp-more-link {
-  color: #121212;
+  color: var(--color-dark);
   background-color: rgba(255, 0, 0, 0);
   text-decoration: none;
   text-align: center;
@@ -3468,7 +3468,7 @@ img.mfp-img {
 
 .fl-node-elrvqkjsa13p .pp-infobox .pp-more-link .pp-button-icon {
   font-size: 22px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-elrvqkjsa13p .pp-infobox .pp-more-link:hover .pp-button-icon {
@@ -3705,7 +3705,7 @@ img.mfp-img {
 }
 
 .fl-node-7lo8vmgtyquk .pp-infobox .pp-more-link {
-  color: #121212;
+  color: var(--color-dark);
   background-color: rgba(255, 0, 0, 0);
   text-decoration: none;
   text-align: center;
@@ -3719,7 +3719,7 @@ img.mfp-img {
 
 .fl-node-7lo8vmgtyquk .pp-infobox .pp-more-link .pp-button-icon {
   font-size: 22px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-7lo8vmgtyquk .pp-infobox .pp-more-link:hover .pp-button-icon {
@@ -3973,7 +3973,7 @@ img.mfp-img {
 }
 
 .fl-node-io8s7pv1xhw4 .pp-infobox .pp-more-link {
-  color: #121212;
+  color: var(--color-dark);
   background-color: rgba(255, 0, 0, 0);
   text-decoration: none;
   text-align: center;
@@ -3987,7 +3987,7 @@ img.mfp-img {
 
 .fl-node-io8s7pv1xhw4 .pp-infobox .pp-more-link .pp-button-icon {
   font-size: 22px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-io8s7pv1xhw4 .pp-infobox .pp-more-link:hover .pp-button-icon {
@@ -4224,7 +4224,7 @@ img.mfp-img {
 }
 
 .fl-node-80acnbjpi3ey .pp-infobox .pp-more-link {
-  color: #121212;
+  color: var(--color-dark);
   background-color: rgba(255, 0, 0, 0);
   text-decoration: none;
   text-align: center;
@@ -4238,7 +4238,7 @@ img.mfp-img {
 
 .fl-node-80acnbjpi3ey .pp-infobox .pp-more-link .pp-button-icon {
   font-size: 22px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-80acnbjpi3ey .pp-infobox .pp-more-link:hover .pp-button-icon {
@@ -4475,7 +4475,7 @@ img.mfp-img {
 }
 
 .fl-node-oxyliub1tke7 .pp-infobox .pp-more-link {
-  color: #121212;
+  color: var(--color-dark);
   background-color: rgba(255, 0, 0, 0);
   text-decoration: none;
   text-align: center;
@@ -4489,7 +4489,7 @@ img.mfp-img {
 
 .fl-node-oxyliub1tke7 .pp-infobox .pp-more-link .pp-button-icon {
   font-size: 22px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-oxyliub1tke7 .pp-infobox .pp-more-link:hover .pp-button-icon {
@@ -6141,7 +6141,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -6153,7 +6153,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: var(--font-system-ui);
   font-weight: 700;
 }
@@ -6176,7 +6176,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -6227,7 +6227,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -6293,7 +6293,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -6319,7 +6319,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content {

--- a/themes/beaver/assets/css/3027-layout.css
+++ b/themes/beaver/assets/css/3027-layout.css
@@ -4709,7 +4709,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -4721,7 +4721,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
@@ -4744,7 +4744,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -4795,7 +4795,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -4860,7 +4860,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -4886,7 +4886,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content {

--- a/themes/beaver/assets/css/3082-layout.css
+++ b/themes/beaver/assets/css/3082-layout.css
@@ -4987,7 +4987,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -4999,7 +4999,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
@@ -5022,7 +5022,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper .gfield select, .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -5073,7 +5073,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -5139,7 +5139,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-jumarfbx1lcn .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -5165,7 +5165,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-jumarfbx1lcn .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-jumarfbx1lcn .pp-gf-content {

--- a/themes/beaver/assets/css/3086-layout2.css
+++ b/themes/beaver/assets/css/3086-layout2.css
@@ -4810,7 +4810,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -4822,7 +4822,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
@@ -4845,7 +4845,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper .gfield select, .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -4896,7 +4896,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -4961,7 +4961,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-erl54g069p1u .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -4987,7 +4987,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-erl54g069p1u .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-erl54g069p1u .pp-gf-content {
@@ -5101,7 +5101,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
   margin-right: 10px;
   margin-bottom: 0;
   font-size: 16px;
-  color: #121212;
+  color: var(--color-dark);
   transition: all .3s ease-in-out;
   text-decoration: none;
 }
@@ -5114,7 +5114,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-t2084qdhsoz6 .pp-content-grid-post-title a:hover {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
 }
 
 .fl-node-t2084qdhsoz6 .career-detail {

--- a/themes/beaver/assets/css/3114-layout.css
+++ b/themes/beaver/assets/css/3114-layout.css
@@ -1673,7 +1673,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -1685,7 +1685,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
@@ -1708,7 +1708,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .gfield select, .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -1759,7 +1759,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -1824,7 +1824,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -1850,7 +1850,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-bmn85orw3pj1 .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-bmn85orw3pj1 .pp-gf-content {
@@ -2051,7 +2051,7 @@ span.pp-accordion-button-icon {
 
 .fl-node-lokc5ru7ftaj .pp-accordion-item .pp-accordion-button {
   background-color: #F5F6F8;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-lokc5ru7ftaj .pp-accordion-item .pp-accordion-button:hover, .fl-node-lokc5ru7ftaj .pp-accordion-item.pp-accordion-item-active .pp-accordion-button {
@@ -2073,14 +2073,14 @@ span.pp-accordion-button-icon {
 
 .fl-node-lokc5ru7ftaj .pp-accordion-item .pp-accordion-content {
   background-color: #ffffff;
-  color: #121212;
+  color: var(--color-dark);
   border-bottom-left-radius: px;
   border-bottom-right-radius: px;
 }
 
 .fl-node-lokc5ru7ftaj .pp-accordion-item .pp-accordion-button-icon {
   font-size: 18px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-lokc5ru7ftaj .pp-accordion-item .pp-accordion-button-icon:before {
@@ -2090,7 +2090,7 @@ span.pp-accordion-button-icon {
 .fl-node-lokc5ru7ftaj .pp-accordion-item .pp-accordion-icon {
   font-size: 15px;
   width: 18.75px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-lokc5ru7ftaj .pp-accordion-item .pp-accordion-button:hover .pp-accordion-icon, .fl-node-lokc5ru7ftaj .pp-accordion-item.pp-accordion-item-active .pp-accordion-icon {
@@ -2131,7 +2131,7 @@ span.pp-accordion-button-icon {
 
 .fl-node-hwc8puan960k .pp-accordion-item .pp-accordion-button {
   background-color: #F5F6F8;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-hwc8puan960k .pp-accordion-item .pp-accordion-button:hover, .fl-node-hwc8puan960k .pp-accordion-item.pp-accordion-item-active .pp-accordion-button {
@@ -2153,14 +2153,14 @@ span.pp-accordion-button-icon {
 
 .fl-node-hwc8puan960k .pp-accordion-item .pp-accordion-content {
   background-color: #ffffff;
-  color: #121212;
+  color: var(--color-dark);
   border-bottom-left-radius: px;
   border-bottom-right-radius: px;
 }
 
 .fl-node-hwc8puan960k .pp-accordion-item .pp-accordion-button-icon {
   font-size: 18px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-hwc8puan960k .pp-accordion-item .pp-accordion-button-icon:before {
@@ -2170,7 +2170,7 @@ span.pp-accordion-button-icon {
 .fl-node-hwc8puan960k .pp-accordion-item .pp-accordion-icon {
   font-size: 15px;
   width: 18.75px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-hwc8puan960k .pp-accordion-item .pp-accordion-button:hover .pp-accordion-icon, .fl-node-hwc8puan960k .pp-accordion-item.pp-accordion-item-active .pp-accordion-icon {

--- a/themes/beaver/assets/css/404.css
+++ b/themes/beaver/assets/css/404.css
@@ -1695,7 +1695,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   border-bottom-width: 0px;
   border-left-width: 0px;
   border-right-width: 0px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-menu .pp-advanced-menu .menu > li > a:hover,
 .fl-node-menu .pp-advanced-menu .menu > li > a:focus,
@@ -1714,7 +1714,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .pp-menu-toggle:before,
 .fl-node-menu .pp-advanced-menu .pp-toggle-none .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-menu
   .pp-advanced-menu
@@ -1820,7 +1820,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a {
   border-width: 0;
   border-style: solid;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-menu .sub-menu > li > a:hover,
 .fl-node-menu .sub-menu > li > a:focus,
@@ -1853,7 +1853,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   .pp-toggle-none
   .sub-menu
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-menu
   .pp-advanced-menu
@@ -2042,7 +2042,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   justify-content: flex-end;
 }
 .fl-node-menu .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box,
 .fl-node-menu
@@ -2077,11 +2077,11 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   .pp-hamburger
   .pp-hamburger-box
   .pp-hamburger-inner:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 .fl-node-menu .pp-advanced-menu-mobile-toggle rect {
-  fill: #121212;
+  fill: var(--color-dark);
 }
 @media (min-width: 861px) {
   .fl-node-menu ul.sub-menu {
@@ -2133,7 +2133,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   }
   .fl-node-menu .pp-advanced-menu .menu > li > a,
   .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a {
-    color: #121212;
+    color: var(--color-dark);
   }
   .fl-node-menu .sub-menu > li > a,
   .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a {
@@ -2161,7 +2161,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 .fl-node-menu .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-menu .pp-advanced-menu.off-canvas .menu {
 }
@@ -2187,7 +2187,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   li
   .pp-has-submenu-container
   a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
   -webkit-transition: all 0.3s ease-in-out;
@@ -2247,7 +2247,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   .pp-toggle-none
   .sub-menu
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .pp-menu-toggle {
   width: 14px;
@@ -4705,7 +4705,7 @@ body .pp-post-feed-meta {
 .fl-builder-content .fl-node-fxvw9yp0o6l7 a.fl-button,
 .fl-builder-content .fl-node-fxvw9yp0o6l7 a.fl-button:hover,
 .fl-builder-content .fl-node-fxvw9yp0o6l7 a.fl-button:visited {
-  background: #121212;
+  background: var(--color-dark);
 }
 .fl-builder-content .fl-node-fxvw9yp0o6l7 a.fl-button:hover {
   background-color: #24292d;
@@ -4754,7 +4754,7 @@ body .pp-post-feed-meta {
 }
 .fl-node-5nxtj94i8khs .post-terms ul li a {
   font-size: 16px;
-  color: #121212;
+  color: var(--color-dark);
   transition: all 0.3s ease-in-out;
   text-decoration: none;
 }

--- a/themes/beaver/assets/css/586.css
+++ b/themes/beaver/assets/css/586.css
@@ -348,11 +348,11 @@ footer .footer-menu.careers-text .fl-rich-text p:last-child a strong {
 }
 
 .jt-service-box:hover .pp-infobox-title-wrapper .pp-infobox-title a {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
 }
 
 .jt-service-box:hover .pp-infobox-description {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
 }
 
 .jt-service-box:hover .pp-infobox-description .pp-infobox-button .pp-more-link {
@@ -669,7 +669,7 @@ footer .footer-menu.careers-text .fl-rich-text p:last-child a strong {
 
   .blog-archive-search .pp-post-filters-wrapper .pp-search-form-wrap form .pp-search-form__container button {
     background-color: transparent !important;
-    color: #121212 !important;
+    color: var(--color-dark) !important;
   }
 }
 
@@ -848,7 +848,7 @@ footer .footer-menu.careers-text .fl-rich-text p:last-child a strong {
 
 .single-author .pp-description-wrap .author-social a {
   padding: 9px 12px;
-  background-color: #121212;
+  background-color: var(--color-dark);
   color: #FFF;
   border-radius: 6px;
   font-size: 14px;
@@ -866,7 +866,7 @@ footer .footer-menu.careers-text .fl-rich-text p:last-child a strong {
 
 .single-author .pp-description-wrap .author-social a:hover {
   background-color: #FFF;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .single-author .pp-description-wrap .author-social.social-linkedin + p {
@@ -1137,7 +1137,7 @@ footer .footer-menu.careers-text .fl-rich-text p:last-child a strong {
   }
 
   ul.menu li .pp-has-submenu-container a .menu-item-text .pp-menu-toggle::before {
-    border-color: #121212 !important;
+    border-color: var(--color-dark) !important;
   }
 
   ul.menu li ul.sub-menu {
@@ -1173,7 +1173,7 @@ footer .footer-menu.careers-text .fl-rich-text p:last-child a strong {
 
   ul.menu > li:last-child {
     padding: 11px;
-    background: #121212;
+    background: var(--color-dark);
     border-radius: 6px;
   }
 

--- a/themes/beaver/assets/css/590-layout.css
+++ b/themes/beaver/assets/css/590-layout.css
@@ -708,12 +708,12 @@
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label.pp-tab-active, .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label.pp-tab-active:hover, .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label:hover, .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label:focus {
   background-color: #F5F6F8;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label .pp-tab-description {
@@ -731,7 +731,7 @@
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label.pp-tab-active .pp-toggle-icon {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-horizontal.pp-tabs-default .pp-tabs-label.pp-tab-active {
@@ -744,7 +744,7 @@
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-1 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-2 .pp-tabs-label.pp-tab-active .pp-tab-label-inner:after {
@@ -756,20 +756,20 @@
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-3 .pp-tabs-label:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-3 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
   background-color: ;
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-4 .pp-tabs-label:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-4 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
   background-color: ;
 }
 
@@ -782,7 +782,7 @@
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-5 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-6 .pp-tabs-label:first-child.pp-tab-active ~ .pp-tabs-label:last-child::before {
@@ -812,11 +812,11 @@
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-6 .pp-tabs-label, .fl-node-vo75i29j3fmz .pp-tabs-style-6 .pp-tabs-label.pp-tab-active, .fl-node-vo75i29j3fmz .pp-tabs-style-6 .pp-tabs-label.pp-tab-active:hover, .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-style-6 .pp-tabs-label:hover {
   background-color: transparent !important;
-  color: #121212 !important;
+  color: var(--color-dark) !important;
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-6 .pp-tabs-label:last-child:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-7 .pp-tabs-label .pp-tab-label-inner {
@@ -840,7 +840,7 @@
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-8 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-horizontal.pp-tabs-style-8 .pp-tabs-label {
@@ -858,7 +858,7 @@
   }
 
   .fl-node-vo75i29j3fmz .pp-tabs-vertical.pp-tabs-style-6 .pp-tabs-label.pp-tab-active {
-    border-bottom: 4px solid #121212;
+    border-bottom: 4px solid var(--color-dark);
   }
 
   .fl-node-vo75i29j3fmz .pp-tabs-vertical.pp-tabs-style-7 .pp-tabs-label .pp-tab-label-inner {
@@ -2404,7 +2404,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -2416,7 +2416,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: var(--font-system-ui);
   font-weight: 700;
 }
@@ -2439,7 +2439,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -2490,7 +2490,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -2556,7 +2556,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -2582,7 +2582,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content {
@@ -5712,15 +5712,15 @@ img.mfp-img {
 }
 
 .fl-node-dxali8vntcr0 .pp-infobox .pp-infobox-title:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-dxali8vntcr0 .pp-infobox .pp-infobox-title a:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-dxali8vntcr0 .pp-infobox .pp-infobox-description:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-dxali8vntcr0 .pp-infobox-image {
@@ -5910,15 +5910,15 @@ img.mfp-img {
 }
 
 .fl-node-075ztwhd3cxn .pp-infobox .pp-infobox-title:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-075ztwhd3cxn .pp-infobox .pp-infobox-title a:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-075ztwhd3cxn .pp-infobox .pp-infobox-description:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-075ztwhd3cxn .pp-infobox-image {
@@ -6108,15 +6108,15 @@ img.mfp-img {
 }
 
 .fl-node-lajty926uxf5 .pp-infobox .pp-infobox-title:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-lajty926uxf5 .pp-infobox .pp-infobox-title a:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-lajty926uxf5 .pp-infobox .pp-infobox-description:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-lajty926uxf5 .pp-infobox-image {
@@ -6326,15 +6326,15 @@ img.mfp-img {
 }
 
 .fl-node-do5fjakv8b29 .pp-infobox .pp-infobox-title:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-do5fjakv8b29 .pp-infobox .pp-infobox-title a:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-do5fjakv8b29 .pp-infobox .pp-infobox-description:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-do5fjakv8b29 .pp-infobox-image {
@@ -6524,15 +6524,15 @@ img.mfp-img {
 }
 
 .fl-node-3eq5kcmfz0an .pp-infobox .pp-infobox-title:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-3eq5kcmfz0an .pp-infobox .pp-infobox-title a:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-3eq5kcmfz0an .pp-infobox .pp-infobox-description:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-3eq5kcmfz0an .pp-infobox-image {
@@ -6782,15 +6782,15 @@ img.mfp-img {
 }
 
 .fl-node-v3gpr4klqmob .pp-infobox .pp-infobox-title:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-v3gpr4klqmob .pp-infobox .pp-infobox-title a:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-v3gpr4klqmob .pp-infobox .pp-infobox-description:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-v3gpr4klqmob .pp-infobox-image {
@@ -9554,7 +9554,7 @@ body .pp-post-feed-meta {
 }
 
 .fl-builder-content .fl-node-n0ztf7v9mspi a.fl-button, .fl-builder-content .fl-node-n0ztf7v9mspi a.fl-button:hover, .fl-builder-content .fl-node-n0ztf7v9mspi a.fl-button:visited {
-  background: #121212;
+  background: var(--color-dark);
 }
 
 .fl-builder-content .fl-node-n0ztf7v9mspi a.fl-button:hover {
@@ -10384,12 +10384,12 @@ body .pp-post-feed-meta {
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label.pp-tab-active, .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label.pp-tab-active:hover, .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label:hover, .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label:focus {
   background-color: #F5F6F8;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label .pp-tab-description {
@@ -10407,7 +10407,7 @@ body .pp-post-feed-meta {
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label.pp-tab-active .pp-toggle-icon {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-horizontal.pp-tabs-default .pp-tabs-label.pp-tab-active {
@@ -10420,7 +10420,7 @@ body .pp-post-feed-meta {
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-1 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-2 .pp-tabs-label.pp-tab-active .pp-tab-label-inner:after {
@@ -10432,20 +10432,20 @@ body .pp-post-feed-meta {
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-3 .pp-tabs-label:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-3 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
   background-color: ;
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-4 .pp-tabs-label:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-4 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
   background-color: ;
 }
 
@@ -10458,7 +10458,7 @@ body .pp-post-feed-meta {
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-5 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-6 .pp-tabs-label:first-child.pp-tab-active ~ .pp-tabs-label:last-child::before {
@@ -10488,11 +10488,11 @@ body .pp-post-feed-meta {
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-6 .pp-tabs-label, .fl-node-vo75i29j3fmz .pp-tabs-style-6 .pp-tabs-label.pp-tab-active, .fl-node-vo75i29j3fmz .pp-tabs-style-6 .pp-tabs-label.pp-tab-active:hover, .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-style-6 .pp-tabs-label:hover {
   background-color: transparent !important;
-  color: #121212 !important;
+  color: var(--color-dark) !important;
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-6 .pp-tabs-label:last-child:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-7 .pp-tabs-label .pp-tab-label-inner {
@@ -10516,7 +10516,7 @@ body .pp-post-feed-meta {
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-style-8 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-vo75i29j3fmz .pp-tabs-horizontal.pp-tabs-style-8 .pp-tabs-label {
@@ -10534,7 +10534,7 @@ body .pp-post-feed-meta {
   }
 
   .fl-node-vo75i29j3fmz .pp-tabs-vertical.pp-tabs-style-6 .pp-tabs-label.pp-tab-active {
-    border-bottom: 4px solid #121212;
+    border-bottom: 4px solid var(--color-dark);
   }
 
   .fl-node-vo75i29j3fmz .pp-tabs-vertical.pp-tabs-style-7 .pp-tabs-label .pp-tab-label-inner {
@@ -12080,7 +12080,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -12092,7 +12092,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: var(--font-system-ui);
   font-weight: 700;
 }
@@ -12115,7 +12115,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -12166,7 +12166,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -12232,7 +12232,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -12258,7 +12258,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content {

--- a/themes/beaver/assets/css/701-layout.css
+++ b/themes/beaver/assets/css/701-layout.css
@@ -4186,7 +4186,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -4198,7 +4198,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
@@ -4221,7 +4221,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -4272,7 +4272,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -4338,7 +4338,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -4364,7 +4364,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content {

--- a/themes/beaver/assets/css/706-layout.css
+++ b/themes/beaver/assets/css/706-layout.css
@@ -1660,7 +1660,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -1672,7 +1672,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
@@ -1695,7 +1695,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper .gfield select, .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -1746,7 +1746,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -1811,7 +1811,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-dzu3licn9ow5 .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -1838,7 +1838,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-dzu3licn9ow5 .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-dzu3licn9ow5 .pp-gf-content {
@@ -2039,7 +2039,7 @@ span.pp-accordion-button-icon {
 
 .fl-node-bsgr4vwu32cn .pp-accordion-item .pp-accordion-button {
   background-color: #F5F6F8;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-bsgr4vwu32cn .pp-accordion-item .pp-accordion-button:hover, .fl-node-bsgr4vwu32cn .pp-accordion-item.pp-accordion-item-active .pp-accordion-button {
@@ -2061,14 +2061,14 @@ span.pp-accordion-button-icon {
 
 .fl-node-bsgr4vwu32cn .pp-accordion-item .pp-accordion-content {
   background-color: #ffffff;
-  color: #121212;
+  color: var(--color-dark);
   border-bottom-left-radius: px;
   border-bottom-right-radius: px;
 }
 
 .fl-node-bsgr4vwu32cn .pp-accordion-item .pp-accordion-button-icon {
   font-size: 18px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-bsgr4vwu32cn .pp-accordion-item .pp-accordion-button-icon:before {
@@ -2078,7 +2078,7 @@ span.pp-accordion-button-icon {
 .fl-node-bsgr4vwu32cn .pp-accordion-item .pp-accordion-icon {
   font-size: 15px;
   width: 18.75px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-bsgr4vwu32cn .pp-accordion-item .pp-accordion-button:hover .pp-accordion-icon, .fl-node-bsgr4vwu32cn .pp-accordion-item.pp-accordion-item-active .pp-accordion-icon {
@@ -2119,7 +2119,7 @@ span.pp-accordion-button-icon {
 
 .fl-node-qupih6a9xymw .pp-accordion-item .pp-accordion-button {
   background-color: #F5F6F8;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-qupih6a9xymw .pp-accordion-item .pp-accordion-button:hover, .fl-node-qupih6a9xymw .pp-accordion-item.pp-accordion-item-active .pp-accordion-button {
@@ -2141,14 +2141,14 @@ span.pp-accordion-button-icon {
 
 .fl-node-qupih6a9xymw .pp-accordion-item .pp-accordion-content {
   background-color: #ffffff;
-  color: #121212;
+  color: var(--color-dark);
   border-bottom-left-radius: px;
   border-bottom-right-radius: px;
 }
 
 .fl-node-qupih6a9xymw .pp-accordion-item .pp-accordion-button-icon {
   font-size: 18px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-qupih6a9xymw .pp-accordion-item .pp-accordion-button-icon:before {
@@ -2158,7 +2158,7 @@ span.pp-accordion-button-icon {
 .fl-node-qupih6a9xymw .pp-accordion-item .pp-accordion-icon {
   font-size: 15px;
   width: 18.75px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-qupih6a9xymw .pp-accordion-item .pp-accordion-button:hover .pp-accordion-icon, .fl-node-qupih6a9xymw .pp-accordion-item.pp-accordion-item-active .pp-accordion-icon {

--- a/themes/beaver/assets/css/737-layout.css
+++ b/themes/beaver/assets/css/737-layout.css
@@ -4445,12 +4445,12 @@ img.mfp-img {
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs .pp-tabs-label {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs .pp-tabs-label.pp-tab-active, .fl-node-fy2sd3rz1qtj .pp-tabs .pp-tabs-label.pp-tab-active:hover, .fl-node-fy2sd3rz1qtj .pp-tabs .pp-tabs-label:hover, .fl-node-fy2sd3rz1qtj .pp-tabs .pp-tabs-label:focus {
   background-color: #F5F6F8;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs .pp-tabs-label .pp-tab-description {
@@ -4468,7 +4468,7 @@ img.mfp-img {
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs .pp-tabs-label.pp-tab-active .pp-toggle-icon {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-horizontal.pp-tabs-default .pp-tabs-label.pp-tab-active {
@@ -4481,7 +4481,7 @@ img.mfp-img {
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-style-1 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-style-2 .pp-tabs-label.pp-tab-active .pp-tab-label-inner:after {
@@ -4493,20 +4493,20 @@ img.mfp-img {
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-style-3 .pp-tabs-label:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-style-3 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
   background-color: ;
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-style-4 .pp-tabs-label:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-style-4 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
   background-color: ;
 }
 
@@ -4519,7 +4519,7 @@ img.mfp-img {
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-style-5 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-style-6 .pp-tabs-label:first-child.pp-tab-active ~ .pp-tabs-label:last-child::before {
@@ -4549,11 +4549,11 @@ img.mfp-img {
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-style-6 .pp-tabs-label, .fl-node-fy2sd3rz1qtj .pp-tabs-style-6 .pp-tabs-label.pp-tab-active, .fl-node-fy2sd3rz1qtj .pp-tabs-style-6 .pp-tabs-label.pp-tab-active:hover, .fl-node-fy2sd3rz1qtj .pp-tabs .pp-tabs-style-6 .pp-tabs-label:hover {
   background-color: transparent !important;
-  color: #121212 !important;
+  color: var(--color-dark) !important;
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-style-6 .pp-tabs-label:last-child:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-style-7 .pp-tabs-label .pp-tab-label-inner {
@@ -4577,7 +4577,7 @@ img.mfp-img {
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-style-8 .pp-tabs-label:hover {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-fy2sd3rz1qtj .pp-tabs-horizontal.pp-tabs-style-8 .pp-tabs-label {
@@ -4595,7 +4595,7 @@ img.mfp-img {
   }
 
   .fl-node-fy2sd3rz1qtj .pp-tabs-vertical.pp-tabs-style-6 .pp-tabs-label.pp-tab-active {
-    border-bottom: 4px solid #121212;
+    border-bottom: 4px solid var(--color-dark);
   }
 
   .fl-node-fy2sd3rz1qtj .pp-tabs-vertical.pp-tabs-style-7 .pp-tabs-label .pp-tab-label-inner {
@@ -6220,7 +6220,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -6232,7 +6232,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
@@ -6255,7 +6255,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -6306,7 +6306,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -6372,7 +6372,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -6398,7 +6398,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content {

--- a/themes/beaver/assets/css/bf72bba397177a0376baed325bffdc75-layout-bundle.css
+++ b/themes/beaver/assets/css/bf72bba397177a0376baed325bffdc75-layout-bundle.css
@@ -773,14 +773,14 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   border-right-width: 0px;
   border-color: ;
   background-color: ;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .menu > li > a:hover, .fl-node-menu .pp-advanced-menu .menu > li > a:focus, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a:hover, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a:focus {
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-arrows li.focus .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none li.focus .pp-menu-toggle:before {
@@ -823,7 +823,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   border-bottom-width: px;
   border-color: ;
   background-color: ;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .sub-menu > li > a:hover, .fl-node-menu .sub-menu > li > a:focus, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a:hover, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a:focus {
@@ -839,7 +839,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .sub-menu .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .sub-menu .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .sub-menu li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .sub-menu li:hover .pp-menu-toggle:before {
@@ -1009,7 +1009,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:before, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:after {
@@ -1017,12 +1017,12 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:before, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle rect {
-  fill: #121212;
+  fill: var(--color-dark);
 }
 
 @media ( min-width: 861px ) {
@@ -1085,7 +1085,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   }
 
   .fl-node-menu .pp-advanced-menu .menu > li > a, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a {
-    color: #121212;
+    color: var(--color-dark);
   }
 
   .fl-node-menu .sub-menu > li > a, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a {
@@ -1121,7 +1121,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 
 .fl-node-menu .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .menu {
@@ -1141,7 +1141,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .menu li a, .fl-node-menu .pp-advanced-menu.off-canvas .menu li .pp-has-submenu-container a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
   -webkit-transition: all 0.3s ease-in-out;
@@ -1157,7 +1157,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-none .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .sub-menu .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-none .sub-menu .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .pp-menu-toggle {

--- a/themes/beaver/assets/css/component-bundle.css
+++ b/themes/beaver/assets/css/component-bundle.css
@@ -932,7 +932,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   border-left-width: 0px;
   border-right-width: 0px;
   border-color: transparent;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .menu > li > a:hover,
@@ -953,7 +953,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .pp-menu-toggle:before,
 .fl-node-menu .pp-advanced-menu .pp-toggle-none .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu
@@ -1071,7 +1071,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   border-bottom-width: 0px;
   border-color: transparent;
 
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .sub-menu > li > a:hover,
@@ -1109,7 +1109,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   .pp-toggle-none
   .sub-menu
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu
@@ -1329,7 +1329,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box,
@@ -1366,12 +1366,12 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   .pp-hamburger
   .pp-hamburger-box
   .pp-hamburger-inner:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle rect {
-  fill: #121212;
+  fill: var(--color-dark);
 }
 
 @media (min-width: 861px) {
@@ -1440,7 +1440,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 
   .fl-node-menu .pp-advanced-menu .menu > li > a,
   .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a {
-    color: #121212;
+    color: var(--color-dark);
   }
 
   .fl-node-menu .sub-menu > li > a,
@@ -1477,7 +1477,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 
 .fl-node-menu .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .menu {
@@ -1508,7 +1508,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   li
   .pp-has-submenu-container
   a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
   -webkit-transition: all 0.3s ease-in-out;
@@ -1571,7 +1571,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   .pp-toggle-none
   .sub-menu
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .pp-menu-toggle {

--- a/themes/beaver/assets/css/critical/about-us-critical.css
+++ b/themes/beaver/assets/css/critical/about-us-critical.css
@@ -135,7 +135,7 @@
     a
     .menu-item-text
     .pp-menu-toggle::before {
-    border-color: #121212 !important;
+    border-color: var(--color-dark) !important;
   }
   ul.menu li ul.sub-menu {
     padding-top: 15px;
@@ -153,7 +153,7 @@
   }
   ul.menu > li:last-child {
     padding: 11px;
-    background: #121212;
+    background: var(--color-dark);
     border-radius: 6px;
   }
   ul.menu > li:last-child a {
@@ -913,13 +913,13 @@
   border-bottom-width: 0;
   border-left-width: 0;
   border-right-width: 0;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .menu > li.current-menu-item > a {
   color: #1a8cff;
@@ -939,7 +939,7 @@
   border-width: 0;
   border-style: solid;
   border-bottom-width: px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .sub-menu > li:last-child > a:not(:focus) {
   border: 0;
@@ -1020,7 +1020,7 @@
   justify-content: flex-end;
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu-mobile-toggle
@@ -1058,7 +1058,7 @@
   .pp-hamburger
   .pp-hamburger-box
   .pp-hamburger-inner:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 @media (min-width: 861px) {
@@ -1130,7 +1130,7 @@
     > .pp-has-submenu-container
     > a,
   .fl-node-ncg61wov0ytq .pp-advanced-menu .menu > li > a {
-    color: #121212;
+    color: var(--color-dark);
   }
   .fl-node-ncg61wov0ytq .sub-menu > li > a {
     border-bottom-width: px;
@@ -1154,7 +1154,7 @@
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .sub-menu {
   box-shadow: none;
@@ -1171,7 +1171,7 @@
   .pp-has-submenu-container
   a,
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .menu li a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
 }
@@ -1179,7 +1179,7 @@
   .pp-advanced-menu.off-canvas
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu.off-canvas
@@ -1458,7 +1458,7 @@ h1 {
 }
 body {
   background-color: #fff;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   font-size: 18px;
   font-weight: 400;
@@ -1468,7 +1468,7 @@ body {
   word-wrap: break-word;
 }
 h1 {
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   line-height: 1.4;
@@ -1479,7 +1479,7 @@ h1 {
   font-size: 70px;
   line-height: 1;
   letter-spacing: -1px;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   font-style: normal;
@@ -1612,7 +1612,7 @@ button {
   text-transform: capitalize;
   border-style: none;
   border-width: 1px;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: dedup-twin of the identical skin-65eda28877e04.css .fl-page fl-button rule - var() here breaks the twin match and changes the minifier merge product (border is style:none, invisible anyway) */
   border-radius: 25px;
 }
 .fl-page a.fl-button *,
@@ -1782,7 +1782,7 @@ header ul.menu > li > ul.sub-menu > li > a .menu-image {
     a
     .menu-item-text
     .pp-menu-toggle::before {
-    border-color: #121212 !important;
+    border-color: var(--color-dark) !important;
   }
   ul.menu li ul.sub-menu {
     padding-top: 15px;
@@ -1800,7 +1800,7 @@ header ul.menu > li > ul.sub-menu > li > a .menu-image {
   }
   ul.menu > li:last-child {
     padding: 11px;
-    background: #121212;
+    background: var(--color-dark);
     border-radius: 6px;
   }
   ul.menu > li:last-child a {

--- a/themes/beaver/assets/css/critical/careers-critical.css
+++ b/themes/beaver/assets/css/critical/careers-critical.css
@@ -831,13 +831,13 @@
   border-bottom-width: 0;
   border-left-width: 0;
   border-right-width: 0;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .menu > li.current-menu-item > a {
   color: #1a8cff;
@@ -857,7 +857,7 @@
   border-width: 0;
   border-style: solid;
   border-bottom-width: px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .sub-menu > li:last-child > a:not(:focus) {
   border: 0;
@@ -938,7 +938,7 @@
   justify-content: flex-end;
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu-mobile-toggle
@@ -976,7 +976,7 @@
   .pp-hamburger
   .pp-hamburger-box
   .pp-hamburger-inner:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 @media (min-width: 861px) {
@@ -1048,7 +1048,7 @@
     > .pp-has-submenu-container
     > a,
   .fl-node-ncg61wov0ytq .pp-advanced-menu .menu > li > a {
-    color: #121212;
+    color: var(--color-dark);
   }
   .fl-node-ncg61wov0ytq .sub-menu > li > a {
     border-bottom-width: px;
@@ -1072,7 +1072,7 @@
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .sub-menu {
   box-shadow: none;
@@ -1089,7 +1089,7 @@
   .pp-has-submenu-container
   a,
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .menu li a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
 }
@@ -1097,7 +1097,7 @@
   .pp-advanced-menu.off-canvas
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu.off-canvas
@@ -1381,7 +1381,7 @@ h2 {
 }
 body {
   background-color: #fff;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   font-size: 18px;
   font-weight: 400;
@@ -1392,7 +1392,7 @@ body {
 }
 h1,
 h2 {
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   line-height: 1.4;
@@ -1403,7 +1403,7 @@ h1 {
   font-size: 70px;
   line-height: 1;
   letter-spacing: -1px;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   font-style: normal;
@@ -1538,7 +1538,7 @@ button {
   text-transform: capitalize;
   border-style: none;
   border-width: 1px;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: dedup-twin of the identical skin-65eda28877e04.css .fl-page fl-button rule - var() here breaks the twin match and changes the minifier merge product (border is style:none, invisible anyway) */
   border-radius: 25px;
 }
 .fl-page a.fl-button *,
@@ -1711,7 +1711,7 @@ header ul.menu > li > ul.sub-menu > li > a .menu-image {
     a
     .menu-item-text
     .pp-menu-toggle::before {
-    border-color: #121212 !important;
+    border-color: var(--color-dark) !important;
   }
   ul.menu li ul.sub-menu {
     padding-top: 15px;
@@ -1729,7 +1729,7 @@ header ul.menu > li > ul.sub-menu > li > a .menu-image {
   }
   ul.menu > li:last-child {
     padding: 11px;
-    background: #121212;
+    background: var(--color-dark);
     border-radius: 6px;
   }
   ul.menu > li:last-child a {

--- a/themes/beaver/assets/css/critical/fl-common-modules.css
+++ b/themes/beaver/assets/css/critical/fl-common-modules.css
@@ -380,7 +380,7 @@ header ul.menu > li > ul.sub-menu > li > a .menu-image {
     a
     .menu-item-text
     .pp-menu-toggle::before {
-    border-color: #121212 !important;
+    border-color: var(--color-dark) !important;
   }
   ul.menu li ul.sub-menu {
     padding-top: 15px;
@@ -398,7 +398,7 @@ header ul.menu > li > ul.sub-menu > li > a .menu-image {
   }
   ul.menu > li:last-child {
     padding: 11px;
-    background: #121212;
+    background: var(--color-dark);
     border-radius: 6px;
   }
   ul.menu > li:last-child a {
@@ -559,7 +559,7 @@ h1 {
 /* JT Theme Typography & Layout */
 body {
   background-color: #fff;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   font-size: 18px;
   font-weight: 400;
@@ -569,7 +569,7 @@ body {
   word-wrap: break-word;
 }
 h1 {
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   line-height: 1.4;
@@ -580,7 +580,7 @@ h1 {
   font-size: 70px;
   line-height: 1;
   letter-spacing: -1px;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   font-style: normal;
@@ -712,7 +712,7 @@ button {
   text-transform: capitalize;
   border-style: none;
   border-width: 1px;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: dedup-twin of the identical skin-65eda28877e04.css .fl-page fl-button rule - var() here breaks the twin match and changes the minifier merge product (border is style:none, invisible anyway) */
   border-radius: 25px;
 }
 .fl-page a.fl-button *,

--- a/themes/beaver/assets/css/critical/free-consultation-critical.css
+++ b/themes/beaver/assets/css/critical/free-consultation-critical.css
@@ -259,7 +259,7 @@
   .gform_wrapper
   .gfield
   .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 .fl-builder-content
@@ -277,7 +277,7 @@
     [type="button"]
   ):not([type="image"]):not([type="file"]),
 .fl-node-bmn85orw3pj1 .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #fff;
   width: 100% !important;
   outline: none;
@@ -527,13 +527,13 @@
   border-right-width: 0;
   border-color:;
   background-color:;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .menu .pp-has-submenu .sub-menu {
   display: none;
@@ -552,7 +552,7 @@
   border-bottom-width: px;
   border-color:;
   background-color:;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .sub-menu > li:last-child > a:not(:focus) {
   border: 0;
@@ -670,7 +670,7 @@
   justify-content: flex-end;
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu-mobile-toggle
@@ -708,7 +708,7 @@
   .pp-hamburger
   .pp-hamburger-box
   .pp-hamburger-inner:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 @media (min-width: 861px) {
@@ -757,7 +757,7 @@
     > li
     > .pp-has-submenu-container
     > a {
-    color: #121212;
+    color: var(--color-dark);
   }
   .fl-node-ncg61wov0ytq .sub-menu > li > a {
     border-bottom-width: px;
@@ -784,7 +784,7 @@
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .sub-menu {
   box-shadow: none;
@@ -801,7 +801,7 @@
   li
   .pp-has-submenu-container
   a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
 }
@@ -809,7 +809,7 @@
   .pp-advanced-menu.off-canvas
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu.off-canvas

--- a/themes/beaver/assets/css/critical/homepage-critical.css
+++ b/themes/beaver/assets/css/critical/homepage-critical.css
@@ -226,7 +226,7 @@
     a
     .menu-item-text
     .pp-menu-toggle::before {
-    border-color: #121212 !important;
+    border-color: var(--color-dark) !important;
   }
   ul.menu li ul.sub-menu {
     padding-top: 15px;
@@ -244,7 +244,7 @@
   }
   ul.menu > li:last-child {
     padding: 11px;
-    background: #121212;
+    background: var(--color-dark);
     border-radius: 6px;
   }
   ul.menu > li:last-child a {
@@ -512,13 +512,13 @@
   border-bottom-width: 0;
   border-left-width: 0;
   border-right-width: 0;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .menu .pp-has-submenu .sub-menu {
   display: none;
@@ -537,7 +537,7 @@
   border-width: 0;
   border-style: solid;
   border-bottom-width: px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .sub-menu > li:last-child > a:not(:focus) {
   border: 0;
@@ -620,7 +620,7 @@
   justify-content: flex-end;
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu-mobile-toggle
@@ -658,7 +658,7 @@
   .pp-hamburger
   .pp-hamburger-box
   .pp-hamburger-inner:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 
@@ -734,7 +734,7 @@
     > .pp-has-submenu-container
     > a,
   .fl-node-ncg61wov0ytq .pp-advanced-menu .menu > li > a {
-    color: #121212;
+    color: var(--color-dark);
   }
   .fl-node-ncg61wov0ytq .sub-menu > li > a {
     border-bottom-width: px;
@@ -759,7 +759,7 @@
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .sub-menu {
   box-shadow: none;
@@ -776,7 +776,7 @@
   .pp-has-submenu-container
   a,
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .menu li a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
 }
@@ -784,7 +784,7 @@
   .pp-advanced-menu.off-canvas
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu.off-canvas
@@ -1428,18 +1428,18 @@
   text-align: left;
 }
 .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label.pp-tab-active {
   background-color: #f5f6f8;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-vo75i29j3fmz .pp-tabs-panel-label .pp-toggle-icon {
   font-size: 16px;
   color: #333;
 }
 .fl-node-vo75i29j3fmz .pp-tabs .pp-tabs-label.pp-tab-active .pp-toggle-icon {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-vo75i29j3fmz .pp-tabs-panels .pp-tabs-label .pp-tab-title {
   font-family: var(--font-system-ui);
@@ -1681,7 +1681,7 @@ button::-moz-focus-inner {
 /* JetThoughts Theme Styles */
 body {
   background-color: #fff;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-size: 18px;
   font-weight: 400;
@@ -1692,7 +1692,7 @@ body {
 }
 h1,
 h3 {
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   line-height: 1.4;
@@ -1703,7 +1703,7 @@ h1 {
   font-size: 70px;
   line-height: 1;
   letter-spacing: -1px;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   font-style: normal;
@@ -1839,7 +1839,7 @@ button {
   text-transform: capitalize;
   border-style: none;
   border-width: 1px;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: dedup-twin of the identical skin-65eda28877e04.css .fl-page fl-button rule - var() here breaks the twin match and changes the minifier merge product (border is style:none, invisible anyway) */
   border-radius: 25px;
 }
 .fl-page a.fl-button *,
@@ -2075,7 +2075,7 @@ header ul.menu > li > ul.sub-menu > li > a .menu-image {
     a
     .menu-item-text
     .pp-menu-toggle::before {
-    border-color: #121212 !important;
+    border-color: var(--color-dark) !important;
   }
   ul.menu li ul.sub-menu {
     padding-top: 15px;
@@ -2093,7 +2093,7 @@ header ul.menu > li > ul.sub-menu > li > a .menu-image {
   }
   ul.menu > li:last-child {
     padding: 11px;
-    background: #121212;
+    background: var(--color-dark);
     border-radius: 6px;
   }
   ul.menu > li:last-child a {

--- a/themes/beaver/assets/css/critical/privacy-policy-critical.css
+++ b/themes/beaver/assets/css/critical/privacy-policy-critical.css
@@ -66,13 +66,13 @@
   border-right-width: 0;
   border-color:;
   background-color:;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .menu .pp-has-submenu .sub-menu {
   display: none;
@@ -91,7 +91,7 @@
   border-bottom-width: px;
   border-color:;
   background-color:;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .sub-menu > li:last-child > a:not(:focus) {
   border: 0;
@@ -209,7 +209,7 @@
   justify-content: flex-end;
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu-mobile-toggle
@@ -247,7 +247,7 @@
   .pp-hamburger
   .pp-hamburger-box
   .pp-hamburger-inner:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 @media (min-width: 861px) {
@@ -296,7 +296,7 @@
     > li
     > .pp-has-submenu-container
     > a {
-    color: #121212;
+    color: var(--color-dark);
   }
   .fl-node-ncg61wov0ytq .sub-menu > li > a {
     border-bottom-width: px;
@@ -323,7 +323,7 @@
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .sub-menu {
   box-shadow: none;
@@ -340,7 +340,7 @@
   li
   .pp-has-submenu-container
   a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
 }
@@ -348,7 +348,7 @@
   .pp-advanced-menu.off-canvas
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu.off-canvas

--- a/themes/beaver/assets/css/critical/single-careers.css
+++ b/themes/beaver/assets/css/critical/single-careers.css
@@ -56,7 +56,7 @@ h2 {
 }
 h1,
 h2 {
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   line-height: 1.4;
@@ -142,7 +142,7 @@ h2 {
     a
     .menu-item-text
     .pp-menu-toggle::before {
-    border-color: #121212 !important;
+    border-color: var(--color-dark) !important;
   }
   ul.menu li ul.sub-menu {
     padding-top: 15px;
@@ -160,7 +160,7 @@ h2 {
   }
   ul.menu > li:last-child {
     padding: 11px;
-    background: #121212;
+    background: var(--color-dark);
     border-radius: 6px;
   }
   ul.menu > li:last-child a {
@@ -728,13 +728,13 @@ h2 {
   border-bottom-width: 0;
   border-left-width: 0;
   border-right-width: 0;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .menu .pp-has-submenu .sub-menu {
   display: none;
@@ -751,7 +751,7 @@ h2 {
   border-width: 0;
   border-style: solid;
   border-bottom-width: px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .sub-menu > li:last-child > a:not(:focus) {
   border: 0;
@@ -832,7 +832,7 @@ h2 {
   justify-content: flex-end;
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu-mobile-toggle
@@ -870,7 +870,7 @@ h2 {
   .pp-hamburger
   .pp-hamburger-box
   .pp-hamburger-inner:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 @media (min-width: 861px) {
@@ -950,7 +950,7 @@ h2 {
     > .pp-has-submenu-container
     > a,
   .fl-node-ncg61wov0ytq .pp-advanced-menu .menu > li > a {
-    color: #121212;
+    color: var(--color-dark);
   }
   .fl-node-ncg61wov0ytq .sub-menu > li > a {
     border-bottom-width: px;
@@ -980,7 +980,7 @@ h2 {
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .sub-menu {
   box-shadow: none;
@@ -997,7 +997,7 @@ h2 {
   .pp-has-submenu-container
   a,
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .menu li a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
 }
@@ -1005,7 +1005,7 @@ h2 {
   .pp-advanced-menu.off-canvas
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu.off-canvas
@@ -1393,7 +1393,7 @@ body:not(.single-fl-theme-layout)
   .pp-social-share-content.pp-share-buttons-skin-minimal
   .pp-share-button
   .pp-share-button-icon {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 .fl-builder-content
   .fl-node-rnjk7gex4iu1
@@ -1406,7 +1406,7 @@ body:not(.single-fl-theme-layout)
   .pp-share-button
   a
   * {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-builder-content
   .fl-node-rnjk7gex4iu1
@@ -1414,7 +1414,7 @@ body:not(.single-fl-theme-layout)
   .pp-share-button
   .pp-share-button-icon
   * {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-rnjk7gex4iu1 .pp-social-share-content .pp-share-button {
   height: 22px;
@@ -1534,7 +1534,7 @@ body:not(.single-fl-theme-layout)
   .gform_wrapper
   .gfield
   .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 .fl-builder-content
@@ -1551,7 +1551,7 @@ body:not(.single-fl-theme-layout)
   input:not([type="radio"]):not([type="checkbox"]):not([type="submit"]):not(
     [type="button"]
   ):not([type="image"]):not([type="file"]) {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #fff;
   width: 100% !important;
   outline: 0;
@@ -1761,7 +1761,7 @@ h3 {
 }
 body {
   background-color: #fff;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: Roboto, Arial, sans-serif;
   font-size: 18px;
   font-weight: 300;
@@ -1773,7 +1773,7 @@ body {
 h1,
 h2,
 h3 {
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   line-height: 1.4;
@@ -1784,7 +1784,7 @@ h1 {
   font-size: 70px;
   line-height: 1;
   letter-spacing: -1px;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   font-style: normal;
@@ -1859,7 +1859,7 @@ input[type="text"] {
   padding: 6px 12px;
   font-size: 14px;
   line-height: 1.428571429;
-  color: #121212;
+  color: var(--color-dark);
   background-color: #fcfcfc;
   background-image: none;
   border: 1px solid #e6e6e6;
@@ -1913,7 +1913,7 @@ input[type="text"]:-ms-input-placeholder {
   text-transform: capitalize;
   border-style: none;
   border-width: 1px;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: dedup-twin of the identical skin-65eda28877e04.css .fl-page fl-button rule - var() here breaks the twin match and changes the minifier merge product (border is style:none, invisible anyway) */
   border-radius: 25px;
 }
 .fl-page a.fl-button *,
@@ -2144,7 +2144,7 @@ header ul.menu > li > ul.sub-menu > li > a .menu-image {
     a
     .menu-item-text
     .pp-menu-toggle::before {
-    border-color: #121212 !important;
+    border-color: var(--color-dark) !important;
   }
   ul.menu li ul.sub-menu {
     padding-top: 15px;
@@ -2162,7 +2162,7 @@ header ul.menu > li > ul.sub-menu > li > a .menu-image {
   }
   ul.menu > li:last-child {
     padding: 11px;
-    background: #121212;
+    background: var(--color-dark);
     border-radius: 6px;
   }
   ul.menu > li:last-child a {

--- a/themes/beaver/assets/css/critical/single-clients.css
+++ b/themes/beaver/assets/css/critical/single-clients.css
@@ -768,13 +768,13 @@
   border-bottom-width: 0;
   border-left-width: 0;
   border-right-width: 0;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .menu .pp-has-submenu .sub-menu {
   display: none;
@@ -791,7 +791,7 @@
   border-width: 0;
   border-style: solid;
   border-bottom-width: px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .sub-menu > li:last-child > a:not(:focus) {
   border: 0;
@@ -872,7 +872,7 @@
   justify-content: flex-end;
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu-mobile-toggle
@@ -910,7 +910,7 @@
   .pp-hamburger
   .pp-hamburger-box
   .pp-hamburger-inner:before {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 @media (min-width: 861px) {
@@ -982,7 +982,7 @@
     > .pp-has-submenu-container
     > a,
   .fl-node-ncg61wov0ytq .pp-advanced-menu .menu > li > a {
-    color: #121212;
+    color: var(--color-dark);
   }
   .fl-node-ncg61wov0ytq .sub-menu > li > a {
     border-bottom-width: px;
@@ -1006,7 +1006,7 @@
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .sub-menu {
   box-shadow: none;
@@ -1023,7 +1023,7 @@
   .pp-has-submenu-container
   a,
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .menu li a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
 }
@@ -1031,7 +1031,7 @@
   .pp-advanced-menu.off-canvas
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu.off-canvas
@@ -1468,7 +1468,7 @@ h1 {
 }
 body {
   background-color: #fff;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: Roboto, Arial, sans-serif;
   font-size: 18px;
   font-weight: 300;
@@ -1478,7 +1478,7 @@ body {
   word-wrap: break-word;
 }
 h1 {
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   line-height: 1.4;
@@ -1489,7 +1489,7 @@ h1 {
   font-size: 70px;
   line-height: 1;
   letter-spacing: -1px;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   font-style: normal;
@@ -1569,7 +1569,7 @@ button {
   text-transform: capitalize;
   border-style: none;
   border-width: 1px;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: dedup-twin of the identical skin-65eda28877e04.css .fl-page fl-button rule - var() here breaks the twin match and changes the minifier merge product (border is style:none, invisible anyway) */
   border-radius: 25px;
 }
 .fl-page a.fl-button *,
@@ -1727,7 +1727,7 @@ header ul.menu > li > ul.sub-menu > li > a .menu-image {
     a
     .menu-item-text
     .pp-menu-toggle::before {
-    border-color: #121212 !important;
+    border-color: var(--color-dark) !important;
   }
   ul.menu li ul.sub-menu {
     padding-top: 15px;
@@ -1745,7 +1745,7 @@ header ul.menu > li > ul.sub-menu > li > a .menu-image {
   }
   ul.menu > li:last-child {
     padding: 11px;
-    background: #121212;
+    background: var(--color-dark);
     border-radius: 6px;
   }
   ul.menu > li:last-child a {

--- a/themes/beaver/assets/css/critical/single-services.css
+++ b/themes/beaver/assets/css/critical/single-services.css
@@ -759,13 +759,13 @@
   border-right-width: 0;
   border-color:;
   background-color:;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .menu .pp-has-submenu .sub-menu {
   display: none;
@@ -784,7 +784,7 @@
   border-bottom-width: px;
   border-color:;
   background-color:;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .sub-menu > li:last-child > a:not(:focus) {
   border: 0;
@@ -906,7 +906,7 @@
   justify-content: flex-end;
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu-mobile-toggle
@@ -944,7 +944,7 @@
   .pp-hamburger
   .pp-hamburger-box
   .pp-hamburger-inner:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 @media (min-width: 861px) {
@@ -993,7 +993,7 @@
     > li
     > .pp-has-submenu-container
     > a {
-    color: #121212;
+    color: var(--color-dark);
   }
   .fl-node-ncg61wov0ytq .sub-menu > li > a {
     border-bottom-width: px;
@@ -1020,7 +1020,7 @@
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .sub-menu {
   box-shadow: none;
@@ -1044,7 +1044,7 @@
   li
   .pp-has-submenu-container
   a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
 }
@@ -1052,7 +1052,7 @@
   .pp-advanced-menu.off-canvas
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu.off-canvas
@@ -1298,7 +1298,7 @@ header
     a
     .menu-item-text
     .pp-menu-toggle::before {
-    border-color: #121212 !important;
+    border-color: var(--color-dark) !important;
   }
   ul.menu li ul.sub-menu {
     padding-top: 15px;
@@ -1316,7 +1316,7 @@ header
   }
   ul.menu > li:last-child {
     padding: 11px;
-    background: #121212;
+    background: var(--color-dark);
     border-radius: 6px;
   }
   ul.menu > li:last-child a {
@@ -1471,7 +1471,7 @@ h1 {
 }
 body {
   background-color: #fff;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   font-size: 18px;
   font-weight: 400;
@@ -1481,7 +1481,7 @@ body {
   word-wrap: break-word;
 }
 h1 {
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   line-height: 1.4;
@@ -1492,7 +1492,7 @@ h1 {
   font-size: 70px;
   line-height: 1;
   letter-spacing: -1px;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   font-style: normal;
@@ -1636,7 +1636,7 @@ button {
   text-transform: capitalize;
   border-style: none;
   border-width: 1px;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: dedup-twin of the identical skin-65eda28877e04.css .fl-page fl-button rule - var() here breaks the twin match and changes the minifier merge product (border is style:none, invisible anyway) */
   border-radius: 25px;
 }
 .fl-page a.fl-button *,

--- a/themes/beaver/assets/css/critical/single-use-cases.css
+++ b/themes/beaver/assets/css/critical/single-use-cases.css
@@ -775,13 +775,13 @@
   border-right-width: 0;
   border-color:;
   background-color:;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .menu .pp-has-submenu .sub-menu {
   display: none;
@@ -800,7 +800,7 @@
   border-bottom-width: px;
   border-color:;
   background-color:;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .sub-menu > li:last-child > a:not(:focus) {
   border: 0;
@@ -922,7 +922,7 @@
   justify-content: flex-end;
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu-mobile-toggle
@@ -960,7 +960,7 @@
   .pp-hamburger
   .pp-hamburger-box
   .pp-hamburger-inner:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 @media (min-width: 861px) {
@@ -1009,7 +1009,7 @@
     > li
     > .pp-has-submenu-container
     > a {
-    color: #121212;
+    color: var(--color-dark);
   }
   .fl-node-ncg61wov0ytq .sub-menu > li > a {
     border-bottom-width: px;
@@ -1036,7 +1036,7 @@
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq .pp-advanced-menu.off-canvas .sub-menu {
   box-shadow: none;
@@ -1060,7 +1060,7 @@
   li
   .pp-has-submenu-container
   a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
 }
@@ -1068,7 +1068,7 @@
   .pp-advanced-menu.off-canvas
   .pp-toggle-arrows
   .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 .fl-node-ncg61wov0ytq
   .pp-advanced-menu.off-canvas
@@ -1328,7 +1328,7 @@ header
     a
     .menu-item-text
     .pp-menu-toggle::before {
-    border-color: #121212 !important;
+    border-color: var(--color-dark) !important;
   }
   ul.menu li ul.sub-menu {
     padding-top: 15px;
@@ -1346,7 +1346,7 @@ header
   }
   ul.menu > li:last-child {
     padding: 11px;
-    background: #121212;
+    background: var(--color-dark);
     border-radius: 6px;
   }
   ul.menu > li:last-child a {
@@ -1514,7 +1514,7 @@ h1 {
 }
 body {
   background-color: #fff;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   font-size: 18px;
   font-weight: 400;
@@ -1524,7 +1524,7 @@ body {
   word-wrap: break-word;
 }
 h1 {
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   line-height: 1.4;
@@ -1535,7 +1535,7 @@ h1 {
   font-size: 70px;
   line-height: 1;
   letter-spacing: -1px;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites cssnano merge-hoist / dedup unmask in production bundles; see skin-65eda28877e04.css body note */
   font-family: var(--font-system-ui);
   font-weight: 800;
   font-style: normal;
@@ -1679,7 +1679,7 @@ button {
   text-transform: capitalize;
   border-style: none;
   border-width: 1px;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: dedup-twin of the identical skin-65eda28877e04.css .fl-page fl-button rule - var() here breaks the twin match and changes the minifier merge product (border is style:none, invisible anyway) */
   border-radius: 25px;
 }
 .fl-page a.fl-button *,

--- a/themes/beaver/assets/css/e93d9b85e7803f50c80b8a698f8d12f9-layout-bundle.css
+++ b/themes/beaver/assets/css/e93d9b85e7803f50c80b8a698f8d12f9-layout-bundle.css
@@ -763,14 +763,14 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   border-right-width: 0px;
   border-color: ;
   background-color: ;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .menu > li > a:hover, .fl-node-menu .pp-advanced-menu .menu > li > a:focus, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a:hover, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a:focus {
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-arrows li.focus .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none li.focus .pp-menu-toggle:before {
@@ -813,7 +813,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   border-bottom-width: px;
   border-color: ;
   background-color: ;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .sub-menu > li > a:hover, .fl-node-menu .sub-menu > li > a:focus, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a:hover, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a:focus {
@@ -829,7 +829,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .sub-menu .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .sub-menu .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .sub-menu li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .sub-menu li:hover .pp-menu-toggle:before {
@@ -999,7 +999,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:before, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:after {
@@ -1007,12 +1007,12 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:before, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle rect {
-  fill: #121212;
+  fill: var(--color-dark);
 }
 
 @media ( min-width: 861px ) {
@@ -1075,7 +1075,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   }
 
   .fl-node-menu .pp-advanced-menu .menu > li > a, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a {
-    color: #121212;
+    color: var(--color-dark);
   }
 
   .fl-node-menu .sub-menu > li > a, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a {
@@ -1111,7 +1111,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 
 .fl-node-menu .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .menu {
@@ -1131,7 +1131,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .menu li a, .fl-node-menu .pp-advanced-menu.off-canvas .menu li .pp-has-submenu-container a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
   -webkit-transition: all 0.3s ease-in-out;
@@ -1147,7 +1147,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-none .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .sub-menu .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-none .sub-menu .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .pp-menu-toggle {

--- a/themes/beaver/assets/css/e966db44b09892b8d7d492247c67e86c-layout-bundle.css
+++ b/themes/beaver/assets/css/e966db44b09892b8d7d492247c67e86c-layout-bundle.css
@@ -1685,14 +1685,14 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   border-right-width: 0px;
   border-color: ;
   background-color: ;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .menu > li > a:hover, .fl-node-menu .pp-advanced-menu .menu > li > a:focus, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a:hover, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a:focus {
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-arrows li.focus .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none li.focus .pp-menu-toggle:before {
@@ -1735,7 +1735,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   border-bottom-width: px;
   border-color: ;
   background-color: ;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .sub-menu > li > a:hover, .fl-node-menu .sub-menu > li > a:focus, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a:hover, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a:focus {
@@ -1751,7 +1751,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .sub-menu .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .sub-menu .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .sub-menu li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .sub-menu li:hover .pp-menu-toggle:before {
@@ -1921,7 +1921,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:before, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:after {
@@ -1929,12 +1929,12 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:before, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle rect {
-  fill: #121212;
+  fill: var(--color-dark);
 }
 
 @media ( min-width: 861px ) {
@@ -1997,7 +1997,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   }
 
   .fl-node-menu .pp-advanced-menu .menu > li > a, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a {
-    color: #121212;
+    color: var(--color-dark);
   }
 
   .fl-node-menu .sub-menu > li > a, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a {
@@ -2033,7 +2033,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 
 .fl-node-menu .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .menu {
@@ -2053,7 +2053,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .menu li a, .fl-node-menu .pp-advanced-menu.off-canvas .menu li .pp-has-submenu-container a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
   -webkit-transition: all 0.3s ease-in-out;
@@ -2069,7 +2069,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-none .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .sub-menu .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-none .sub-menu .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .pp-menu-toggle {
@@ -3780,15 +3780,15 @@ body:not(.single-fl-theme-layout) .fl-builder-content[data-overlay="1"]:not(.fl-
 }
 
 .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-flat .pp-share-button a, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-gradient .pp-share-button a, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-boxed .pp-share-button .pp-share-button-icon, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-minimal .pp-share-button .pp-share-button-icon {
-  background-color: #121212;
+  background-color: var(--color-dark);
 }
 
 .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-framed .pp-share-button a, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-minimal .pp-share-button a, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-boxed .pp-share-button a, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-framed .pp-share-button a *, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-minimal .pp-share-button a *, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-boxed .pp-share-button a * {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-flat .pp-share-button a *, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-gradient .pp-share-button a *, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-boxed .pp-share-button .pp-share-button-icon *, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-minimal .pp-share-button .pp-share-button-icon * {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-flat .pp-share-button:hover a, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-gradient .pp-share-button:hover a, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-boxed .pp-share-button:hover .pp-share-button-icon, .fl-builder-content .fl-node-rnjk7gex4iu1 .pp-social-share-content.pp-share-buttons-skin-minimal .pp-share-button:hover .pp-share-button-icon {
@@ -4097,7 +4097,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -4109,7 +4109,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
@@ -4132,7 +4132,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper .gfield select, .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -4183,7 +4183,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -4248,7 +4248,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-nkrzpgyfwo7s .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -4274,7 +4274,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-nkrzpgyfwo7s .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-nkrzpgyfwo7s .pp-gf-content {

--- a/themes/beaver/assets/css/fb2624e43f3c4277448abe268cde571e-layout-bundle.css
+++ b/themes/beaver/assets/css/fb2624e43f3c4277448abe268cde571e-layout-bundle.css
@@ -1685,14 +1685,14 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   border-right-width: 0px;
   border-color: ;
   background-color: ;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .menu > li > a:hover, .fl-node-menu .pp-advanced-menu .menu > li > a:focus, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a:hover, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a:focus {
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-arrows li.focus .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none li.focus .pp-menu-toggle:before {
@@ -1735,7 +1735,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   border-bottom-width: px;
   border-color: ;
   background-color: ;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .sub-menu > li > a:hover, .fl-node-menu .sub-menu > li > a:focus, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a:hover, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a:focus {
@@ -1751,7 +1751,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .sub-menu .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .sub-menu .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .sub-menu li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .sub-menu li:hover .pp-menu-toggle:before {
@@ -1921,7 +1921,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:before, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:after {
@@ -1929,12 +1929,12 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:before, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px;
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle rect {
-  fill: #121212;
+  fill: var(--color-dark);
 }
 
 @media ( min-width: 861px ) {
@@ -1997,7 +1997,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   }
 
   .fl-node-menu .pp-advanced-menu .menu > li > a, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a {
-    color: #121212;
+    color: var(--color-dark);
   }
 
   .fl-node-menu .sub-menu > li > a, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a {
@@ -2033,7 +2033,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 
 .fl-node-menu .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .menu {
@@ -2053,7 +2053,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .menu li a, .fl-node-menu .pp-advanced-menu.off-canvas .menu li .pp-has-submenu-container a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
   -webkit-transition: all 0.3s ease-in-out;
@@ -2069,7 +2069,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-none .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .sub-menu .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-none .sub-menu .pp-menu-toggle:before {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .pp-menu-toggle {
@@ -6176,7 +6176,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-builder-content .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   display: block;
 }
 
@@ -6188,7 +6188,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .ginput_container label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper table.gfield_list thead th, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_product_price_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper span.ginput_quantity_label, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield_html {
-  color: #121212 !important;
+  color: var(--color-dark) !important;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
@@ -6211,7 +6211,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']), .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #ffffff;
   width: 100% !important;
   outline: none;
@@ -6262,7 +6262,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield input:not([type='radio']):not([type='checkbox']):not([type='submit']):not([type='button']):not([type='image']):not([type='file']):focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield select:focus, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield textarea:focus {
-  border-color: #121212;
+  border-color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label input.medium, .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .top_label select.medium {
@@ -6327,7 +6327,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content .gform_wrapper .gfield.gfield_error .gfield_label {
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 0;
 }
 
@@ -6353,7 +6353,7 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 }
 
 .fl-node-btz2rn93xyu8 .gform_confirmation_wrapper .gform_confirmation_message {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .fl-node-btz2rn93xyu8 .pp-gf-content {

--- a/themes/beaver/assets/css/foundations/css-variables.css
+++ b/themes/beaver/assets/css/foundations/css-variables.css
@@ -10,4 +10,9 @@
      NOT --color-primary: that token already exists as #1a8cff (blue)
      with 89 usages. Name approved by Paul 2026-07-11. */
   --color-ruby: #cc342d;
+
+  /* Primary dark text/border color (JetVelocity obsidian dark; 648
+     literal occurrences repo-wide). Canonical home of the token —
+     variables/colors.css also declares it but is bundled nowhere. */
+  --color-dark: #121212;
 }

--- a/themes/beaver/assets/css/homepage.css
+++ b/themes/beaver/assets/css/homepage.css
@@ -775,14 +775,14 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   border-bottom-width: 0;
   border-left-width: 0;
   border-right-width: 0;
-  color: #121212
+  color: var(--color-dark)
 }
 
 .fl-node-menu .pp-advanced-menu .menu > li > a:hover, .fl-node-menu .pp-advanced-menu .menu > li > a:focus, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a:hover, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a:focus {
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .pp-menu-toggle:before {
-  border-color: #121212
+  border-color: var(--color-dark)
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-arrows li.focus .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none li.focus .pp-menu-toggle:before {
@@ -822,7 +822,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 .fl-node-menu .sub-menu > li > a, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a {
   border-width: 0;
   border-style: solid;
-  color: #121212
+  color: var(--color-dark)
 }
 
 .fl-node-menu .sub-menu > li > a:hover, .fl-node-menu .sub-menu > li > a:focus, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a:hover, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a:focus {
@@ -837,7 +837,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .sub-menu .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .sub-menu .pp-menu-toggle:before {
-  border-color: #121212
+  border-color: var(--color-dark)
 }
 
 .fl-node-menu .pp-advanced-menu .pp-toggle-arrows .sub-menu li:hover .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu .pp-toggle-none .sub-menu li:hover .pp-menu-toggle:before {
@@ -1004,7 +1004,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle {
-  color: #121212
+  color: var(--color-dark)
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:before, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:after {
@@ -1012,12 +1012,12 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:before, .fl-node-menu .pp-advanced-menu-mobile-toggle .pp-hamburger .pp-hamburger-box .pp-hamburger-inner:after {
-  background-color: #121212;
+  background-color: var(--color-dark);
   height: 3px
 }
 
 .fl-node-menu .pp-advanced-menu-mobile-toggle rect {
-  fill: #121212
+  fill: var(--color-dark)
 }
 
 @media (min-width: 861px) {
@@ -1050,7 +1050,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
   }
 
   .fl-node-menu .pp-advanced-menu .menu > li > a, .fl-node-menu .pp-advanced-menu .menu > li > .pp-has-submenu-container > a {
-    color: #121212
+    color: var(--color-dark)
   }
 
   .fl-node-menu .sub-menu > li > a, .fl-node-menu .sub-menu > li > .pp-has-submenu-container > a {
@@ -1084,7 +1084,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 
 .fl-node-menu .pp-advanced-menu .pp-off-canvas-menu .pp-menu-close-btn {
   font-size: 30px;
-  color: #121212
+  color: var(--color-dark)
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .menu {
@@ -1104,7 +1104,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .menu li a, .fl-node-menu .pp-advanced-menu.off-canvas .menu li .pp-has-submenu-container a {
-  color: #121212;
+  color: var(--color-dark);
   border-style: solid;
   border-bottom-color: transparent;
   -webkit-transition: all .3s ease-in-out;
@@ -1120,7 +1120,7 @@ ul.pp-advanced-menu-horizontal li.mega-menu > ul.sub-menu ul.sub-menu {
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-none .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .sub-menu .pp-menu-toggle:before, .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-none .sub-menu .pp-menu-toggle:before {
-  border-color: #121212
+  border-color: var(--color-dark)
 }
 
 .fl-node-menu .pp-advanced-menu.off-canvas .pp-toggle-arrows .pp-menu-toggle {

--- a/themes/beaver/assets/css/navigation.css
+++ b/themes/beaver/assets/css/navigation.css
@@ -7,7 +7,7 @@ body {
   font-size: 18px;
   font-weight: 400;
   line-height: 1.6;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites minifier merge-hoist / dedup unmask; see body/h1 notes above */
 }
 
 .btn,
@@ -182,7 +182,7 @@ a.action-button:hover {
   display: none;
   width: 30px;
   height: 19px;
-  border: solid #121212;
+  border: solid var(--color-dark);
   border-width: 3px 0;
   position: relative;
   cursor: pointer;
@@ -197,7 +197,7 @@ a.action-button:hover {
   position: absolute;
   width: 100%;
   height: 3px;
-  background-color: #121212;
+  background-color: var(--color-dark);
   left: 0;
   top: 50%;
   margin-top: -1px;
@@ -217,7 +217,7 @@ a.action-button:hover {
   content: '';
   position: absolute;
   height: 2px;
-  background-color: #121212;
+  background-color: var(--color-dark);
   left: 4px;
   right: 4px;
   top: 50%;
@@ -229,7 +229,7 @@ a.action-button:hover {
   content: '';
   position: absolute;
   height: 2px;
-  background-color: #121212;
+  background-color: var(--color-dark);
   left: 4px;
   right: 4px;
   top: 50%;
@@ -276,7 +276,7 @@ a.action-button:hover {
   margin-top: -6px;
   width: 9px;
   height: 9px;
-  border-color: #121212;
+  border-color: var(--color-dark);
   border-style: solid;
   border-width: 0 2px 2px 0;
   transform-origin: 70% 70%;
@@ -291,7 +291,7 @@ a.action-button:hover {
   font-size: 16px;
   font-weight: 300;
   line-height: 24px;
-  color: #121212;
+  color: var(--color-dark);
   text-decoration: none;
   transition: .3s;
 }
@@ -379,7 +379,7 @@ a.action-button:hover {
   font-weight: 700;
   font-size: 20px;
   line-height: 26px;
-  color: #121212;
+  color: var(--color-dark);
   transition: .3s;
 }
 
@@ -451,7 +451,7 @@ a.action-button:hover {
     font-weight: 300;
     line-height: 22px;
     font-size: 16px;
-    background-color: #121212;
+    background-color: var(--color-dark);
     color: #fff;
     border-radius: 6px;
     margin-top: 15px;

--- a/themes/beaver/assets/css/skin-65eda28877e04.css
+++ b/themes/beaver/assets/css/skin-65eda28877e04.css
@@ -34,7 +34,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
-  color: #121212
+  color: #121212 /* KEEP LITERAL: reboot-generic selector - var() form invites minifier merge-hoist / dedup unmask; see body/h1 notes above */
 }
 
 h1 a:hover, h2 a:hover, h3 a:hover, h4 a:hover, h5 a:hover, h6 a:hover {
@@ -56,7 +56,7 @@ h1 {
 }
 
 h1 a {
-  color: #121212
+  color: #121212 /* KEEP LITERAL: reboot-generic selector - var() form invites minifier merge-hoist / dedup unmask; see body/h1 notes above */
 }
 
 h2 {
@@ -1003,7 +1003,7 @@ input[type=text].fl-search-input {
 }
 
 input[type=text].fl-search-input:focus {
-  color: #121212
+  color: var(--color-dark)
 }
 
 .widget_calendar table {
@@ -1074,7 +1074,7 @@ input[type=text].fl-search-input:focus {
   color: #515151;
   border: none;
   border-radius: 25px;
-  border-color: #121212
+  border-color: #121212 /* KEEP LITERAL: border is style:none (invisible); var() here changes the minifier border shorthand/longhand merge product across bundles */
 }
 
 .fl-page .fl-module-woocommerce button.button:disabled, .fl-page .fl-module-woocommerce button.button:disabled[disabled], .fl-page .fl-module-woocommerce button.alt.disabled {
@@ -1102,7 +1102,7 @@ input[type=text].fl-search-input:focus {
   color: #515151;
   border: none;
   border-radius: 25px;
-  border-color: #121212
+  border-color: #121212 /* KEEP LITERAL: border is style:none (invisible); var() here changes the minifier border shorthand/longhand merge product across bundles */
 }
 
 .woocommerce-page button.pswp__button:hover {
@@ -1185,7 +1185,7 @@ button:active, input[type=button]:active, input[type=submit]:active, button:focu
 }
 
 button.btn-default, input[type=button].btn-default, input[type=submit].btn-default, button.btn-default:hover, input[type=button].btn-default:hover, input[type=submit].btn-default:hover, button.btn-default:focus, input[type=button].btn-default:focus, input[type=submit].btn-default:focus, button.btn-default.active, input[type=button].btn-default.active, input[type=submit].btn-default.active {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #fcfcfc;
   border-color: #ccc
 }
@@ -1201,7 +1201,7 @@ input[type=text], input[type=password], input[type=email], input[type=tel], inpu
   padding: 6px 12px;
   font-size: 14px;
   line-height: 1.428571429;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: bare textarea in selector list - reboot-generic class */
   background-color: #fcfcfc;
   background-image: none;
   border: 1px solid #e6e6e6;
@@ -1244,7 +1244,7 @@ input[type=text]:focus, input[type=password]:focus, input[type=email]:focus, inp
 .form-control {
   background-color: #fcfcfc;
   border-color: #e6e6e6;
-  color: #121212;
+  color: var(--color-dark);
   -moz-transition: all ease-in-out .15s;
   -webkit-transition: all ease-in-out .15s;
   transition: all ease-in-out .15s
@@ -1385,7 +1385,7 @@ img.mfp-img {
 
   .fl-page-nav .navbar-nav li > a {
     padding: 15px 15px;
-    color: #121212
+    color: var(--color-dark)
   }
 
   .fl-page-nav .navbar-nav li > a:hover, .fl-page-nav .navbar-nav li > a:focus {
@@ -1397,7 +1397,7 @@ img.mfp-img {
   }
 
   .fl-page-nav .navbar-nav li.current-menu-item ~ li.current-menu-item > a {
-    color: #121212
+    color: var(--color-dark)
   }
 
   .fl-page-nav-wrap {
@@ -1686,7 +1686,7 @@ body.fl-framework-base-4 nav a.no-menu, body.fl-framework-bootstrap-4 nav a.no-m
 
 body.woocommerce-page.fl-framework-bootstrap .product .label {
   font-size: 18px;
-  color: #121212;
+  color: var(--color-dark);
   padding: 0px
 }
 
@@ -2398,7 +2398,7 @@ ul.wp-block-latest-posts.alignwide, ul.wp-block-latest-posts.alignfull, ul.wp-bl
   text-transform: capitalize;
   border-style: none;
   border-width: 1px;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: dedup-twin of the identical .fl-page fl-button rule in critical/*.css (kept literal there too) */
   border-radius: 25px
 }
 
@@ -2408,7 +2408,7 @@ ul.wp-block-latest-posts.alignwide, ul.wp-block-latest-posts.alignfull, ul.wp-bl
 
 .fl-page input[type=button]:hover, .fl-responsive-preview-content input[type=button]:hover, .fl-button-lightbox-content input[type=button]:hover, .fl-page input[type=submit]:hover, .fl-responsive-preview-content input[type=submit]:hover, .fl-button-lightbox-content input[type=submit]:hover, .fl-page a.fl-button:hover, .fl-responsive-preview-content a.fl-button:hover, .fl-button-lightbox-content a.fl-button:hover, .fl-page a.button:hover, .fl-responsive-preview-content a.button:hover, .fl-button-lightbox-content a.button:hover, .fl-page button.button:hover, .fl-responsive-preview-content button.button:hover, .fl-button-lightbox-content button.button:hover, .fl-page .fl-page-nav-toggle-button .fl-page-nav .navbar-toggle:hover, .fl-responsive-preview-content .fl-page-nav-toggle-button .fl-page-nav .navbar-toggle:hover, .fl-button-lightbox-content .fl-page-nav-toggle-button .fl-page-nav .navbar-toggle:hover {
   color: #fff;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: dedup-twin of the identical .fl-page fl-button rule in critical/*.css (kept literal there too) */
   background-color: #007af4;
   border-style: none;
   border-width: 1px;

--- a/themes/beaver/assets/css/theme-main.css
+++ b/themes/beaver/assets/css/theme-main.css
@@ -1,8 +1,8 @@
 :root {
   --jt-primary-color: var(--color-primary);
-  --jt-text-color: #121212;
+  --jt-text-color: #121212; /* KEEP LITERAL (value side): shadow token - repointing to var(--color-dark) is a deliberate follow-up decision, not a mechanical swap */
   --jt-primary: #1a8cff;
-  --jt-text-primary: #121212;
+  --jt-text-primary: #121212; /* KEEP LITERAL (value side): shadow token - repointing to var(--color-dark) is a deliberate follow-up decision, not a mechanical swap */
   --jt-primary-dark: #0066cc;
   --jt-primary-hover: #007af4;
   --jt-white: #ffffff;
@@ -18,7 +18,7 @@
 
 body {
   background-color: #fff;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites minifier merge-hoist / dedup unmask; see body/h1 notes above */
   font-family:
     system-ui,
     -apple-system,
@@ -58,7 +58,7 @@ h3,
 h4,
 h5,
 h6 {
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites minifier merge-hoist / dedup unmask; see body/h1 notes above */
   font-family:
     system-ui,
     -apple-system,
@@ -85,7 +85,7 @@ h3 a,
 h4 a,
 h5 a,
 h6 a {
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites minifier merge-hoist / dedup unmask; see body/h1 notes above */
 }
 
 h1 a:hover,
@@ -101,7 +101,7 @@ h1 {
   font-size: 70px;
   line-height: 1;
   letter-spacing: -1px;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites minifier merge-hoist / dedup unmask; see body/h1 notes above */
   font-family:
     system-ui,
     -apple-system,
@@ -122,7 +122,7 @@ h1 {
 }
 
 h1 a {
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: reboot-generic selector - var() form invites minifier merge-hoist / dedup unmask; see body/h1 notes above */
 }
 
 h2 {
@@ -1128,7 +1128,7 @@ input[type="text"].fl-search-input {
 }
 
 input[type="text"].fl-search-input:focus {
-  color: #121212;
+  color: var(--color-dark);
 }
 
 .widget_calendar table {
@@ -1224,7 +1224,7 @@ input[type="text"].fl-search-input:focus {
   color: #515151;
   border: none;
   border-radius: 25px;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: border is style:none (invisible); var() here changes the minifier border shorthand/longhand merge product across bundles */
 }
 
 .fl-page .fl-module-woocommerce button.button:disabled,
@@ -1285,7 +1285,7 @@ input[type="text"].fl-search-input:focus {
   color: #515151;
   border: none;
   border-radius: 25px;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: border is style:none (invisible); var() here changes the minifier border shorthand/longhand merge product across bundles */
 }
 
 .woocommerce-page button.pswp__button:hover {
@@ -1394,7 +1394,7 @@ input[type="submit"].btn-default:focus,
 button.btn-default.active,
 input[type="button"].btn-default.active,
 input[type="submit"].btn-default.active {
-  color: #121212;
+  color: var(--color-dark);
   background-color: #fcfcfc;
   border-color: #ccc;
 }
@@ -1424,7 +1424,7 @@ textarea {
   padding: 6px 12px;
   font-size: 14px;
   line-height: 1.428571429;
-  color: #121212;
+  color: #121212; /* KEEP LITERAL: bare textarea in selector list - reboot-generic class */
   background-color: #fcfcfc;
   background-image: none;
   border: 1px solid #e6e6e6;
@@ -1522,7 +1522,7 @@ textarea:focus {
 .form-control {
   background-color: #fcfcfc;
   border-color: #e6e6e6;
-  color: #121212;
+  color: var(--color-dark);
   -moz-transition: all ease-in-out 0.15s;
   -webkit-transition: all ease-in-out 0.15s;
   transition: all ease-in-out 0.15s;
@@ -1682,7 +1682,7 @@ img.mfp-img {
 
   .fl-page-nav .navbar-nav li > a {
     padding: 15px 15px;
-    color: #121212;
+    color: var(--color-dark);
   }
 
   .fl-page-nav .navbar-nav li > a:hover,
@@ -1697,7 +1697,7 @@ img.mfp-img {
   }
 
   .fl-page-nav .navbar-nav li.current-menu-item ~ li.current-menu-item > a {
-    color: #121212;
+    color: var(--color-dark);
   }
 
   .fl-page-nav-wrap {
@@ -2034,7 +2034,7 @@ body.fl-framework-bootstrap-4 nav a.no-menu {
 
 body.woocommerce-page.fl-framework-bootstrap .product .label {
   font-size: 18px;
-  color: #121212;
+  color: var(--color-dark);
   padding: 0px;
 }
 
@@ -3164,7 +3164,7 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   text-transform: capitalize;
   border-style: none;
   border-width: 1px;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: border is style:none (invisible); var() here changes the minifier border shorthand/longhand merge product across bundles */
   border-radius: 25px;
 }
 
@@ -3230,7 +3230,7 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   .fl-page-nav
   .navbar-toggle:hover {
   color: #fff;
-  border-color: #121212;
+  border-color: #121212; /* KEEP LITERAL: border is style:none (invisible); var() here changes the minifier border shorthand/longhand merge product across bundles */
   background-color: #007af4;
   border-style: none;
   border-width: 1px;

--- a/themes/beaver/assets/css/use-cases-dynamic.css
+++ b/themes/beaver/assets/css/use-cases-dynamic.css
@@ -7,7 +7,7 @@
 
 .use-cases .subheading {
   font-size: 60px;
-  color: #121212;
+  color: var(--color-dark);
   margin-left: 200px;
   margin-right: 200px;
   text-align: center;
@@ -64,7 +64,7 @@
 }
 
 .use-cases .tab-title, .use-cases .tab-title-mobile {
-  color: #121212;
+  color: var(--color-dark);
   border: none;
   border-radius: 14px;
   padding: 28px 35px;

--- a/themes/beaver/layouts/blog/list.html
+++ b/themes/beaver/layouts/blog/list.html
@@ -3,18 +3,7 @@
 {{ end }}
 
 {{ define "header" }}
-  {{- $cssFiles := slice
-    (resources.Get "css/dynamic-icons.css" | resources.ExecuteAsTemplate "css/dynamic586.css" .)
-    (resources.Get "css/pagination.css")
-    (resources.Get "css/services-layout.css")
-    (resources.Get "css/style.css")
-    (resources.Get "css/vendors/base-4.min.css")
-    (resources.Get "css/homepage-layout.css")
-    (resources.Get "css/component-bundle.css")
-    (resources.Get "css/theme-main.css")
-    (resources.Get "css/single-post.css")
-    (resources.Get "css/footer.css")
-  }}
+  {{- $cssFiles := partial "assets/blog-list-css-resources.html" . -}}
 
   {{ partial "assets/css-processor.html" (dict
     "resources" $cssFiles

--- a/themes/beaver/layouts/list.html
+++ b/themes/beaver/layouts/list.html
@@ -3,18 +3,14 @@
 {{ end }}
 
 {{ define "header" }}
-  {{- $cssFiles := slice
-    (resources.Get "css/foundations/css-variables.css")
-    (resources.Get "css/dynamic-icons.css" | resources.ExecuteAsTemplate "css/dynamic586.css" .)
-    (resources.Get "css/586.css")
-    (resources.Get "css/style.css")
-    (resources.Get "css/vendors/base-4.min.css")
-    (resources.Get "css/3114-layout.css")
-    (resources.Get "css/bf72bba397177a0376baed325bffdc75-layout-bundle.css")
-    (resources.Get "css/skin-65eda28877e04.css")
-    (resources.Get "css/single-post.css")
-    (resources.Get "css/footer.css")
-  }}
+  {{- /* This slice used to differ from blog/list.html's while sharing the
+         "blog-list" bundleName — in every observed build (and on the live
+         site) blog/list.html's concat won the name race, so tag pages have
+         always shipped THAT set. The shared partial pins the served set and
+         removes the race; this template's old declared-only members
+         (css-variables, 586, 3114-layout, bf72bba…, skin) never reached
+         production. */ -}}
+  {{- $cssFiles := partial "assets/blog-list-css-resources.html" . -}}
 
   {{ partial "assets/css-processor.html" (dict
     "resources" $cssFiles

--- a/themes/beaver/layouts/partials/assets/blog-list-css-resources.html
+++ b/themes/beaver/layouts/partials/assets/blog-list-css-resources.html
@@ -5,7 +5,11 @@
      bundle for BOTH page sets. Identical membership makes the shared name
      deterministic. Keep order stable — legacy styles depend on cascade
      sequence. */}}
+{{- /* css-variables first: members (services-layout, homepage-layout)
+       consume var(--color-dark); this bundle carried no definition, so
+       those declarations were invalid at computed-value time. */ -}}
 {{- return (slice
+  (resources.Get "css/foundations/css-variables.css")
   (resources.Get "css/dynamic-icons.css" | resources.ExecuteAsTemplate "css/dynamic586.css" .)
   (resources.Get "css/pagination.css")
   (resources.Get "css/services-layout.css")

--- a/themes/beaver/layouts/partials/assets/blog-list-css-resources.html
+++ b/themes/beaver/layouts/partials/assets/blog-list-css-resources.html
@@ -1,0 +1,19 @@
+{{/* Blog-list CSS bundle composition — shared by blog/list.html (blog index)
+     and list.html (tag/taxonomy fallback). Both templates emit bundleName
+     "blog-list"; resources.Concat caches by target path, so when their member
+     slices differed, whichever template rendered first silently decided the
+     bundle for BOTH page sets. Identical membership makes the shared name
+     deterministic. Keep order stable — legacy styles depend on cascade
+     sequence. */}}
+{{- return (slice
+  (resources.Get "css/dynamic-icons.css" | resources.ExecuteAsTemplate "css/dynamic586.css" .)
+  (resources.Get "css/pagination.css")
+  (resources.Get "css/services-layout.css")
+  (resources.Get "css/style.css")
+  (resources.Get "css/vendors/base-4.min.css")
+  (resources.Get "css/homepage-layout.css")
+  (resources.Get "css/component-bundle.css")
+  (resources.Get "css/theme-main.css")
+  (resources.Get "css/single-post.css")
+  (resources.Get "css/footer.css")
+) -}}

--- a/themes/beaver/layouts/services/single.html
+++ b/themes/beaver/layouts/services/single.html
@@ -1,6 +1,12 @@
 {{ define "header" }}
 
+  {{- /* css-variables first: critical/single-services.css consumes
+         var(--font-system-ui) but this bundle never carried the definition
+         (sprint-1 wiring covered the careers/single-careers/single-use-cases
+         no-base bundles and missed this one), so the token was unresolved
+         and fonts fell back to inherited stacks. */ -}}
   {{- $servicesResources := slice
+    (resources.Get "css/foundations/css-variables.css")
     (resources.Get "css/critical/single-services.css")
     (resources.Get "css/2949-layout.css")
     (resources.Get "css/bf72bba397177a0376baed325bffdc75-layout-bundle.css")


### PR DESCRIPTION
## Summary

Sprint 4 of the 2509 CSS migration (WP1.1 continuation), 7 commits under the option-A protocol: every substitution gated by a production-bundle rule-level masking analysis before landing, plus both visual suites per commit.

**Two latent bugs fixed, one build nondeterminism removed, 404 of 648 `#121212` literals tokenized.**

## Commits

1. **fbd38c63 — blog-list bundle collision fix.** Root `list.html` (renders the 383 `/blog/tags/*` pages — correcting the sprint-3 note that no taxonomy pages generate) and `blog/list.html` both emitted bundleName `blog-list` with different resource slices; `resources.Concat` caches by target path, so the first-rendered template silently decided the CSS for both page sets. Live-site + scratch-build evidence shows `blog/list.html`'s slice always won, so sprint 3's css-variables wiring for taxonomy pages never reached production. Fixed with a shared resource partial — deterministic by construction, **compiled output byte-identical** (all 19 bundle hashes unchanged).
2. **a621f8f6 — live bug: `single-service` bundle shipped 17 unresolved `var(--font-system-ui)`** (sprint-1's no-base wiring missed `services/single.html`). Fonts on service detail pages silently fell back to inherited stacks. Gate: +1 `:root` rule, everything else byte-identical.
3. **9c264fa3 — `--color-dark: #121212` defined** in `foundations/css-variables.css` (the per-bundle-imported, site-wide-inlined token home). The only prior definition (`variables/colors.css`) is bundled nowhere — every shipped `var(--color-dark)` consumer was invalid at computed-value time. Reviewer traced all consumers against rendered HTML: no visible change (inherited color was already #121212).
4. **e25d9f00 — blog-list bundle wired with the foundation** so its consumers resolve.
5. **48bb2c71 — 384 swaps `#121212` → `var(--color-dark)`** across 19 live layout/bundle files (whole-file, all `.fl-node-*`/class-scoped) + 10 `critical/*` files (minus reboot generics).
6. **662b59cb — batch 3: skin/theme-main/navigation scoped lines** (20 swaps). The inline navigation bundle now carries the def, so the token resolves on every page.
7. **9da3eed0 — tracker update.**

## What was deliberately NOT tokenized (KEEP LITERAL comments in-file)

- 25 reboot-generic `body`/`h1` color rules in `critical/*` + skin/theme-main/navigation generics — the var() form invites the cssnano merge-hoist that caused sprint 3's h1 70px→40px rollback.
- 10 `.fl-page a.fl-button` border-colors + 6 woo/fl-button border-colors — dedup-twins / invisible (`style:none`) borders whose var() form churns the minifier's border shorthand↔longhand merge product (computed-identical but not byte-pure; nothing to gain).
- 2 shadow-token definitions (`--jt-text-color`, `--jt-text-primary`) — repointing them is a deliberate follow-up decision.
- ~157 literals in 13 **orphan** files (fl-*-layout etc., reachable only via dead aggregators) — queued for a deletion PR instead.

## Gate evidence (per commit)

- Production build to scratch + symmetric rule-level diff (normalize `var(--color-dark)`↔`#121212` both sides, strip the def): **empty diff + identical rule counts for all 19 bundles**; inline bundles extracted from compiled HTML and diffed the same way.
- The gate caught and prevented three masking classes invisible to visual suites: dedup-twin rule re-appearance (partial-bundle tokenization), border shorthand/longhand merge churn, and merge-hoist candidates.
- `bin/rake test:critical` 46/46 (macOS) and `bin/dtest` 46/46 (Linux) green on every commit; screenshot baselines restored each run (no baseline changes in this PR).
- Standing reviewer (ruflo-core:reviewer) approved every commit hunk-by-hunk with independent bundle re-verification.

## Also documented (pre-existing, not addressed here)

- Inline components bundle flickers dead rules between builds (`hugo_stats.json` omits classes that exist only in dead templates; stale postcss cache sometimes preserves them; no `[[build.cachebusters]]` configured). Visually inert — the affected rules match no live markup.
- Tag-page term titles are nondeterministic per build (CrewAI vs Crewai) — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)