### PR TITLE
fix(build): structural guard for the CI PurgeCSS cold-start race

### DIFF
--- a/.github/workflows/_hugo.yml
+++ b/.github/workflows/_hugo.yml
@@ -73,6 +73,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-hugo-assets-
 
+      # Warm-up pass: hugo_stats.json does not exist on a cold runner, so the
+      # first build's PurgeCSS runs against absent/partial stats and can purge
+      # live classes (2026-07-19: a deploy shipped the inline nav bundle
+      # without .sr-only - visible skip-link site-wide; same phenomenon
+      # documented earlier for the fl-button safelist entries). The warm-up
+      # generates complete stats; the [[build.cachebusters]] entry then makes
+      # the real build reprocess every CSS bundle against them. Mirrors the
+      # local "converged build x2" gate doctrine.
+      - name: Warm up hugo_stats.json (PurgeCSS race guard)
+        run: |
+          PATH="./node_modules/.bin:app/bin:$PATH" hugo \
+            --gc \
+            --baseURL "https://jetthoughts.com/" \
+            --environment production \
+            --quiet || true
+          test -s hugo_stats.json && echo "hugo_stats.json ready: $(wc -c < hugo_stats.json) bytes"
+
       - name: Build with Hugo
         run: |
           PATH="./node_modules/.bin:app/bin:$PATH" hugo \

--- a/bin/hugo-build
+++ b/bin/hugo-build
@@ -41,6 +41,16 @@ HUGO_ARGS=(hugo build --noBuildLock --environment "$ENVIRONMENT" --destination "
 [ -n "$BASE_URL" ] && HUGO_ARGS+=(--baseURL "$BASE_URL")
 [ -n "$BUILD_DRAFTS" ] && HUGO_ARGS+=(--buildDrafts)
 
+# Cold-start guard: production PurgeCSS reads hugo_stats.json, which only
+# exists AFTER a build. On a fresh clone/CI runner the first pass purges
+# against absent stats and can drop live classes (2026-07-19: a deploy
+# shipped the nav bundle without .sr-only). Warm up stats, then build for
+# real - the [[build.cachebusters]] entry reprocesses CSS against them.
+if [ "$ENVIRONMENT" = "production" ] && [ ! -s hugo_stats.json ]; then
+  echo "hugo_stats.json missing - warm-up pass (PurgeCSS race guard)..."
+  "${HUGO_ARGS[@]}" --quiet || true
+fi
+
 "${HUGO_ARGS[@]}"
 
 echo "✓ Build complete"


### PR DESCRIPTION
Closes the class of bug behind today's visible skip-link deploy (and the older fl-button CI purges that forced safelist entries): `hugo_stats.json` only exists **after** a build, so a cold runner's first production pass runs PurgeCSS against absent stats and can drop live classes.

**Guard in both build paths:**
- `bin/hugo-build`: when `ENVIRONMENT=production` and `hugo_stats.json` is missing/empty → warm-up pass first (covers CI tests via setup-hugo and fresh local clones).
- `_hugo.yml` deploy build: explicit warm-up step before the minified build.

The existing `[[build.cachebusters]]` hugo_stats.json→css entry then reprocesses every bundle against complete stats — the CI mirror of the local converged-build-×2 doctrine.

**Verified**: cold-start simulation (stats file removed + `resources/_gen/assets` wiped) → warm-up fires → final build contains `.sr-only` in the inline nav bundle. The safelist entries from #377 stay as defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYRU9wGepomJo5hSuqtu7V