### PR TITLE
feat(course): targeted media batch - 3-screen wireframe, interview scorecard, FAQ module strip

### DIFF
--- a/content/course/tech-for-non-technical-founders-2026/clickable-prototype-validation-2-hour-lovable/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/clickable-prototype-validation-2-hour-lovable/index.md
@@ -108,6 +108,8 @@ Try to "polish the prototype into the MVP later" and you spend much longer on it
 
 Three screens is the constraint - not five, not ten - because each extra screen multiplies the build effort without sharpening the validation signal.
 
+![Wireframe of a passing 3-screen prototype: Screen 1 entry point with a fake file list and a Match transactions button, Screen 2 core action showing a Stripe-vs-QuickBooks match table where testers stall, and Screen 3 result with a summary card and Download report - the screen a passing tester reaches without coaching](wireframe-strip.svg)
+
 > **The two caps that replace "spend a weekend on it".** (1) **Stop at 3 screens.** The fourth screen is the prototype turning into the MVP - exactly the failure mode this chapter prevents. (2) **Aim for a navigable 3-screen prototype within your first ~10 Lovable exchanges.** If after 10 messages the screens still aren't navigable, the hypothesis or the prompt is too vague - sharpen the prompt (or go back to Ch 1.1) before continuing. Do NOT keep adding messages hoping to brute-force coherence.
 
 ### Screen 1 - The entry point

