### PR TITLE
fix(css): safelist sr-only + skip-link against the CI purge race

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -35,6 +35,13 @@ const purgecss = createPurgeCss({
       // removing them despite hugo_stats.json containing the class —
       // explicit safelist guards against that drift.
       "btn", "btn-primary", "fl-button", "fl-button-wrap", "action-button",
+
+      // Accessibility skip-link (baseof.html) — same CI-purge phenomenon as
+      // the fl-button entries above: 2026-07-19 a scheduled deploy shipped
+      // the inline navigation bundle WITHOUT .sr-only (visible "Skip to
+      // main content" on every page) while local builds of the same commit
+      // kept it. Never purge these.
+      "sr-only", "skip-link",
     ],
 
     deep: [


### PR DESCRIPTION
Hotfix for the visible "Skip to main content" link on production (careers single, /blog/, blog posts — site-wide, since the navigation bundle is inlined once per build).

**Root cause**: today's scheduled deploy shipped the inline navigation bundle **without** the `.sr-only` rule, while local builds of the same commit keep it — the same CI-only PurgeCSS race already documented in the safelist for the `fl-button` entries ("PurgeCSS in CI has been observed removing them despite hugo_stats.json containing the class"). Diagnosis evidence: live blog-list fingerprint matches current master exactly, but live HTML lacks the rule; local clean build of the same commit contains it.

**Fix**: explicit standard safelist entries for `sr-only` + `skip-link`. Local gate: all bundle fingerprints byte-identical, rule present in the inline bundle.

Deploy dispatch follows merge; will verify live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYRU9wGepomJo5hSuqtu7V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved accessibility features such as screen-reader-only content and skip links during CSS optimization.
  * Prevented these accessibility styles from being removed in production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->