### PR TITLE
CSS Phase C sprint C5 + phase closure: critical-vs-pages dedup (5 winner-safe pairs), Phase D decisions

### DIFF
--- a/docs/projects/2509-css-migration/TASK-TRACKER.md
+++ b/docs/projects/2509-css-migration/TASK-TRACKER.md
@@ -2,8 +2,8 @@
 
 **Purpose**: Status tracking for the CSS maintainability goal — FL-Builder export CSS retired page-by-page (strangler rewrites)
 **Update Frequency**: After each sprint or status change
-**Last Updated**: 2026-07-18
-**Current Phase**: 🔄 Phase C (post-burn-down cleanup) — sprints C1–C3 planned; FL burn-down itself ✅ 16/16 (PR #365)
+**Last Updated**: 2026-07-19
+**Current Phase**: ✅ PHASE C COMPLETE (2026-07-19) - C1 #371 · C2 #372 · C3 #374 · C4 #375 · C5 dedup. Phase D backlog defined below.
 
 ---
 
@@ -696,6 +696,31 @@ non_goals: NO wrapper-div collapse, NO visual changes, NO rule edits —
 ```
 
 ---
+
+## ✅ PHASE C CLOSURE (2026-07-19) + Phase D backlog
+
+Final scorecard: (1) FL files 0 ✅ · (2) no obfuscated artifacts ✅ - zero
+hashed fl-node classes in any template, zero hash-named files ·
+(3) no duplication in hand layer ✅ - shared components extracted (C1),
+critical-vs-pages twins deduped for the 5 winner-safe pairs (C5) ·
+(4) safe-edit headers + map ✅ · (5) evidence rule held throughout ✅.
+
+**C5 finding**: 4 twin sets are POSITION-LOAD-BEARING and NOT dedupeable
+as-is (clients rich-text font-size, single-service/single-use-cases
+.clearfix:after, single-career apply-form display) - the pages copies
+re-override critical-side defaults by position. Dedup requires
+rule-content normalization first (fold the override into one rule).
+
+**Phase D backlog (decisions, Claude 2026-07-19, per Paul delegation)**:
+- Wrapper collapse (fl-col-group/fl-col/fl-col-content flattening) +
+  the critical/fl-* trio + fl-builder-common-base retirement it
+  unblocks: DEFERRED - DOM restructuring with expected visual/baseline
+  changes contradicts Phase C charter; needs per-page design QA.
+- Legacy-shared strangler (theme-main 3,671 · component-bundle 2,907 ·
+  legacy-theme-skin 2,692 · 586 1,260 · style 1,005 lines) via
+  per-bundle PurgeCSS-survival audit: DEFERRED to own sprints.
+- The 4 position-sensitive twin sets above: fold-then-dedup, own sprint.
+- jt-reviews-box swiper design restoration: POSTPONED (Paul) - see C2 note.
 
 ## 🚨 BLOCKERS & RISKS
 

--- a/themes/beaver/assets/css/pages/about-us.css
+++ b/themes/beaver/assets/css/pages/about-us.css
@@ -39,31 +39,6 @@
 .fl-clearfix:after {
   clear: both;
 }
-
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-
-.fl-col-group-equal-height .fl-col.fl-visible-desktop {
-  display: flex;
-}
-
-
-.fl-row, .fl-row-content {
-  margin-left: auto;
-  margin-right: auto;
-  min-width: 0;
-}
-
 /* .fl-row-content-wrap { position: relative; } removed - already in critical/fl-layout-grid.css */
 .fl-builder-mobile .fl-row-bg-photo .fl-row-content-wrap {
   background-attachment: scroll;
@@ -280,35 +255,9 @@
   justify-content: flex-start;
   -webkit-justify-content: flex-start;
 }
-
-
-.fl-col-group-equal-height {
-  display: flex;
-  flex-wrap: wrap;
-  width: 100%;
-}
-
-
 .fl-col-group-equal-height.fl-col-group-has-child-loading {
   flex-wrap: nowrap;
 }
-
-
-.fl-col-group-equal-height .fl-col, .fl-col-group-equal-height .fl-col-content {
-  display: flex;
-  flex: 1 1 auto;
-}
-
-
-.fl-col-group-equal-height .fl-col-content {
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  width: 100%;
-}
-
-
 .fl-col-group-equal-height:before, .fl-col-group-equal-height .fl-col:before, .fl-col-group-equal-height .fl-col-content:before, .fl-col-group-equal-height:after, .fl-col-group-equal-height .fl-col:after, .fl-col-group-equal-height .fl-col-content:after {
   content: none;
 }
@@ -338,14 +287,6 @@
 .fl-builder-ie-11 .fl-col-group-equal-height, .fl-builder-ie-11 .fl-col-group-equal-height .fl-col, .fl-builder-ie-11 .fl-col-group-equal-height .fl-col-content, .fl-builder-ie-11 .fl-col-group-equal-height .fl-module, .fl-col-group-equal-height.fl-col-group-align-center .fl-col-group {
   min-height: 1px;
 }
-
-
-.fl-col {
-  float: left;
-  min-height: 1px;
-}
-
-
 .fl-col-bg-overlay .fl-col-content {
   position: relative;
 }
@@ -368,13 +309,6 @@
   position: relative;
   z-index: 2;
 }
-
-
-.fl-module img {
-  max-width: 100%;
-}
-
-
 .fl-builder-module-template {
   margin: 0 auto;
   max-width: 1100px;
@@ -501,19 +435,6 @@
 .fl-icon-text span.mce-edit-focus {
   min-width: 1px;
 }
-
-
-.fl-photo {
-  line-height: 0;
-  position: relative;
-}
-
-
-.fl-photo-align-left {
-  text-align: left;
-}
-
-
 .fl-photo-align-center {
   text-align: center;
 }
@@ -777,18 +698,6 @@ img.mfp-img {
   pointer-events: none;
   overflow: hidden;
 }
-
-
-.fl-builder-shape-layer {
-  z-index: 0;
-}
-
-
-.fl-builder-shape-layer.fl-builder-bottom-edge-layer {
-  z-index: 1;
-}
-
-
 .fl-row-bg-overlay .fl-builder-shape-layer {
   z-index: 1;
 }
@@ -797,40 +706,9 @@ img.mfp-img {
 .fl-row-bg-overlay .fl-builder-shape-layer.fl-builder-bottom-edge-layer {
   z-index: 2;
 }
-
-
-.fl-row-has-layers .fl-row-content {
-  z-index: 1;
-}
-
-
 .fl-row-bg-overlay .fl-row-content {
   z-index: 2;
 }
-
-
-.fl-builder-layer > * {
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-}
-
-
-.fl-builder-layer + .fl-row-content {
-  position: relative;
-}
-
-
-.fl-builder-layer .fl-shape {
-  fill: #aaa;
-  stroke: none;
-  stroke-width: 0;
-  width: 100%;
-}
-
-
 @supports (-webkit-touch-callout: inherit) {
   .fl-row.fl-row-bg-parallax .fl-row-content-wrap, .fl-row.fl-row-bg-fixed .fl-row-content-wrap {
     background-position: center !important;
@@ -845,29 +723,12 @@ img.mfp-img {
     background-attachment: scroll !important;
   }
 }
-
-
-.fl-row-fixed-width {
-  max-width: 1180px;
-}
-
-
 .fl-row-content-wrap {
   margin-top: 0px;
   margin-right: 0px;
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.fl-row-content-wrap {
-  padding-top: 20px;
-  padding-right: 20px;
-  padding-bottom: 20px;
-  padding-left: 20px;
-}
-
-
 .fl-col-content {
   margin-top: 0px;
   margin-right: 0px;
@@ -903,14 +764,6 @@ img.mfp-img {
   .fl-visible-desktop, .fl-visible-medium, .fl-visible-mobile, .fl-col-group-equal-height .fl-col.fl-visible-desktop, .fl-col-group-equal-height .fl-col.fl-visible-medium, .fl-col-group-equal-height .fl-col.fl-visible-mobile {
     display: none;
   }
-
-  .fl-visible-large {
-    display: block;
-  }
-
-  .fl-col-group-equal-height .fl-col.fl-visible-large {
-    display: flex;
-  }
 }
 
 
@@ -918,15 +771,6 @@ img.mfp-img {
   .fl-visible-desktop, .fl-visible-large, .fl-visible-mobile, .fl-col-group-equal-height .fl-col.fl-visible-desktop, .fl-col-group-equal-height .fl-col.fl-visible-large, .fl-col-group-equal-height .fl-col.fl-visible-mobile {
     display: none;
   }
-
-  .fl-visible-medium {
-    display: block;
-  }
-
-  .fl-col-group-equal-height .fl-col.fl-visible-medium {
-    display: flex;
-  }
-
   .fl-col-group.fl-col-group-medium-reversed {
     display: -webkit-flex;
     display: flex;
@@ -956,26 +800,10 @@ img.mfp-img {
   .fl-col-group-equal-height .fl-col.fl-visible-mobile {
     display: flex;
   }
-
-  .fl-row-content-wrap {
-    background-attachment: scroll !important;
-  }
-
   .fl-row-bg-parallax .fl-row-content-wrap {
     background-attachment: scroll !important;
     background-position: center center !important;
   }
-
-  .fl-col-group.fl-col-group-equal-height {
-    display: block;
-  }
-
-  .fl-col-group.fl-col-group-equal-height.fl-col-group-custom-width {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: flex;
-  }
-
   .fl-col-group.fl-col-group-responsive-reversed {
     display: -webkit-flex;
     display: flex;
@@ -996,45 +824,12 @@ img.mfp-img {
     flex-wrap: unset;
     flex-direction: unset;
   }
-
-  .fl-col {
-    clear: both;
-    float: none;
-    margin-left: auto;
-    margin-right: auto;
-    width: auto !important;
-  }
-
-  .fl-col-small:not(.fl-col-small-full-width) {
-    max-width: 400px;
-  }
-
   .fl-block-col-resize {
     display: none;
   }
-
-  .fl-row[data-node] .fl-row-content-wrap {
-    margin: 0;
-    padding-left: 0;
-    padding-right: 0;
-  }
-
   .fl-row[data-node] .fl-bg-video, .fl-row[data-node] .fl-bg-slideshow {
     left: 0;
     right: 0;
-  }
-
-  .fl-col[data-node] .fl-col-content {
-    margin: 0;
-    padding-left: 0;
-    padding-right: 0;
-  }
-
-  .fl-row[data-node] > .fl-row-content-wrap {
-    padding-top: 20px;
-    padding-right: 20px;
-    padding-bottom: 20px;
-    padding-left: 20px;
   }
 }
 
@@ -1047,81 +842,10 @@ img.mfp-img {
 .about-hero > .fl-row-content-wrap {
   background-color: #F5F6F8;
 }
-
-
-.about-hero .fl-builder-bottom-edge-layer {
-  bottom: -1%;
-}
-
-
-.about-hero .fl-builder-bottom-edge-layer > * {
-  width: 100%;
-  left: calc(50% - 50%);
-  right: auto;
-  height: 15%;
-  top: auto;
-  bottom: 0;
-  transform: scaleX(-1) scaleY(-1);
-}
-
-
-.about-hero .fl-builder-bottom-edge-layer .fl-shape-content .fl-shape {
-  fill: #ffffff;
-}
-
-
 .about-hero > .fl-row-content-wrap {
   padding-top: 200px;
   padding-bottom: 0px;
 }
-
-
-@media ( max-width: 1115px ) {
-  .about-hero.fl-row > .fl-row-content-wrap {
-    padding-top: 150px;
-  }
-}
-
-
-@media ( max-width: 860px ) {
-  .about-hero.fl-row > .fl-row-content-wrap {
-    padding-top: 100px;
-    padding-bottom: 25px;
-  }
-}
-
-
-.about-mission > .fl-row-content-wrap {
-
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-attachment: scroll;
-  background-size: cover;
-}
-
-
-.about-mission > .fl-row-content-wrap {
-  padding-top: 130px;
-  padding-bottom: 130px;
-}
-
-
-@media ( max-width: 1115px ) {
-  .about-mission.fl-row > .fl-row-content-wrap {
-    padding-top: 50px;
-    padding-bottom: 50px;
-  }
-}
-
-
-@media ( max-width: 860px ) {
-  .about-mission.fl-row > .fl-row-content-wrap {
-    padding-top: 25px;
-    padding-bottom: 50px;
-  }
-}
-
-
 .about-achievements > .fl-row-content-wrap {
   background-color: #000;
   background-repeat: no-repeat;
@@ -1204,81 +928,6 @@ img.mfp-img {
     padding-left: 20px;
   }
 }
-
-
-.about-hero-col {
-  width: 100%;
-}
-
-
-.about-mission-col {
-  width: 50%;
-}
-
-
-@media (max-width: 860px) {
-  .fl-builder-content .about-mission-col {
-    width: 100% !important;
-    max-width: none;
-    clear: none;
-    float: left;
-  }
-}
-
-
-.about-mission-col > .fl-col-content {
-  padding-right: 50px;
-}
-
-
-.about-culture-col {
-  width: 50%;
-}
-
-
-@media (max-width: 860px) {
-  .fl-builder-content .about-culture-col {
-    width: 100% !important;
-    max-width: none;
-    clear: none;
-    float: left;
-  }
-}
-
-
-.about-culture-col > .fl-col-content {
-  padding-left: 50px;
-}
-
-
-@media ( max-width: 860px ) {
-  .about-culture-col.fl-col > .fl-col-content {
-    padding-top: 30px;
-  }
-}
-
-
-.about-values-header-col {
-  width: 100%;
-}
-
-
-@media (max-width: 860px) {
-  .fl-builder-content .about-values-header-col {
-    width: 100% !important;
-    max-width: none;
-    clear: none;
-    float: left;
-  }
-}
-
-
-.about-values-header-col > .fl-col-content {
-  padding-top: 130px;
-  padding-bottom: 60px;
-}
-
-
 @media ( max-width: 860px ) {
   .about-values-header-col.fl-col > .fl-col-content {
     padding-top: 50px;
@@ -1579,15 +1228,6 @@ img.mfp-img {
 img.mfp-img {
   padding-bottom: 40px !important;
 }
-
-
-@media (max-width: 860px) {
-  .fl-photo-content, .fl-photo-img {
-    max-width: 100%;
-  }
-}
-
-
 .fl-photo {
   text-align: left;
 }
@@ -1599,71 +1239,17 @@ img.mfp-img {
   border-bottom-left-radius: 20px;
   border-bottom-right-radius: 20px;
 }
-
-
-.about-hero-photo > .fl-module-content {
-  margin-top: 80px;
-}
-
-
-@media ( max-width: 860px ) {
-  .about-hero-photo.fl-module > .fl-module-content {
-    margin-top: 30px;
-  }
-}
-
-
 .fl-builder-content .fl-rich-text strong {
   font-weight: bold;
 }
-
-
-.fl-builder-content .about-mission-headline .fl-module-content .fl-rich-text, .fl-builder-content .about-mission-headline .fl-module-content .fl-rich-text * {
-  color: var(--color-primary);
-}
-
-
 .fl-builder-content .about-mission-headline .fl-rich-text, .fl-builder-content .about-mission-headline .fl-rich-text *:not(b, strong) {
   font-weight: 600;
   font-size: 23px;
 }
-
-
-.about-mission-list > .fl-module-content {
-  margin-top: 30px;
-}
-
-
-@media ( max-width: 860px ) {
-  .about-mission-list.fl-module > .fl-module-content {
-    margin-top: 15px;
-  }
-}
-
-
-.fl-builder-content .about-culture-headline .fl-module-content .fl-rich-text, .fl-builder-content .about-culture-headline .fl-module-content .fl-rich-text * {
-  color: var(--color-primary);
-}
-
-
 .fl-builder-content .about-culture-headline .fl-rich-text, .fl-builder-content .about-culture-headline .fl-rich-text *:not(b, strong) {
   font-weight: 600;
   font-size: 23px;
 }
-
-
-.about-culture-list > .fl-module-content {
-  margin-top: 30px;
-}
-
-
-@media ( max-width: 860px ) {
-  .about-culture-list.fl-module > .fl-module-content {
-    margin-top: 15px;
-  }
-}
-
-
 .fl-builder-content .about-values-eyebrow .fl-module-content .fl-rich-text, .fl-builder-content .about-values-eyebrow .fl-module-content .fl-rich-text * {
   color: var(--color-primary);
 }
@@ -2848,13 +2434,6 @@ img.mfp-img {
     margin-left: 0px;
   }
 }
-
-
-.fl-row-fixed-width {
-  min-width: 1px;
-}
-
-
 .fl-col-group.fl-col-group-responsive-reversed, .fl-col-group.fl-col-group-responsive-reversed .fl-col, .fl-col-group.fl-col-group-responsive-reversed .fl-col-content, .fl-col-group-equal-height .fl-col, .fl-col-group-equal-height .fl-col-content {
   min-width: 0px;
 }

--- a/themes/beaver/assets/css/pages/careers.css
+++ b/themes/beaver/assets/css/pages/careers.css
@@ -39,12 +39,6 @@
   white-space: nowrap;
   border: 0;
 }
-
-.fl-row, .fl-row-content {
-  margin-left: auto;
-  margin-right: auto;
-  min-width: 0;
-}
 /* .fl-row-content-wrap { position: relative; } removed - already in critical/fl-layout-grid.css */
 .fl-builder-mobile .fl-row-bg-photo .fl-row-content-wrap {
   background-attachment: scroll;
@@ -237,13 +231,6 @@
   justify-content: flex-start;
   -webkit-justify-content: flex-start;
 }
-
-.fl-col-group-equal-height {
-  display: flex;
-  flex-wrap: wrap;
-  width: 100%;
-}
-
 .fl-col-group-equal-height.fl-col-group-has-child-loading {
   flex-wrap: nowrap;
 }
@@ -252,15 +239,6 @@
   display: flex;
   flex: 1 1 auto;
 }
-
-.fl-col-group-equal-height .fl-col-content {
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  width: 100%;
-}
-
 .fl-col-group-equal-height:before, .fl-col-group-equal-height .fl-col:before, .fl-col-group-equal-height .fl-col-content:before, .fl-col-group-equal-height:after, .fl-col-group-equal-height .fl-col:after, .fl-col-group-equal-height .fl-col-content:after {
   content: none;
 }
@@ -285,12 +263,6 @@
 .fl-builder-ie-11 .fl-col-group-equal-height, .fl-builder-ie-11 .fl-col-group-equal-height .fl-col, .fl-builder-ie-11 .fl-col-group-equal-height .fl-col-content, .fl-builder-ie-11 .fl-col-group-equal-height .fl-module, .fl-col-group-equal-height.fl-col-group-align-center .fl-col-group {
   min-height: 1px;
 }
-
-.fl-col {
-  float: left;
-  min-height: 1px;
-}
-
 .fl-col-bg-overlay .fl-col-content {
   position: relative;
 }
@@ -311,11 +283,6 @@
   position: relative;
   z-index: 2;
 }
-
-.fl-module img {
-  max-width: 100%;
-}
-
 .fl-builder-module-template {
   margin: 0 auto;
   max-width: 1100px;
@@ -423,16 +390,6 @@
 .fl-icon-text span.mce-edit-focus {
   min-width: 1px;
 }
-
-.fl-photo {
-  line-height: 0;
-  position: relative;
-}
-
-.fl-photo-align-left {
-  text-align: left;
-}
-
 .fl-photo-align-center {
   text-align: center;
 }
@@ -715,25 +672,12 @@ img.mfp-img {
     background-attachment: scroll !important;
   }
 }
-
-.fl-row-fixed-width {
-  max-width: 1180px;
-}
-
 .fl-row-content-wrap {
   margin-top: 0px;
   margin-right: 0px;
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-.fl-row-content-wrap {
-  padding-top: 20px;
-  padding-right: 20px;
-  padding-bottom: 20px;
-  padding-left: 20px;
-}
-
 .fl-col-content {
   margin-top: 0px;
   margin-right: 0px;
@@ -765,44 +709,14 @@ img.mfp-img {
     flex-wrap: wrap-reverse;
     flex-direction: row-reverse;
   }
-
-  .fl-row[data-node] > .fl-row-content-wrap {
-    padding-top: 20px;
-    padding-right: 20px;
-    padding-bottom: 20px;
-    padding-left: 20px;
-  }
 }
 
 
 @media (max-width: 860px) {
-  .fl-row-content-wrap {
-    background-attachment: scroll !important;
-  }
-
   .fl-row-bg-parallax .fl-row-content-wrap {
     background-attachment: scroll !important;
     background-position: center center !important;
   }
-
-  .fl-col-group.fl-col-group-equal-height {
-    display: block;
-  }
-
-  .fl-col-group.fl-col-group-equal-height.fl-col-group-custom-width {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: flex;
-  }
-
-  .fl-col-group.fl-col-group-responsive-reversed {
-    display: -webkit-flex;
-    display: flex;
-    -webkit-flex-wrap: wrap-reverse;
-    flex-wrap: wrap-reverse;
-    flex-direction: row-reverse;
-  }
-
   .fl-col-group.fl-col-group-responsive-reversed .fl-col:not(.fl-col-small-custom-width) {
     flex-basis: 100%;
     width: 100% !important;
@@ -815,45 +729,12 @@ img.mfp-img {
     flex-wrap: unset;
     flex-direction: unset;
   }
-
-  .fl-col {
-    clear: both;
-    float: none;
-    margin-left: auto;
-    margin-right: auto;
-    width: auto !important;
-  }
-
-  .fl-col-small:not(.fl-col-small-full-width) {
-    max-width: 400px;
-  }
-
   .fl-block-col-resize {
     display: none;
   }
-
-  .fl-row[data-node] .fl-row-content-wrap {
-    margin: 0;
-    padding-left: 0;
-    padding-right: 0;
-  }
-
   .fl-row[data-node] .fl-bg-video, .fl-row[data-node] .fl-bg-slideshow {
     left: 0;
     right: 0;
-  }
-
-  .fl-col[data-node] .fl-col-content {
-    margin: 0;
-    padding-left: 0;
-    padding-right: 0;
-  }
-
-  .fl-row[data-node] > .fl-row-content-wrap {
-    padding-top: 20px;
-    padding-right: 20px;
-    padding-bottom: 20px;
-    padding-left: 20px;
   }
 }
 
@@ -869,26 +750,6 @@ img.mfp-img {
   background-attachment: scroll;
   background-size: cover;
 }
-
-.careers-hero > .fl-row-content-wrap {
-  padding-top: 200px;
-  padding-bottom: 130px;
-}
-
-@media ( max-width: 1115px ) {
-  .careers-hero.fl-row > .fl-row-content-wrap {
-    padding-top: 150px;
-    padding-bottom: 50px;
-  }
-}
-
-@media ( max-width: 860px ) {
-  .careers-hero.fl-row > .fl-row-content-wrap {
-    padding-top: 100px;
-    padding-bottom: 50px;
-  }
-}
-
 .careers-why-us > .fl-row-content-wrap {
 
   background-repeat: no-repeat;
@@ -896,26 +757,12 @@ img.mfp-img {
   background-attachment: scroll;
   background-size: cover;
 }
-
-.careers-why-us > .fl-row-content-wrap {
-  padding-top: 130px;
-  padding-bottom: 130px;
-}
-
 @media ( max-width: 1115px ) {
   .careers-why-us.fl-row > .fl-row-content-wrap {
     padding-top: 0px;
     padding-bottom: 50px;
   }
 }
-
-@media ( max-width: 860px ) {
-  .careers-why-us.fl-row > .fl-row-content-wrap {
-    padding-top: 30px;
-    padding-bottom: 50px;
-  }
-}
-
 .careers-testimonial > .fl-row-content-wrap {
   background-color: #000;
   background-repeat: no-repeat;
@@ -986,74 +833,17 @@ img.mfp-img {
     padding-bottom: 50px;
   }
 }
-
-.careers-hero-col {
-  width: 100%;
-}
-
-.careers-why-us-copy {
-  width: 50%;
-}
-
-@media (max-width: 860px) {
-  .fl-builder-content .careers-why-us-copy {
-    width: 100% !important;
-    max-width: none;
-    clear: none;
-    float: left;
-  }
-}
-
-.careers-why-us-copy > .fl-col-content {
-  padding-right: 50px;
-}
-
-@media ( max-width: 1115px ) {
-  .careers-why-us-copy.fl-col > .fl-col-content {
-    padding-right: 20px;
-  }
-}
-
 @media ( max-width: 860px ) {
   .careers-why-us-copy.fl-col > .fl-col-content {
     padding-top: 30px;
     padding-right: 0px;
   }
 }
-
-.careers-why-us-media {
-  width: 50%;
-}
-
-@media (max-width: 860px) {
-  .fl-builder-content .careers-why-us-media {
-    width: 100% !important;
-    max-width: none;
-    clear: none;
-    float: left;
-  }
-}
-
-.careers-why-us-media > .fl-col-content {
-  margin-top: -280px;
-}
-
-@media ( max-width: 1115px ) {
-  .careers-why-us-media.fl-col > .fl-col-content {
-    margin-top: -130px;
-  }
-}
-
 @media ( max-width: 860px ) {
   .careers-why-us-media.fl-col > .fl-col-content {
     margin-top: 0px;
   }
 }
-
-.careers-values-spacer-top-col {
-  width: 100%;
-}
-
 .careers-value-people {
   width: 32%;
 }
@@ -1143,11 +933,6 @@ img.mfp-img {
     padding-top: 30px;
   }
 }
-
-.careers-values-spacer-mid-col {
-  width: 100%;
-}
-
 .careers-value-flexibility {
   width: 32%;
 }
@@ -1396,13 +1181,6 @@ img.mfp-img {
     padding-left: 0px;
   }
 }
-
-/* .fl-module-heading .fl-heading removed - already in critical/fl-common-modules.css */
-
-.careers-hero-title > .fl-module-content {
-  margin-right: 280px;
-}
-
 @media ( max-width: 1115px ) {
   .careers-hero-title.fl-module > .fl-module-content {
     margin-right: 0px;
@@ -1423,12 +1201,6 @@ img.mfp-img {
     font-size: 18px;
   }
 }
-
-.careers-hero-subtitle > .fl-module-content {
-  margin-top: 15px;
-  margin-right: 400px;
-}
-
 @media ( max-width: 1115px ) {
   .careers-hero-subtitle.fl-module > .fl-module-content {
     margin-right: 0px;
@@ -1444,50 +1216,9 @@ img.mfp-img {
 
 .fl-builder-content .careers-hero-cta a.fl-button, .fl-builder-content .careers-hero-cta a.fl-button:hover, .fl-builder-content .careers-hero-cta a.fl-button:visited {
 }
-
-.careers-hero-cta .fl-button-wrap {
-  text-align: left;
-}
-
-.careers-hero-cta > .fl-module-content {
-  margin-top: 32px;
-}
-
-@media ( max-width: 860px ) {
-  .careers-hero-cta.fl-module > .fl-module-content {
-    margin-top: 20px;
-  }
-}
-
-.fl-builder-content .careers-why-us-eyebrow .fl-module-content .fl-rich-text, .fl-builder-content .careers-why-us-eyebrow .fl-module-content .fl-rich-text * {
-  color: var(--color-primary);
-}
-
 .fl-builder-content .careers-why-us-eyebrow .fl-rich-text, .fl-builder-content .careers-why-us-eyebrow .fl-rich-text *:not(b, strong) {
   font-weight: 600;
 }
-
-.careers-why-us-title > .fl-module-content {
-  margin-top: 30px;
-}
-
-@media ( max-width: 860px ) {
-  .careers-why-us-title.fl-module > .fl-module-content {
-    margin-top: 10px;
-  }
-}
-
-.careers-why-us-intro > .fl-module-content {
-  margin-top: 20px;
-  margin-right: 100px;
-}
-
-@media ( max-width: 1115px ) {
-  .careers-why-us-intro.fl-module > .fl-module-content {
-    margin-right: 50px;
-  }
-}
-
 @media ( max-width: 860px ) {
   .careers-why-us-intro.fl-module > .fl-module-content {
     margin-top: 20px;
@@ -1498,34 +1229,6 @@ img.mfp-img {
 img.mfp-img {
   padding-bottom: 40px !important;
 }
-
-@media (max-width: 860px) {
-  .fl-photo-content, .fl-photo-img {
-    max-width: 100%;
-  }
-}
-
-.careers-why-us-photo .fl-photo {
-  text-align: left;
-}
-
-.careers-why-us-photo .fl-photo-img {
-  border-top-left-radius: 20px;
-  border-top-right-radius: 20px;
-  border-bottom-left-radius: 20px;
-  border-bottom-right-radius: 20px;
-}
-
-@media (max-width: 860px) {
-  .careers-why-us-photo .fl-photo {
-    text-align: left;
-  }
-
-  .careers-why-us-photo .fl-photo-content, .careers-why-us-photo .fl-photo-img {
-    width: 400px;
-  }
-}
-
 .careers-why-us-photo > .fl-module-content {
   margin-top: 0px;
 }
@@ -1538,24 +1241,6 @@ img.mfp-img {
 
 @media (max-width: 860px) {
 }
-
-.careers-values-spacer-top .pp-spacer-module {
-  height: 80px;
-  width: 100%;
-}
-
-@media only screen and (max-width: 1115px) {
-  .careers-values-spacer-top .pp-spacer-module {
-    height: 60px;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .careers-values-spacer-top .pp-spacer-module {
-    height: 15px;
-  }
-}
-
 .pp-infobox:before, .pp-infobox:after {
   content: " ";
   display: table;
@@ -2396,24 +2081,6 @@ img.mfp-img {
 .careers-value-team-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
   margin-left: 10px;
 }
-
-.careers-values-spacer-mid .pp-spacer-module {
-  height: 60px;
-  width: 100%;
-}
-
-@media only screen and (max-width: 1115px) {
-  .careers-values-spacer-mid .pp-spacer-module {
-    height: 40px;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .careers-values-spacer-mid .pp-spacer-module {
-    height: 15px;
-  }
-}
-
 .fl-col-group-equal-height .careers-value-flexibility-box, .fl-col-group-equal-height .careers-value-flexibility-box .fl-module-content, .fl-col-group-equal-height .careers-value-flexibility-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .careers-value-flexibility-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .careers-value-flexibility-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .careers-value-flexibility-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
   display: flex;
   -webkit-box-orient: vertical;
@@ -3186,15 +2853,6 @@ img.mfp-img {
   content: "";
   display: table;
 }
-
-.clearfix:after {
-  clear: both;
-}
-
-.fl-row-fixed-width {
-  min-width: 1px;
-}
-
 .fl-col-group.fl-col-group-responsive-reversed, .fl-col-group.fl-col-group-responsive-reversed .fl-col, .fl-col-group.fl-col-group-responsive-reversed .fl-col-content, .fl-col-group-equal-height .fl-col, .fl-col-group-equal-height .fl-col-content {
   min-width: 0px;
 }

--- a/themes/beaver/assets/css/pages/homepage.css
+++ b/themes/beaver/assets/css/pages/homepage.css
@@ -19,18 +19,6 @@
   content: "";
   display: table;
 }
-
-
-.pp-clearfix:after {
-  clear: both;
-}
-
-
-.pp-tabs-panel-label {
-  display: none;
-}
-
-
 .pp-tabs-panel-label span {
   display: table-cell;
   width: 100%;
@@ -46,23 +34,6 @@
   vertical-align: middle;
   width: auto;
 }
-
-
-.pp-tabs-panel-label .pp-tab-close {
-  display: none;
-}
-
-
-.pp-tabs-panel-label.pp-tabs-label.pp-tab-active .pp-tab-close {
-  display: table-cell;
-}
-
-
-.pp-tabs-panel-label.pp-tabs-label.pp-tab-active .pp-tab-open {
-  display: none;
-}
-
-
 .pp-tabs-default .pp-tabs-panels {
   border-width: 1px;
   border-style: solid;
@@ -73,38 +44,13 @@
 .pp-tabs-horizontal.pp-tabs-default .pp-tabs-panels {
   clear: both;
 }
-
-
-.pp-tabs-panel-content {
-  display: none !important;
-  padding: 30px;
-  clear: both;
-}
-
-
 .pp-tabs-panel-content.pp-tab-active {
   display: block !important;
 }
-
-
-.pp-tabs-panel-content p:last-child {
-  margin-bottom: 0;
-  padding-bottom: 0;
-}
-
-
 .pp-tabs-vertical .pp-tabs-panel-content.pp-tab-active {
   display: table;
   width: 100%;
 }
-
-
-.pp-tabs-panel .pp-tabs-label .pp-tab-label-inner {
-  display: flex;
-  align-items: center;
-}
-
-
 .pp-tabs-horizontal .pp-tabs-label {
   float: left;
 }
@@ -131,47 +77,17 @@
 .pp-tabs-horizontal.pp-tabs-default .pp-tabs-label.pp-tab-active {
   top: 1px;
 }
-
-
-.pp-tabs-vertical .pp-tabs-labels {
-  float: left;
-  width: 30%;
-}
-
-
 .pp-tabs-vertical.pp-tabs-vertical-right .pp-tabs-labels {
   float: right;
 }
-
-
-.pp-tabs-vertical .pp-tabs-label {
-  text-align: center;
-  padding: 20px 10px;
-}
-
-
 .pp-tabs-vertical .pp-tabs-label.pp-tab-active {
   border-width: 0px;
   border-style: solid;
 }
-
-
-.pp-tabs-vertical.pp-tabs-default .pp-tabs-label {
-  margin-right: -1px;
-}
-
-
 .pp-tabs-vertical.pp-tabs-vertical-right.pp-tabs-default .pp-tabs-label {
   margin-right: auto;
   margin-left: -1px;
 }
-
-
-.pp-tabs-vertical.pp-tabs-default .pp-tabs-label.pp-tab-active {
-  border-width: 1px;
-}
-
-
 .pp-tabs-vertical .pp-tabs-panels {
   float: left;
   width: 70%;
@@ -223,13 +139,6 @@
   flex: 1;
   padding: 15px 18px 12px;
 }
-
-
-.pp-tabs-labels .pp-tabs-label .pp-tab-label-inner {
-  position: relative;
-}
-
-
 .pp-tabs-style-1 .pp-tabs-labels {
   border: 4px solid #eee;
 }
@@ -628,16 +537,6 @@
 
 
 @media (max-width: 860px) {
-  .pp-tabs-labels {
-    display: none !important;
-  }
-
-  .pp-tabs-panel-label {
-    display: table;
-    width: 100%;
-    padding: 20px 15px;
-  }
-
   .pp-tabs-panel-label span {
     width: auto;
   }
@@ -657,34 +556,10 @@
   .pp-tabs-horizontal .pp-tabs-label.pp-tab-active {
     border: none;
   }
-
-  .pp-tabs-vertical .pp-tabs-labels {
-    float: none;
-    width: auto;
-  }
-
-  .pp-tabs-vertical .pp-tabs-label.pp-tab-active {
-    border: none;
-  }
-
   .pp-tabs-vertical .pp-tabs-panels {
     float: none;
     width: auto;
   }
-
-  .pp-tabs-panel-content {
-    padding: 20px;
-  }
-
-  .pp-tabs .pp-tabs-label {
-    text-align: left;
-    border-bottom: 2px solid #e7e7e7;
-  }
-
-  .pp-tabs .pp-tabs-label.pp-tab-active {
-    border-bottom: 0;
-  }
-
   .pp-tabs .pp-tabs-default .pp-tabs-label, .pp-tabs .pp-tabs-default .pp-tabs-label.pp-tab-active, .pp-tabs .pp-tabs-style-5 .pp-tabs-label, .pp-tabs .pp-tabs-style-6 .pp-tabs-label, .pp-tabs .pp-tabs-style-6 .pp-tabs-label.pp-tab-active, .pp-tabs .pp-tabs-style-7 .pp-tabs-label, .pp-tabs .pp-tabs-style-7 .pp-tabs-label.pp-tab-active, .pp-tabs .pp-tabs-style-8 .pp-tabs-label {
     background-color: transparent !important;
   }
@@ -724,12 +599,6 @@
   .pp-tabs-style-2 .pp-tabs-label:first-child:before, .pp-tabs-style-2 .pp-tabs-label::after {
     display: none;
   }
-
-  .pp-tabs .pp-tab-title {
-    display: inline-block;
-    width: auto;
-  }
-
   .pp-tab-icon {
     padding-left: 0 !important;
     display: inline-table !important;
@@ -742,11 +611,6 @@
     margin-right: 0 !important;
     margin-left: 15px !important;
   }
-
-  .pp-tabs-panel-label .pp-toggle-icon {
-    text-align: right;
-  }
-
   .pp-tabs-style-5 .pp-tabs-label .pp-tab-label-inner:after {
     display: none;
   }
@@ -1431,29 +1295,9 @@ fl-builder-content *, .fl-builder-content *:before, .fl-builder-content *:after 
 .fl-icon-text span.mce-edit-focus {
   min-width: 1px;
 }
-
-
-.fl-photo {
-  line-height: 0;
-  position: relative;
-}
-
-
-.fl-photo-align-left {
-  text-align: left;
-}
-
-
 .fl-photo-align-center {
   text-align: center;
 }
-
-
-.fl-photo-align-right {
-  text-align: right;
-}
-
-
 /* .fl-photo-content and .fl-photo-content img removed - already in critical/fl-common-modules.css */
 
 .fl-photo-img-svg {
@@ -2953,23 +2797,6 @@ img.mfp-img {
     padding-left: 20px;
   }
 }
-
-
-/* .fl-module-heading .fl-heading removed - already in critical/fl-common-modules.css */
-
-.home-hero-title.fl-module-heading .fl-heading {
-  font-size: 80px;
-  letter-spacing: -0.8px;
-}
-
-
-@media (max-width: 860px) {
-  .home-hero-title.fl-module-heading .fl-heading {
-    font-size: 40px;
-  }
-}
-
-
 .fl-builder-content .fl-rich-text strong {
   font-weight: bold;
 }
@@ -2985,14 +2812,6 @@ img.mfp-img {
     font-size: 16px;
   }
 }
-
-
-.home-hero-subtitle > .fl-module-content {
-  margin-top: 20px;
-  margin-right: 50px;
-}
-
-
 @media ( max-width: 860px ) {
   .home-hero-subtitle.fl-module > .fl-module-content {
     margin-top: 15px;
@@ -3003,84 +2822,9 @@ img.mfp-img {
 
 .fl-builder-content .home-hero-cta a.fl-button, .fl-builder-content .home-hero-cta a.fl-button:hover, .fl-builder-content .home-hero-cta a.fl-button:visited {
 }
-
-
-.home-hero-cta .fl-button-wrap {
-  text-align: left;
-}
-
-
-.fl-builder-content .home-hero-cta a.fl-button, .fl-builder-content .home-hero-cta a.fl-button:visited {
-  text-transform: none;
-}
-
-
-.home-hero-cta > .fl-module-content {
-  margin-top: 32px;
-}
-
-
-@media ( max-width: 860px ) {
-  .home-hero-cta.fl-module > .fl-module-content {
-    margin-top: 25px;
-  }
-}
-
-
 img.mfp-img {
   padding-bottom: 40px !important;
 }
-
-
-@media (max-width: 860px) {
-  .fl-photo-content, .fl-photo-img {
-    max-width: 100%;
-  }
-}
-
-
-.home-hero-photo .fl-photo {
-  text-align: right;
-}
-
-
-.home-hero-photo .fl-photo-content, .home-hero-photo .fl-photo-img {
-  width: 365px;
-}
-
-
-.home-hero-photo .fl-photo-img {
-  border-top-left-radius: 20px;
-  border-top-right-radius: 20px;
-  border-bottom-left-radius: 20px;
-  border-bottom-right-radius: 20px;
-}
-
-
-@media (max-width: 860px) {
-  .home-hero-photo .fl-photo {
-    text-align: left;
-  }
-}
-
-
-.home-hero-badge-logo .fl-photo {
-  text-align: left;
-}
-
-
-.home-hero-badge-logo .fl-photo-content, .home-hero-badge-logo .fl-photo-img {
-  width: 120px;
-}
-
-
-@media (max-width: 860px) {
-  .home-hero-badge-logo .fl-photo {
-    text-align: center;
-  }
-}
-
-
 .fl-builder-content .home-hero-badge-counter .fl-rich-text, .fl-builder-content .home-hero-badge-counter .fl-rich-text *:not(b, strong) {
   font-family: var(--font-system-ui);
   font-weight: 700;
@@ -3097,71 +2841,12 @@ img.mfp-img {
     text-align: center;
   }
 }
-
-
-.home-hero-badge-counter > .fl-module-content {
-  margin-top: 35px;
-}
-
-
-@media ( max-width: 860px ) {
-  .home-hero-badge-counter.fl-module > .fl-module-content {
-    margin-top: 20px;
-  }
-}
-
-
 .fl-builder-content .home-hero-badge-text .fl-rich-text, .fl-builder-content .home-hero-badge-text .fl-rich-text *:not(b, strong) {
   font-size: 16px;
   text-align: center;
 }
-
-
-.home-hero-badge-text > .fl-module-content {
-  margin-top: 5px;
-}
-
-
-@media ( max-width: 860px ) {
-  .home-hero-badge-text.fl-module > .fl-module-content {
-    margin-top: 10px;
-  }
-}
-
-
 .fl-builder-content .home-hero-badge-cta a.fl-button, .fl-builder-content .home-hero-badge-cta a.fl-button:hover, .fl-builder-content .home-hero-badge-cta a.fl-button:visited {
 }
-
-
-.home-hero-badge-cta .fl-button-wrap {
-  text-align: center;
-}
-
-
-.fl-builder-content .home-hero-badge-cta .fl-button-wrap a.fl-button {
-  padding-top: 11px;
-  padding-bottom: 11px;
-}
-
-
-.fl-builder-content .home-hero-badge-cta a.fl-button, .fl-builder-content .home-hero-badge-cta a.fl-button:visited {
-  font-size: 16px;
-  text-align: center;
-}
-
-
-.home-hero-badge-cta > .fl-module-content {
-  margin-top: 30px;
-}
-
-
-@media ( max-width: 860px ) {
-  .home-hero-badge-cta.fl-module > .fl-module-content {
-    margin-top: 20px;
-  }
-}
-
-
 .fl-builder-content .home-companies-heading .fl-rich-text, .fl-builder-content .home-companies-heading .fl-rich-text *:not(b, strong) {
   text-align: center;
 }
@@ -3188,14 +2873,6 @@ img.mfp-img {
   transform: translateY(-50%);
   left: -6px;
 }
-
-
-.pp-logos-content .logo-slider-next {
-  right: -6px;
-  left: auto;
-}
-
-
 .pp-logos-content .logo-slider-nav {
   text-decoration: none;
   box-shadow: none;
@@ -3217,20 +2894,6 @@ img.mfp-img {
 .pp-logos-content .disabled {
   pointer-events: none;
 }
-
-
-.pp-logos-content .logo-slider-nav svg {
-  height: 20px;
-  fill: currentColor;
-}
-
-
-.pp-logos-content .pp-logo {
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
-}
-
-
 .pp-logos-content .sr-only {
   position: absolute !important;
   height: 1px !important;
@@ -3251,13 +2914,6 @@ img.mfp-img {
   margin-bottom: 0;
   direction: ltr;
 }
-
-
-.pp-logos-carousel:not(.pp-logos-wrapper-loaded) {
-  opacity: 0;
-}
-
-
 .home-companies-logos .clearfix:before, .home-companies-logos .clearfix:after {
   content: "";
   display: table;
@@ -3267,13 +2923,6 @@ img.mfp-img {
 .home-companies-logos .clearfix:after {
   clear: both;
 }
-
-
-.home-companies-logos .pp-logos-content {
-  position: relative;
-}
-
-
 .home-companies-logos .pp-logos-content .pp-logo {
   position: relative;
   width: calc((100% - 201px) / 6);
@@ -3282,53 +2931,11 @@ img.mfp-img {
   float: left;
   transition: background-color 0.3s ease-in-out;
 }
-
-
-.home-companies-logos .pp-logos-content .pp-logo:nth-of-type(6n+1) {
-  clear: left;
-}
-
-
-.home-companies-logos .pp-logos-content .pp-logo:nth-of-type(6n) {
-  margin-right: 0;
-}
-
-
 .home-companies-logos .pp-logos-content .pp-logo:hover {
 }
-
-
-.home-companies-logos .pp-logos-wrapper {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-
-.home-companies-logos .pp-logos-content .pp-logo {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-
 .home-companies-logos .pp-logos-content .pp-logo > a, .home-companies-logos .pp-logos-content .pp-logo .pp-logo-inner {
   flex: 1 1 auto;
 }
-
-
-.home-companies-logos .pp-logos-content .pp-logo .pp-logo-inner .pp-logo-inner-wrap {
-  text-align: center;
-}
-
-
-.home-companies-logos .pp-logos-content .pp-logo a {
-  display: block;
-  text-decoration: none;
-  box-shadow: none;
-  border: none;
-}
-
-
 .home-companies-logos .pp-logos-content .pp-logo div.title-wrapper {
   display: block
 }
@@ -3415,27 +3022,6 @@ img.mfp-img {
 
 
 @media only screen and (max-width: 1200px) {
-  .home-companies-logos .pp-logos-content .pp-logo {
-    width: calc((100% - 201px) / 6);
-  }
-
-  .home-companies-logos .pp-logos-content .pp-logo:nth-of-type(6n+1) {
-    clear: left;
-  }
-
-  .home-companies-logos .pp-logos-content .pp-logo:nth-of-type(6n) {
-    margin-right: 40px;
-    margin-bottom: 40px;
-  }
-
-  .home-companies-logos .pp-logos-content .pp-logo:nth-of-type(6n) {
-    margin-right: 0;
-  }
-
-  .home-companies-logos .pp-logos-content .pp-logo:nth-of-type(6n+1) {
-    clear: none;
-  }
-
   .home-companies-logos .pp-logos-content .logo-slider-nav button {
   }
 
@@ -3445,27 +3031,6 @@ img.mfp-img {
 
 
 @media only screen and (max-width: 1115px) {
-  .home-companies-logos .pp-logos-content .pp-logo {
-    width: calc((100% - 121px) / 4);
-  }
-
-  .home-companies-logos .pp-logos-content .pp-logo:nth-of-type(4n+1) {
-    clear: left;
-  }
-
-  .home-companies-logos .pp-logos-content .pp-logo:nth-of-type(6n) {
-    margin-right: 40px;
-    margin-bottom: 40px;
-  }
-
-  .home-companies-logos .pp-logos-content .pp-logo:nth-of-type(4n) {
-    margin-right: 0;
-  }
-
-  .home-companies-logos .pp-logos-content .pp-logo:nth-of-type(6n+1) {
-    clear: none;
-  }
-
   .home-companies-logos .pp-logos-content .logo-slider-nav button {
   }
 
@@ -3475,27 +3040,6 @@ img.mfp-img {
 
 
 @media only screen and (max-width: 860px) {
-  .home-companies-logos .pp-logos-content .pp-logo {
-    width: calc((100% - 41px) / 2);
-  }
-
-  .home-companies-logos .pp-logos-content .pp-logo:nth-of-type(4n+1) {
-    clear: none;
-  }
-
-  .home-companies-logos .pp-logos-content .pp-logo:nth-of-type(2n+1) {
-    clear: left;
-  }
-
-  .home-companies-logos .pp-logos-content .pp-logo:nth-of-type(4n) {
-    margin-right: 40px;
-    margin-bottom: 40px;
-  }
-
-  .home-companies-logos .pp-logos-content .pp-logo:nth-of-type(2n) {
-    margin-right: 0;
-  }
-
   .home-companies-logos .pp-logos-content .logo-slider-nav button {
   }
 
@@ -3510,13 +3054,6 @@ img.mfp-img {
   padding-bottom: 0px;
   padding-left: 0px;
 }
-
-
-.home-companies-logos > .fl-module-content {
-  margin-top: 60px;
-}
-
-
 @media (max-width: 860px) {
   .home-companies-logos > .fl-module-content {
     margin-top: 0px;
@@ -4569,28 +4106,6 @@ img.mfp-img {
 .home-service-qa-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
   margin-left: 10px;
 }
-
-
-.home-services-spacer .pp-spacer-module {
-  height: 32px;
-  width: 100%;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .home-services-spacer .pp-spacer-module {
-    height: 30px;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .home-services-spacer .pp-spacer-module {
-    height: 15px;
-  }
-}
-
-
 .fl-col-group-equal-height .home-service-product-box, .fl-col-group-equal-height .home-service-product-box .fl-module-content, .fl-col-group-equal-height .home-service-product-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .home-service-product-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .home-service-product-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .home-service-product-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
   display: flex;
   -webkit-box-orient: vertical;
@@ -8201,26 +7716,11 @@ body .pp-post-feed-meta {
   -ms-transition: all 0.2s ease-in;
   -o-transition: all 0.2s ease-in;
 }
-
-
-.pp-tabs-label.pp-tab-active {
-  position: relative;
-  z-index: 1;
-}
-
-
 .pp-tab-label-flex {
   display: flex;
   flex-direction: row;
   flex: 1 1 auto;
 }
-
-
-.pp-tabs-label .pp-tab-label-flex {
-  align-items: center;
-}
-
-
 .pp-tabs-label.pp-tab-icon-top .pp-tab-label-flex, .pp-tabs-label.pp-tab-icon-bottom .pp-tab-label-flex {
   flex-direction: column;
 }
@@ -8236,18 +7736,6 @@ body .pp-post-feed-meta {
   content: "";
   display: table;
 }
-
-
-.pp-clearfix:after {
-  clear: both;
-}
-
-
-.pp-tabs-panel-label {
-  display: none;
-}
-
-
 .pp-tabs-panel-label span {
   display: table-cell;
   width: 100%;
@@ -8263,23 +7751,6 @@ body .pp-post-feed-meta {
   vertical-align: middle;
   width: auto;
 }
-
-
-.pp-tabs-panel-label .pp-tab-close {
-  display: none;
-}
-
-
-.pp-tabs-panel-label.pp-tabs-label.pp-tab-active .pp-tab-close {
-  display: table-cell;
-}
-
-
-.pp-tabs-panel-label.pp-tabs-label.pp-tab-active .pp-tab-open {
-  display: none;
-}
-
-
 .pp-tabs-default .pp-tabs-panels {
   border-width: 1px;
   border-style: solid;
@@ -8290,38 +7761,13 @@ body .pp-post-feed-meta {
 .pp-tabs-horizontal.pp-tabs-default .pp-tabs-panels {
   clear: both;
 }
-
-
-.pp-tabs-panel-content {
-  display: none !important;
-  padding: 30px;
-  clear: both;
-}
-
-
 .pp-tabs-panel-content.pp-tab-active {
   display: block !important;
 }
-
-
-.pp-tabs-panel-content p:last-child {
-  margin-bottom: 0;
-  padding-bottom: 0;
-}
-
-
 .pp-tabs-vertical .pp-tabs-panel-content.pp-tab-active {
   display: table;
   width: 100%;
 }
-
-
-.pp-tabs-panel .pp-tabs-label .pp-tab-label-inner {
-  display: flex;
-  align-items: center;
-}
-
-
 .pp-tabs-horizontal .pp-tabs-label {
   float: left;
 }
@@ -8348,47 +7794,17 @@ body .pp-post-feed-meta {
 .pp-tabs-horizontal.pp-tabs-default .pp-tabs-label.pp-tab-active {
   top: 1px;
 }
-
-
-.pp-tabs-vertical .pp-tabs-labels {
-  float: left;
-  width: 30%;
-}
-
-
 .pp-tabs-vertical.pp-tabs-vertical-right .pp-tabs-labels {
   float: right;
 }
-
-
-.pp-tabs-vertical .pp-tabs-label {
-  text-align: center;
-  padding: 20px 10px;
-}
-
-
 .pp-tabs-vertical .pp-tabs-label.pp-tab-active {
   border-width: 0px;
   border-style: solid;
 }
-
-
-.pp-tabs-vertical.pp-tabs-default .pp-tabs-label {
-  margin-right: -1px;
-}
-
-
 .pp-tabs-vertical.pp-tabs-vertical-right.pp-tabs-default .pp-tabs-label {
   margin-right: auto;
   margin-left: -1px;
 }
-
-
-.pp-tabs-vertical.pp-tabs-default .pp-tabs-label.pp-tab-active {
-  border-width: 1px;
-}
-
-
 .pp-tabs-vertical .pp-tabs-panels {
   float: left;
   width: 70%;
@@ -8440,13 +7856,6 @@ body .pp-post-feed-meta {
   flex: 1;
   padding: 15px 18px 12px;
 }
-
-
-.pp-tabs-labels .pp-tabs-label .pp-tab-label-inner {
-  position: relative;
-}
-
-
 .pp-tabs-style-1 .pp-tabs-labels {
   border: 4px solid #eee;
 }
@@ -8845,16 +8254,6 @@ body .pp-post-feed-meta {
 
 
 @media (max-width: 860px) {
-  .pp-tabs-labels {
-    display: none !important;
-  }
-
-  .pp-tabs-panel-label {
-    display: table;
-    width: 100%;
-    padding: 20px 15px;
-  }
-
   .pp-tabs-panel-label span {
     width: auto;
   }
@@ -8874,34 +8273,10 @@ body .pp-post-feed-meta {
   .pp-tabs-horizontal .pp-tabs-label.pp-tab-active {
     border: none;
   }
-
-  .pp-tabs-vertical .pp-tabs-labels {
-    float: none;
-    width: auto;
-  }
-
-  .pp-tabs-vertical .pp-tabs-label.pp-tab-active {
-    border: none;
-  }
-
   .pp-tabs-vertical .pp-tabs-panels {
     float: none;
     width: auto;
   }
-
-  .pp-tabs-panel-content {
-    padding: 20px;
-  }
-
-  .pp-tabs .pp-tabs-label {
-    text-align: left;
-    border-bottom: 2px solid #e7e7e7;
-  }
-
-  .pp-tabs .pp-tabs-label.pp-tab-active {
-    border-bottom: 0;
-  }
-
   .pp-tabs .pp-tabs-default .pp-tabs-label, .pp-tabs .pp-tabs-default .pp-tabs-label.pp-tab-active, .pp-tabs .pp-tabs-style-5 .pp-tabs-label, .pp-tabs .pp-tabs-style-6 .pp-tabs-label, .pp-tabs .pp-tabs-style-6 .pp-tabs-label.pp-tab-active, .pp-tabs .pp-tabs-style-7 .pp-tabs-label, .pp-tabs .pp-tabs-style-7 .pp-tabs-label.pp-tab-active, .pp-tabs .pp-tabs-style-8 .pp-tabs-label {
     background-color: transparent !important;
   }
@@ -8941,12 +8316,6 @@ body .pp-post-feed-meta {
   .pp-tabs-style-2 .pp-tabs-label:first-child:before, .pp-tabs-style-2 .pp-tabs-label::after {
     display: none;
   }
-
-  .pp-tabs .pp-tab-title {
-    display: inline-block;
-    width: auto;
-  }
-
   .pp-tab-icon {
     padding-left: 0 !important;
     display: inline-table !important;
@@ -8959,11 +8328,6 @@ body .pp-post-feed-meta {
     margin-right: 0 !important;
     margin-left: 15px !important;
   }
-
-  .pp-tabs-panel-label .pp-toggle-icon {
-    text-align: right;
-  }
-
   .pp-tabs-style-5 .pp-tabs-label .pp-tab-label-inner:after {
     display: none;
   }

--- a/themes/beaver/assets/css/pages/services.css
+++ b/themes/beaver/assets/css/pages/services.css
@@ -1054,26 +1054,6 @@ img.mfp-img {
   padding-top: 200px;
   padding-bottom: 130px;
 }
-
-
-@media ( max-width: 1115px ) {
-  .services-hero.fl-row > .fl-row-content-wrap {
-    padding-top: 150px;
-    padding-bottom: 50px;
-  }
-}
-
-
-@media ( max-width: 860px ) {
-  .services-hero.fl-row > .fl-row-content-wrap {
-    padding-top: 100px;
-    padding-right: 20px;
-    padding-bottom: 50px;
-    padding-left: 20px;
-  }
-}
-
-
 .services-technologies > .fl-row-content-wrap {
   background-color:#f5f6f8;
   background-repeat: no-repeat;
@@ -1158,13 +1138,6 @@ img.mfp-img {
     padding-left: 20px;
   }
 }
-
-
-.services-intro-col {
-  width: 100%;
-}
-
-
 .services-intro-col > .fl-col-content {
   margin-top: 0px;
 }
@@ -1182,56 +1155,6 @@ img.mfp-img {
     padding-bottom: 0px;
   }
 }
-
-
-.services-card-cto-col {
-  width: 32.8%;
-}
-
-
-@media (max-width: 860px) {
-  .fl-builder-content .services-card-cto-col {
-    width: 100% !important;
-    max-width: none;
-    clear: none;
-    float: left;
-  }
-}
-
-
-.services-card-cto-col > .fl-col-content {
-  margin-right: 15px;
-}
-
-
-@media ( max-width: 860px ) {
-  .services-card-cto-col.fl-col > .fl-col-content {
-    padding-top: 30px;
-  }
-}
-
-
-.services-card-webdev-col {
-  width: 34.4%;
-}
-
-
-@media (max-width: 860px) {
-  .fl-builder-content .services-card-webdev-col {
-    width: 100% !important;
-    max-width: none;
-    clear: none;
-    float: left;
-  }
-}
-
-
-.services-card-webdev-col > .fl-col-content {
-  margin-right: 15px;
-  margin-left: 15px;
-}
-
-
 @media ( max-width: 860px ) {
   .services-card-webdev-col.fl-col > .fl-col-content {
     padding-top: 0px;
@@ -1242,18 +1165,6 @@ img.mfp-img {
 .services-card-qa-col {
   width: 32.80%;
 }
-
-
-@media (max-width: 860px) {
-  .fl-builder-content .services-card-qa-col {
-    width: 100% !important;
-    max-width: none;
-    clear: none;
-    float: left;
-  }
-}
-
-
 .services-card-qa-col > .fl-col-content {
   margin-right: 0px;
   margin-left: 15px;
@@ -1272,28 +1183,6 @@ img.mfp-img {
     padding-top: 0px;
   }
 }
-
-
-.services-spacer-col {
-  width: 100%;
-}
-
-
-.services-card-product-col {
-  width: 32%;
-}
-
-
-@media (max-width: 860px) {
-  .fl-builder-content .services-card-product-col {
-    width: 100% !important;
-    max-width: none;
-    clear: none;
-    float: left;
-  }
-}
-
-
 .services-card-product-col > .fl-col-content {
   margin-right: 0px;
 }
@@ -1304,51 +1193,11 @@ img.mfp-img {
     padding-top: 0px;
   }
 }
-
-
-.services-card-staffing-col {
-  width: 36%;
-}
-
-
-@media (max-width: 860px) {
-  .fl-builder-content .services-card-staffing-col {
-    width: 100% !important;
-    max-width: none;
-    clear: none;
-    float: left;
-  }
-}
-
-
-.services-card-staffing-col > .fl-col-content {
-  margin-right: 15px;
-  margin-left: 15px;
-}
-
-
 @media ( max-width: 860px ) {
   .services-card-staffing-col.fl-col > .fl-col-content {
     padding-top: 0px;
   }
 }
-
-
-.services-card-recruiting-col {
-  width: 32%;
-}
-
-
-@media (max-width: 860px) {
-  .fl-builder-content .services-card-recruiting-col {
-    width: 100% !important;
-    max-width: none;
-    clear: none;
-    float: left;
-  }
-}
-
-
 .services-card-recruiting-col > .fl-col-content {
   margin-right: 0px;
   margin-left: 15px;
@@ -1466,58 +1315,6 @@ img.mfp-img {
 .fl-builder-content .fl-rich-text strong {
   font-weight: bold;
 }
-
-
-.fl-builder-content .services-eyebrow .fl-module-content .fl-rich-text, .fl-builder-content .services-eyebrow .fl-module-content .fl-rich-text * {
-  color: var(--color-primary);
-}
-
-
-.fl-builder-content .services-eyebrow .fl-rich-text, .fl-builder-content .services-eyebrow .fl-rich-text *:not(b, strong) {
-  font-weight: 600;
-  text-align: center;
-}
-
-
-/* .fl-module-heading .fl-heading removed - already in critical/fl-common-modules.css */
-
-.services-heading.fl-module-heading .fl-heading {
-  text-align: center;
-}
-
-
-.services-heading > .fl-module-content {
-  margin-top: 30px;
-}
-
-
-@media ( max-width: 860px ) {
-  .services-heading.fl-module > .fl-module-content {
-    margin-top: 10px;
-  }
-}
-
-
-.fl-builder-content .services-subtitle .fl-rich-text, .fl-builder-content .services-subtitle .fl-rich-text *:not(b, strong) {
-  text-align: center;
-}
-
-
-.services-subtitle > .fl-module-content {
-  margin-top: 15px;
-  margin-right: 300px;
-  margin-left: 300px;
-}
-
-
-@media ( max-width: 1115px ) {
-  .services-subtitle.fl-module > .fl-module-content {
-    margin-right: 50px;
-    margin-left: 50px;
-  }
-}
-
-
 @media ( max-width: 860px ) {
   .services-subtitle.fl-module > .fl-module-content {
     margin-top: 15px;
@@ -2660,28 +2457,6 @@ img.mfp-img {
 .services-card-qa .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
   margin-left: 10px;
 }
-
-
-.services-spacer .pp-spacer-module {
-  height: 32px;
-  width: 100%;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .services-spacer .pp-spacer-module {
-    height: 30px;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .services-spacer .pp-spacer-module {
-    height: 15px;
-  }
-}
-
-
 .fl-col-group-equal-height .services-card-product, .fl-col-group-equal-height .services-card-product .fl-module-content, .fl-col-group-equal-height .services-card-product .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .services-card-product .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .services-card-product .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .services-card-product .fl-module-content .pp-infobox-wrap > .pp-more-link {
   display: flex;
   -webkit-box-orient: vertical;

--- a/themes/beaver/assets/css/pages/single-client.css
+++ b/themes/beaver/assets/css/pages/single-client.css
@@ -423,9 +423,6 @@ div.fancybox-container {
   border-radius: 0;
   box-shadow: none;
 }
-.cs-gallery-mod .pp-photo-gallery-item:nth-child(3n+1) {
-  clear: left;
-}
 .cs-gallery-mod .pp-photo-gallery-item:nth-child(3n+0) {
   clear: right;
 }
@@ -463,17 +460,11 @@ div.fancybox-container {
 }
 
 @media only screen and ( max-width: 1200px ) {
-.cs-gallery-mod .pp-photo-gallery-item:nth-child(3n+1) {
-    clear: none;
-  }
 .cs-gallery-mod .pp-photo-gallery-item:nth-child(3n+0) {
     clear: none;
   }
 .cs-gallery-mod .pp-photo-gallery-item:nth-child(3n) {
     margin-right: 2%;
-  }
-.cs-gallery-mod .pp-photo-gallery-item:nth-child(3n+1) {
-    clear: left;
   }
 .cs-gallery-mod .pp-photo-gallery-item:nth-child(3n+0) {
     clear: right;
@@ -484,30 +475,15 @@ div.fancybox-container {
 }
 
 @media only screen and ( max-width: 1115px ) {
-.cs-gallery-mod .pp-photo-gallery-item:nth-child(3n+1) {
-    clear: none;
-  }
 .cs-gallery-mod .pp-photo-gallery-item:nth-child(3n+0) {
     clear: none;
   }
 .cs-gallery-mod .pp-photo-gallery-item:nth-child(3n) {
     margin-right: 2%;
   }
-.cs-gallery-mod .pp-photo-gallery-item:nth-child(2n+1) {
-    clear: left;
-  }
-.cs-gallery-mod .pp-photo-gallery-item:nth-child(2n+0) {
-    clear: right;
-  }
 }
 
 @media only screen and ( max-width: 860px ) {
-.cs-gallery-mod .pp-photo-gallery-item:nth-child(2n+1) {
-    clear: none;
-  }
-.cs-gallery-mod .pp-photo-gallery-item:nth-child(2n+0) {
-    clear: none;
-  }
 .cs-gallery-mod .pp-photo-gallery-item:nth-child(1n) {
     margin-right: 0;
   }


### PR DESCRIPTION
## What this is

The final Phase C sprint plus the phase closure. After this PR, **Phase C's five success criteria are all met** and the remaining work is a decided, documented Phase D backlog.

## C5 — critical-vs-pages twin dedup

Every `critical/*.css` shared 8-81 key-identical rules with its `pages/*.css` file (delta-port leftovers). Formatting differences meant the byte-level production dedup plugin never removed them — **both copies shipped**, so this is a real payload cut.

- **Shipped: 5 winner-safe pairs** (about-us 60, careers 58, homepage 81, services 30, single-client 8 rules deleted from the pages side) — per-selector last-wins winner maps proven exactly unchanged.
- **Reverted: 4 position-sensitive pairs** (clients, single-service, single-use-cases, single-career). The winner gate + a deterministic `careers_ruby` screenshot regression showed those twins are position-load-bearing: the pages copies re-override critical-side defaults (`gform_wrapper` display, `.clearfix:after`, a rich-text font-size). The delta-port headers had warned "keep cascade position — do not dedupe"; the tracker now records them as fold-then-dedup work for Phase D. This is the second time this session the screenshot gate caught what a set-level static gate missed.

## Phase C closure (in the tracker)

Scorecard: FL files 0 ✅ · no obfuscated artifacts ✅ (zero hashed classes, zero hash-named files) · no hand-layer duplication ✅ · safe-edit headers + ownership map ✅ · compiled+gzip evidence rule held ✅.

Phase D decisions (made per Paul's delegation): wrapper collapse + fl-* trio retirement deferred (DOM changes need design QA); legacy-shared strangler deferred to own sprints; the 4 twin sets above fold-then-dedup; jt-reviews-box restoration postponed per Paul.

## Verification

- `careers_ruby` regression fixed and green; churn-based critical suite 34/52 green
- Full macOS system suite: **65 runs / 119 screenshots / 0 failures**, zero baseline changes
- Linux full suite (`bin/dtest-all`): **EXIT=0**, 119 screenshots, no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYRU9wGepomJo5hSuqtu7V