--- a/content/course/tech-for-non-technical-founders-2026/clickable-prototype-validation-2-hour-lovable/wireframe-strip.svg
+++ b/content/course/tech-for-non-technical-founders-2026/clickable-prototype-validation-2-hour-lovable/wireframe-strip.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 400" role="img" aria-labelledby="wf-title">
+  <title id="wf-title">A passing 3-screen prototype: Screen 1 entry point (fake file list + a Match transactions button) leads to Screen 2 core action (a Stripe-vs-QuickBooks match table where testers stall) leads to Screen 3 result (a summary card and Download report), which is where a passing tester lands without coaching.</title>
+  <defs>
+    <style>
+      .heading { font-family: "Caveat", "Patrick Hand", cursive; font-size: 27px; fill: #1a1a1a; font-weight: 700; }
+      .stitle  { font-family: "Caveat", "Patrick Hand", cursive; font-size: 18px; fill: #cc342d; font-weight: 700; }
+      .stitleg { font-family: "Caveat", "Patrick Hand", cursive; font-size: 18px; fill: #2e7d32; font-weight: 700; }
+      .box     { font-family: "Caveat", "Patrick Hand", cursive; font-size: 16px; fill: #333; }
+      .boxq    { font-family: "Caveat", "Patrick Hand", cursive; font-size: 14px; fill: #777; font-style: italic; }
+      .cta     { font-family: "Caveat", "Patrick Hand", cursive; font-size: 17px; fill: #fff; font-weight: 700; }
+      .anno    { font-family: "Caveat", "Patrick Hand", cursive; font-size: 16px; fill: #555; font-style: italic; }
+      .pass    { font-family: "Caveat", "Patrick Hand", cursive; font-size: 15px; fill: #2e7d32; font-weight: 700; }
+      .frame   { fill: #fff5f5; stroke: #cc342d; stroke-width: 2.5; }
+      .frameg  { fill: #f1f9f1; stroke: #2e7d32; stroke-width: 2.5; }
+      .bar     { fill: #ffffff; stroke: #e2b8b8; stroke-width: 1.5; }
+      .barg    { fill: #ffffff; stroke: #b6d9b6; stroke-width: 1.5; }
+      .ctabtn  { fill: #cc342d; stroke: none; }
+      .arrow   { stroke: #cc342d; stroke-width: 3; fill: none; }
+    </style>
+  </defs>
+
+  <text x="480" y="34" class="heading" text-anchor="middle">A passing 3-screen prototype, wireframed</text>
+
+  <!-- ============ PANEL 1 - Entry point ============ -->
+  <g transform="rotate(-0.4 159 173)">
+    <rect x="20" y="58" width="278" height="230" rx="14" class="frame"/>
+    <rect x="34" y="74" width="250" height="32" rx="7" class="bar"/>
+    <text x="159" y="96" class="stitle" text-anchor="middle">Screen 1 · Entry point</text>
+    <rect x="34" y="120" width="250" height="66" rx="8" class="bar"/>
+    <text x="159" y="145" class="box" text-anchor="middle">3 CSV files listed</text>
+    <text x="159" y="168" class="boxq" text-anchor="middle">(hard-coded fake data)</text>
+    <rect x="49" y="210" width="220" height="40" rx="20" class="ctabtn"/>
+    <text x="159" y="236" class="cta" text-anchor="middle">Match transactions</text>
+  </g>
+  <text x="159" y="312" class="anno" text-anchor="middle">First click - can they start?</text>
+
+  <!-- arrow 1 -->
+  <g>
+    <path d="M 303 173 L 330 173" class="arrow"/>
+    <path d="M 330 167 L 342 173 L 330 179 Z" fill="#cc342d"/>
+  </g>
+
+  <!-- ============ PANEL 2 - Core action ============ -->
+  <g transform="rotate(0.4 477 173)">
+    <rect x="338" y="58" width="278" height="230" rx="14" class="frame"/>
+    <rect x="352" y="74" width="250" height="32" rx="7" class="bar"/>
+    <text x="477" y="96" class="stitle" text-anchor="middle">Screen 2 · Core action</text>
+    <rect x="352" y="120" width="250" height="66" rx="8" class="bar"/>
+    <text x="477" y="145" class="box" text-anchor="middle">Stripe  vs  QuickBooks</text>
+    <text x="477" y="168" class="box" text-anchor="middle">12 matched · 3 flagged</text>
+    <rect x="367" y="210" width="220" height="40" rx="20" class="ctabtn"/>
+    <text x="477" y="236" class="cta" text-anchor="middle">Approve all matches</text>
+  </g>
+  <text x="477" y="312" class="anno" text-anchor="middle">Where testers stall</text>
+
+  <!-- arrow 2 -->
+  <g>
+    <path d="M 621 173 L 648 173" class="arrow"/>
+    <path d="M 648 167 L 660 173 L 648 179 Z" fill="#cc342d"/>
+  </g>
+
+  <!-- ============ PANEL 3 - Result (pass target) ============ -->
+  <g transform="rotate(-0.3 795 173)">
+    <rect x="656" y="58" width="278" height="230" rx="14" class="frameg"/>
+    <rect x="670" y="74" width="250" height="32" rx="7" class="barg"/>
+    <text x="795" y="96" class="stitleg" text-anchor="middle">Screen 3 · Result</text>
+    <rect x="670" y="120" width="250" height="66" rx="8" class="barg"/>
+    <text x="795" y="145" class="box" text-anchor="middle">Summary card</text>
+    <text x="795" y="168" class="box" text-anchor="middle">12 matched, 3 flagged</text>
+    <rect x="685" y="210" width="220" height="40" rx="20" class="ctabtn"/>
+    <text x="795" y="236" class="cta" text-anchor="middle">Download report</text>
+  </g>
+  <text x="795" y="312" class="anno" text-anchor="middle">Can they name what it did?</text>
+
+  <!-- PASS marker on the right screen -->
+  <rect x="660" y="326" width="270" height="30" rx="15" fill="#eaf6ea" stroke="#2e7d32" stroke-width="2"/>
+  <text x="795" y="346" class="pass" text-anchor="middle">PASS = reaches here uncoached</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/faq/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/faq/index.md
@@ -29,6 +29,8 @@ related_posts: false
 
 If you're stuck, start here. These are the questions founders ask most often - read the 2-3 that match your situation and get back to the build. If your question isn't here, try the course's [Quickstart path](/course/tech-for-non-technical-founders-2026/quickstart/) or the [How This Course Works](/course/tech-for-non-technical-founders-2026/how-this-course-works/) overview.
 
+![Module map for this FAQ: a General group followed by Module 1 Hypothesis and smoke test, Module 2 Validate the problem, Module 3 Design from evidence, Module 4 Build it yourself, and Module 5 First paying customer - questions below are grouped in this order.](module-strip.svg)
+
 ---
 
 ## Module 1 - Hypothesis & Smoke Test

--- a/content/course/tech-for-non-technical-founders-2026/faq/module-strip.svg
+++ b/content/course/tech-for-non-technical-founders-2026/faq/module-strip.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 200" role="img" aria-labelledby="faq-strip-title">
+  <title id="faq-strip-title">FAQ map: questions are grouped as General, then Module 1 Hypothesis and smoke test, Module 2 Validate the problem, Module 3 Design from evidence, Module 4 Build it yourself, and Module 5 First paying customer - in that order.</title>
+  <defs>
+    <style>
+      .num    { font-family: "Caveat", "Patrick Hand", cursive; font-size: 18px; fill: #ffffff; font-weight: 700; }
+      .lab    { font-family: "Caveat", "Patrick Hand", cursive; font-size: 16px; fill: #ffffff; font-weight: 700; }
+      .glab   { font-family: "Caveat", "Patrick Hand", cursive; font-size: 16px; fill: #1a1a1a; font-weight: 700; }
+      .gsub   { font-family: "Caveat", "Patrick Hand", cursive; font-size: 14px; fill: #666; }
+      .cap    { font-family: "Caveat", "Patrick Hand", cursive; font-size: 16px; fill: #555; font-style: italic; }
+      .chip   { fill: #cc342d; stroke: #a5241f; stroke-width: 2; }
+      .gen    { fill: #fffdf8; stroke: #cc342d; stroke-width: 2; }
+    </style>
+    <marker id="fa" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6" fill="none" stroke="#999" stroke-width="1.6"/>
+    </marker>
+  </defs>
+
+  <!-- General (entry) -->
+  <g transform="rotate(-0.4 91.5 94)">
+    <rect x="24" y="44" width="135" height="100" rx="14" class="gen"/>
+    <text x="91.5" y="90" class="glab" text-anchor="middle">General</text>
+    <text x="91.5" y="112" class="gsub" text-anchor="middle">pace &amp; order</text>
+  </g>
+
+  <!-- M1 -->
+  <g transform="rotate(0.4 246.5 94)">
+    <rect x="179" y="44" width="135" height="100" rx="14" class="chip"/>
+    <text x="246.5" y="78" class="num" text-anchor="middle">M1</text>
+    <text x="246.5" y="103" class="lab" text-anchor="middle">Hypothesis</text>
+    <text x="246.5" y="123" class="lab" text-anchor="middle">&amp; smoke test</text>
+  </g>
+
+  <!-- M2 -->
+  <g transform="rotate(-0.3 401.5 94)">
+    <rect x="334" y="44" width="135" height="100" rx="14" class="chip"/>
+    <text x="401.5" y="78" class="num" text-anchor="middle">M2</text>
+    <text x="401.5" y="103" class="lab" text-anchor="middle">Validate</text>
+    <text x="401.5" y="123" class="lab" text-anchor="middle">the problem</text>
+  </g>
+
+  <!-- M3 -->
+  <g transform="rotate(0.3 556.5 94)">
+    <rect x="489" y="44" width="135" height="100" rx="14" class="chip"/>
+    <text x="556.5" y="78" class="num" text-anchor="middle">M3</text>
+    <text x="556.5" y="103" class="lab" text-anchor="middle">Design from</text>
+    <text x="556.5" y="123" class="lab" text-anchor="middle">evidence</text>
+  </g>
+
+  <!-- M4 -->
+  <g transform="rotate(-0.3 711.5 94)">
+    <rect x="644" y="44" width="135" height="100" rx="14" class="chip"/>
+    <text x="711.5" y="78" class="num" text-anchor="middle">M4</text>
+    <text x="711.5" y="103" class="lab" text-anchor="middle">Build it</text>
+    <text x="711.5" y="123" class="lab" text-anchor="middle">yourself</text>
+  </g>
+
+  <!-- M5 -->
+  <g transform="rotate(0.4 866.5 94)">
+    <rect x="799" y="44" width="135" height="100" rx="14" class="chip"/>
+    <text x="866.5" y="78" class="num" text-anchor="middle">M5</text>
+    <text x="866.5" y="103" class="lab" text-anchor="middle">First paying</text>
+    <text x="866.5" y="123" class="lab" text-anchor="middle">customer</text>
+  </g>
+
+  <!-- Arrows -->
+  <line x1="161" y1="94" x2="177" y2="94" stroke="#999" stroke-width="1.6" marker-end="url(#fa)"/>
+  <line x1="316" y1="94" x2="332" y2="94" stroke="#999" stroke-width="1.6" marker-end="url(#fa)"/>
+  <line x1="471" y1="94" x2="487" y2="94" stroke="#999" stroke-width="1.6" marker-end="url(#fa)"/>
+  <line x1="626" y1="94" x2="642" y2="94" stroke="#999" stroke-width="1.6" marker-end="url(#fa)"/>
+  <line x1="781" y1="94" x2="797" y2="94" stroke="#999" stroke-width="1.6" marker-end="url(#fa)"/>
+
+  <text x="480" y="178" class="cap" text-anchor="middle">Find your module below - questions are grouped in this order.</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/hiring-interview-script/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/hiring-interview-script/index.md
@@ -48,15 +48,9 @@ related_posts: false
 
 ## The 7 questions at a glance
 
-| # | Question (compressed) | What it tests |
-|---|---|---|
-| 1 | Workflow: Jira ticket to merged code, with AI in the loop | Tools named by version, real PR from last week |
-| 2 | Cost: $/dev/month on AI tokens, who pays it | Specific dollar range, pulled before the call |
-| 3 | Verification: what the senior reviewer checks on AI PRs | Opens a real PR on screen, names line-level checks |
-| 4 | Slopsquatting: how do you stop a hallucinated package | Named defense, uses the word, cites the source |
-| 5 | Accountability: last AI-generated-code incident you owned | Date in last 6 months, root cause, workflow change after |
-| 6 | Refactor: last one you led, what stayed/changed/broke | Named system, kept-changed-broke-safety-net structure |
-| 7 | Disagreement: PR review where you said no to the AI | Real PR on screen, specific technical reason, one of many |
+Keep this card open during the call or print it: what to listen for (Pass) sits beside what to walk away from (Fail), question by question. The full criteria for each are in the sections below.
+
+![The 7 hiring questions on one card - the pass signal beside the fail signal for each, with a checkbox to score in real time](scorecard-at-a-glance.svg)
 
 ## Why this exists
 

--- a/content/course/tech-for-non-technical-founders-2026/hiring-interview-script/scorecard-at-a-glance.svg
+++ b/content/course/tech-for-non-technical-founders-2026/hiring-interview-script/scorecard-at-a-glance.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 478" role="img" aria-labelledby="scorecard-title">
+  <title id="scorecard-title">The 7 hiring questions on one card: pass signal versus fail signal for each</title>
+  <defs>
+    <style>
+      .title    { font-family: "Caveat", "Patrick Hand", cursive; font-size: 27px; fill: #1a1a1a; font-weight: 700; }
+      .note     { font-family: "Caveat", "Patrick Hand", cursive; font-size: 15px; fill: #444; font-style: italic; }
+      .colhead  { font-family: "Caveat", "Patrick Hand", cursive; font-size: 17px; fill: #1a1a1a; font-weight: 700; }
+      .qnum     { font-family: "Caveat", "Patrick Hand", cursive; font-size: 20px; fill: #cc342d; font-weight: 700; }
+      .qtext    { font-family: "Caveat", "Patrick Hand", cursive; font-size: 16px; fill: #1a1a1a; font-weight: 700; }
+      .pass     { font-family: "Caveat", "Patrick Hand", cursive; font-size: 15px; fill: #1b5e20; }
+      .fail     { font-family: "Caveat", "Patrick Hand", cursive; font-size: 15px; fill: #b3261e; }
+      .box      { fill: #ffffff; stroke: #1a1a1a; stroke-width: 2; }
+    </style>
+  </defs>
+
+  <text x="30" y="34" class="title">Run the interview from this card</text>
+  <text x="30" y="57" class="note">Tick the box when the answer lands on the Pass side. Full criteria for each question are below.</text>
+
+  <!-- Pass / Fail tinted columns -->
+  <rect x="348" y="72" width="300" height="352" rx="12" fill="#eafaea" stroke="#2e7d32" stroke-width="2"/>
+  <rect x="654" y="72" width="292" height="352" rx="12" fill="#fff2f2" stroke="#cc342d" stroke-width="2"/>
+
+  <!-- Column headers -->
+  <text x="60"  y="93" class="colhead">Question</text>
+  <text x="364" y="93" class="colhead" fill="#1b5e20">PASS sounds like</text>
+  <text x="670" y="93" class="colhead" fill="#b3261e">FAIL sounds like</text>
+  <line x1="30" y1="102" x2="946" y2="102" stroke="#1a1a1a" stroke-width="1.5"/>
+
+  <!-- Q1 -->
+  <rect x="30" y="118" width="22" height="22" rx="4" class="box"/>
+  <text x="64"  y="135" class="qnum">Q1</text>
+  <text x="98"  y="135" class="qtext">Workflow: ticket to code</text>
+  <text x="364" y="135" class="pass">Tools by version + real PR</text>
+  <text x="670" y="135" class="fail">&#8220;Cursor does boilerplate,&#8221; no PR</text>
+
+  <!-- Q2 -->
+  <rect x="30" y="163" width="22" height="22" rx="4" class="box"/>
+  <text x="64"  y="180" class="qnum">Q2</text>
+  <text x="98"  y="180" class="qtext">Cost: $/dev/month</text>
+  <text x="364" y="180" class="pass">$80-300, pulled the receipt</text>
+  <text x="670" y="180" class="fail">&#8220;My company pays,&#8221; no tracking</text>
+
+  <!-- Q3 -->
+  <rect x="30" y="208" width="22" height="22" rx="4" class="box"/>
+  <text x="64"  y="225" class="qnum">Q3</text>
+  <text x="98"  y="225" class="qtext">Verify: reviewer checks</text>
+  <text x="364" y="225" class="pass">Opens real PR, names checks</text>
+  <text x="670" y="225" class="fail">&#8220;I trust the model / CI&#8221;</text>
+
+  <!-- Q4 -->
+  <rect x="30" y="253" width="22" height="22" rx="4" class="box"/>
+  <text x="64"  y="270" class="qnum">Q4</text>
+  <text x="98"  y="270" class="qtext">Slopsquatting defense</text>
+  <text x="364" y="270" class="pass">Named defense + says the word</text>
+  <text x="670" y="270" class="fail">&#8220;Name looks right,&#8221; never hit it</text>
+
+  <!-- Q5 -->
+  <rect x="30" y="298" width="22" height="22" rx="4" class="box"/>
+  <text x="64"  y="315" class="qnum">Q5</text>
+  <text x="98"  y="315" class="qtext">Accountability: owned it</text>
+  <text x="364" y="315" class="pass">Dated incident + root cause</text>
+  <text x="670" y="315" class="fail">&#8220;Never had one,&#8221; blamed Cursor</text>
+
+  <!-- Q6 -->
+  <rect x="30" y="343" width="22" height="22" rx="4" class="box"/>
+  <text x="64"  y="360" class="qnum">Q6</text>
+  <text x="98"  y="360" class="qtext">Refactor you led</text>
+  <text x="364" y="360" class="pass">Named system: kept/changed/broke</text>
+  <text x="670" y="360" class="fail">&#8220;Refactor as I go / rewrote it&#8221;</text>
+
+  <!-- Q7 -->
+  <rect x="30" y="388" width="22" height="22" rx="4" class="box"/>
+  <text x="64"  y="405" class="qnum">Q7</text>
+  <text x="98"  y="405" class="qtext">Disagreement with the AI</text>
+  <text x="364" y="405" class="pass">Real PR on screen, specific reason</text>
+  <text x="670" y="405" class="fail">&#8220;Usually agree,&#8221; then silence</text>
+
+  <line x1="30" y1="424" x2="946" y2="424" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="30" y="462" class="note">Refuses to share screen on Q3 or Q7 = automatic Fail on both. The interview is over.</text>
+</svg>


### PR DESCRIPTION
## Summary

The three media additions the 40.19 premium review identified as genuinely informational (everything else scored MEDIA PREMIUM or was judged acceptable-for-page-type). Built by a 3-agent swarm, every render re-verified by the coordinator.

1. **2.6 Build a Clickable Prototype** — `wireframe-strip.svg`: the lesson asks Sam to build a 3-screen prototype but never showed what a passing one looks like. Now a labeled wireframe strip (entry point → core action → result, using the lesson's own bookkeeper worked example) with the green "PASS = reaches here uncoached" marker on Screen 3, placed at the top of the screen-spec section.
2. **hiring-interview-script** — `scorecard-at-a-glance.svg`: a run-the-call card (Q1–Q7, checkbox, PASS-sounds-like vs FAIL-sounds-like columns, screen-share hard-fail rule beneath). Replaces the existing pass-only summary table in its slot rather than stacking a third summary block — strict superset, no info lost.
3. **FAQ** — `module-strip.svg`: slim General + M1–M5 anchor strip after the intro so readers locate their question's module in one glance (~1,800 words previously had zero visuals).

All three match the course sketch family (Caveat/Patrick Hand, paper tones, red/green accents). Coordinator geometry re-check caught and fixed one defect the agent's self-verify missed (scorecard color bands overlapping the bottom note).

Media investment now freezes until pilot Clarity recordings show real stall points.

## Test evidence
- `bin/validate-course` 8/8 green; `bin/hugo-build` green
- `bin/rake test:critical`: 46 runs, 0 failures, 84 screenshots no diffs
- Every SVG rasterized at 1400px and visually inspected by the coordinator (renders in PR-linked session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYRU9wGepomJo5hSuqtu7V