### PR TITLE
CSS Phase E: the paved path - jt-info-card component (21 instances single-sourced) + new-page checklist

### DIFF
--- a/docs/projects/2509-css-migration/TASK-TRACKER.md
+++ b/docs/projects/2509-css-migration/TASK-TRACKER.md
@@ -718,6 +718,29 @@ last-wins gate that caught both real regressions this phase.
   accidents make per-line archaeology cost grow while the evidence rule
   shows ~zero shipped-byte win (PurgeCSS already strips unused legacy
   rules per bundle).
+## 🔄 PHASE E IN PROGRESS (2026-07-19, branch css-migration/phase-e-paved-path)
+
+Mandate (Paul): a person must be able to create a new page from scratch
+reusing existing components, consistently. Plan + measured facts:
+- E1 info-card component: the pp-infobox card pattern repeats ~21x across
+  home (6: home-service-*-box), services (6: services-card-*), about
+  (3: about-value-*), careers (6: careers-value-*-box). MEASURED:
+  home-cto vs services-cto = 24 rules identical modulo class name
+  (A=36 B=50); variance = home-only :hover colors, services-only
+  equal-height flex framework + empty-body hover stubs. Protocol:
+  C1-style intersection -> components/info-card.css keyed on ONE shared
+  class (jt-info-card), re-key all 21 template instances + page CSS
+  keeps, css-winners + qtest gates per page.
+- E2 stat-row component: about-stat-*, home-proof-stat*, service-stat*
+  counter rows - same treatment (unmeasured yet).
+- E3 paved path docs: docs/workflows/new-page.md (bundle-slice recipe +
+  order warning, purge greedy-prefix trap, qtest PAGE_TESTS entry,
+  ownership-map entry) + a starter/example page template.
+- E4 (optional, riskier): collapse the 6 inline CTA template copies onto
+  partials/page/cta.html - copies diverge at OUTER wrapper classes (page
+  keeps), needs per-page params + visual gates; the partial is already
+  usable for NEW pages today. Also fix cta.html duplicate data-node attr.
+
 - PROPOSED Phase E (awaiting Paul): "new-page paved path" - a page
   starter template/archetype, 2-3 more extracted section components
   (hero, card-grid, stat-row) via the proven C1 protocol, and

--- a/docs/workflows/new-page.md
+++ b/docs/workflows/new-page.md
@@ -1,0 +1,99 @@
+# Adding a new page — the paved path
+
+The checklist for building a new page that reuses the shared components and
+stays consistent with the design system. Every trap listed here has bitten a
+real sprint; do not skip steps.
+
+## 1. Template
+
+Create `themes/beaver/layouts/page/<name>.html`. Start from
+`themes/beaver/layouts/page/clients.html` (the cleanest example) and keep the
+structural shell:
+
+```
+{{ define "header" }}   <- CSS bundle slice (step 2)
+{{ define "main" }}
+  <div id="fl-main-content" class="fl-page-content" role="main">
+    ... fl-row / fl-col-group / fl-col / fl-col-content nesting ...
+```
+
+The `fl-*` framework classes are load-bearing (layout grid from
+`critical/fl-layout-grid.css`) — keep the nesting; name YOUR elements with a
+page prefix (`<name>-hero`, `<name>-grid`, ...). Never introduce hash-like
+class names.
+
+## 2. CSS bundle slice
+
+In the template's `header` block, compose the bundle. **Order is
+load-bearing** — keep exactly this shape:
+
+```
+{{- $resources := slice
+  (resources.Get "css/critical/base.css")            <- pure-@import prelude; MUST be first
+  (resources.Get "css/components/<used>.css")        <- one line per component you use
+  (resources.Get "css/pages/<name>.css")             <- your page CSS
+  (resources.Get "css/dynamic-icons.css" | resources.ExecuteAsTemplate "css/dynamic586.css" .)
+  (resources.Get "css/586.css")
+  (resources.Get "css/vendors/base-4.min.css")
+  (resources.Get "css/style.css")
+  (resources.Get "css/legacy-theme-skin.css")
+  (resources.Get "css/footer.css")
+-}}
+{{ partialCached "assets/css-processor.html" (dict "resources" $resources "bundleName" "<name>") "<name>" }}
+```
+
+TRAPS:
+- `@import` only works in `critical/base.css` (the concat prelude). An
+  `@import` in `pages/*.css` is silently skipped by postcss-import —
+  components join as slice members, never imports.
+- `bundleName` must be unique repo-wide (a collision silently races —
+  the blog-list/taxonomy incident).
+
+## 3. Reusable components (include partial + add CSS slice line)
+
+| Component | Markup | CSS slice line |
+|---|---|---|
+| Testimonials section | `{{ partial "page/testimonials.html" . }}` | `components/testimonials.css` |
+| CTA banner ("Let's get started now") | `{{ partial "page/cta.html" . }}` | `components/cta-banner.css` |
+| Info card (pp-infobox) | `<div class="fl-module fl-module-pp-infobox jt-info-card <name>-card-x">` + pp-infobox markup (copy one instance from `page/services.html`) | `components/info-card.css` |
+| Header CTA trio | (only if the page renders the bf72bba header variant) | `components/header-cta.css` |
+| Technologies strip | `{{ partial "technologies.html" (dict "colorVariant" "dark") }}` | `technologies.css` |
+
+Page-specific tweaks to a component (spacing, hover colors) go in
+`pages/<name>.css` under YOUR page class — they win by concat position.
+Never edit `components/*.css` for one page's needs.
+
+## 4. Design tokens
+
+Use the vars from `foundations/css-variables.css` (inlined site-wide):
+`--color-ruby` (#cc342d) · `--color-primary` (#1a8cff) · `--color-dark`
+(#121212) · `--color-muted` · `--font-system-ui` · `--radius-default` ·
+`--spacing-sm/md`. Visual language: `.stitch/design.md` (JetVelocity).
+
+## 5. PurgeCSS greedy prefix (DO NOT SKIP)
+
+Add your page's class prefix to the `greedy` list in `postcss.config.js`
+(next to `/^testimonials-/ ...`). Without it, any selector that pairs your
+class with a runtime-injected class (swiper, PowerPack `pp-*`) gets purged
+in production only — the visible-skip-link class of bug.
+
+## 6. Tests + maps
+
+- Add the page to `PAGE_TESTS` in `bin/qtest` (key = `pages/<name>.css`
+  basename → test-name regex).
+- Add desktop + mobile screenshot tests
+  (`test/system/desktop_site_test.rb` / `mobile_site_test.rb`); anchor on
+  visible text, then `assert_stable_screenshot "<name>"`.
+- Add the bundle to `docs/projects/2509-css-migration/css-bundle-ownership-map.md`.
+
+## 7. Verify
+
+```
+bin/qtest <name>          # fast scoped gate (build + screenshots + guards)
+bin/rake test:critical    # before commit
+bin/test && bin/dtest     # both platforms before the PR
+```
+
+FORCE_SCREENSHOT_UPDATE=true regenerates baselines (commit macos/ AND
+linux/ together). A failing screenshot run overwrites baselines — restore
+via `git checkout -- test/fixtures/screenshots` before rerunning.

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -54,7 +54,7 @@ const purgecss = createPurgeCss({
       // protection their selectors previously got from /^fl-node/ (PowerPack
       // runtime classes like pp-swiper-button/pp-review-image are never in
       // hugo_stats.json, so without this the renamed rules get purged).
-      /^testimonials-/, /^cta-banner/, /^career-/, /^clients-/,
+      /^testimonials-/, /^cta-banner/, /^jt-info-card/, /^career-/, /^clients-/,
       /^notfound-/, /^use-case-/, /^services-/, /^service-/, /^about-/, /^home-/, /^careers-/,
       // Brand CTA buttons — preserve any selector mentioning these classes.
       // Standard safelist didn't catch tag+class compound selectors like

--- a/themes/beaver/assets/css/components/info-card.css
+++ b/themes/beaver/assets/css/components/info-card.css
@@ -1,0 +1,126 @@
+/* Shared info-card (pp-infobox) core - Phase E paved path.
+   The 16-rule intersection of all 21 card instances across homepage,
+   services, about-us, careers (measured 2026-07-19). Applied via the
+   ADDITIVE class jt-info-card on each card module; page-specific
+   variants (hover colors, equal-height framework, media tweaks) stay
+   in the page files and win by concat position.
+
+   New pages: <div class="fl-module fl-module-pp-infobox jt-info-card">
+   with pp-infobox markup inside - see docs/workflows/new-page.md.
+
+   affects pages: homepage, services, about-us, careers - see
+   docs/projects/2509-css-migration/css-bundle-ownership-map.md */
+
+
+
+
+.fl-col-group-equal-height .jt-info-card, .fl-col-group-equal-height .jt-info-card .fl-module-content, .fl-col-group-equal-height .jt-info-card .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .jt-info-card .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .jt-info-card .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .jt-info-card .fl-module-content .pp-infobox-wrap > .pp-more-link {
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  flex-shrink: 1;
+  min-width: 1px;
+  max-width: 100%;
+  -webkit-box-flex: 1 1 auto;
+  -moz-box-flex: 1 1 auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+
+
+.jt-info-card .pp-infobox .pp-infobox-title-prefix {
+  display: none;
+}
+
+
+
+.jt-info-card .pp-infobox-image {
+  text-align: left
+}
+
+
+
+.fl-builder-content .jt-info-card .pp-infobox-image img {
+  height: auto;
+  max-width: 100%;
+}
+
+
+
+.jt-info-card .pp-infobox:hover .pp-infobox-image img {
+}
+
+
+
+.jt-info-card .pp-infobox .animated {
+  -webkit-animation-duration: 500ms;
+  -moz-animation-duration: 500ms;
+  -o-animation-duration: 500ms;
+  -ms-animation-duration: 500ms;
+  animation-duration: 500ms;
+}
+
+
+
+.jt-info-card .pp-infobox-wrap .layout-3-wrapper, .jt-info-card .pp-infobox-wrap .layout-4-wrapper {
+}
+
+
+
+.jt-info-card .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .jt-info-card .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+
+
+.jt-info-card .pp-infobox-wrap .layout-2 .pp-infobox-description, .jt-info-card .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
+  float: left;
+}
+@media only screen and (max-width: 1115px) {
+
+  .jt-info-card .pp-infobox {
+    text-align: left;
+  }
+}
+@media only screen and (max-width: 860px) {
+
+  .jt-info-card .pp-infobox-wrap .pp-infobox {
+    text-align: left;
+  }
+
+
+  .jt-info-card .pp-infobox-wrap .layout-2 .pp-infobox-description, .jt-info-card .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
+    float: left;
+  }
+}
+@media only screen and (max-width: 480px) {
+
+  .jt-info-card .pp-infobox-wrap .layout-3-wrapper, .jt-info-card .pp-infobox-wrap .layout-4-wrapper {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+
+
+.jt-info-card .pp-infobox-title-wrapper .pp-infobox-title {
+  font-size: 22px;
+}
+
+
+
+.jt-info-card .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
+  margin-right: 10px;
+}
+
+
+
+.jt-info-card .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
+  margin-left: 10px;
+}

--- a/themes/beaver/assets/css/pages/about-us.css
+++ b/themes/beaver/assets/css/pages/about-us.css
@@ -1525,26 +1525,6 @@ img.mfp-img {
 .pp-infobox-wrap .layout-4 .pp-heading-wrapper {
   flex: 1;
 }
-
-
-.fl-col-group-equal-height .about-value-trust, .fl-col-group-equal-height .about-value-trust .fl-module-content, .fl-col-group-equal-height .about-value-trust .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .about-value-trust .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .about-value-trust .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .about-value-trust .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 .fl-col-group-equal-height .about-value-trust.fl-visible-large, .fl-col-group-equal-height .about-value-trust.fl-visible-medium, .fl-col-group-equal-height .about-value-trust.fl-visible-mobile {
   display: none;
 }
@@ -1613,13 +1593,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-
-.about-value-trust .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .about-value-trust .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 25px;
   margin-bottom: 0px;
@@ -1650,23 +1623,6 @@ img.mfp-img {
 
 .about-value-trust .pp-infobox:hover .pp-infobox-description {
 }
-
-
-.about-value-trust .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .about-value-trust .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.about-value-trust .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .about-value-trust .pp-infobox-icon-inner span.pp-icon, .about-value-trust .pp-infobox-image img {
   border-radius: px;
 }
@@ -1681,63 +1637,6 @@ img.mfp-img {
 .about-value-trust .pp-infobox:hover {
   background: rgba(245, 246, 248, 0);
 }
-
-
-.about-value-trust .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.about-value-trust .pp-infobox-wrap .layout-3-wrapper, .about-value-trust .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.about-value-trust .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .about-value-trust .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.about-value-trust .pp-infobox-wrap .layout-2 .pp-infobox-description, .about-value-trust .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .about-value-trust .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .about-value-trust .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .about-value-trust .pp-infobox-wrap .layout-2 .pp-infobox-description, .about-value-trust .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .about-value-trust .pp-infobox-wrap .layout-3-wrapper, .about-value-trust .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.about-value-trust .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .about-value-trust .pp-infobox-image img {
   width: 37px;
 }
@@ -1753,36 +1652,6 @@ img.mfp-img {
   border-bottom-left-radius: 14px;
   border-bottom-right-radius: 14px;
 }
-
-
-.about-value-trust .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.about-value-trust .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
-.fl-col-group-equal-height .about-value-alignment, .fl-col-group-equal-height .about-value-alignment .fl-module-content, .fl-col-group-equal-height .about-value-alignment .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .about-value-alignment .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .about-value-alignment .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .about-value-alignment .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 .fl-col-group-equal-height .about-value-alignment.fl-visible-large, .fl-col-group-equal-height .about-value-alignment.fl-visible-medium, .fl-col-group-equal-height .about-value-alignment.fl-visible-mobile {
   display: none;
 }
@@ -1851,13 +1720,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-
-.about-value-alignment .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .about-value-alignment .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 25px;
   margin-bottom: 0px;
@@ -1888,23 +1750,6 @@ img.mfp-img {
 
 .about-value-alignment .pp-infobox:hover .pp-infobox-description {
 }
-
-
-.about-value-alignment .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .about-value-alignment .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.about-value-alignment .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .about-value-alignment .pp-infobox-icon-inner span.pp-icon, .about-value-alignment .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -1922,63 +1767,6 @@ img.mfp-img {
 .about-value-alignment .pp-infobox:hover {
   background: rgba(245, 246, 248, 0);
 }
-
-
-.about-value-alignment .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.about-value-alignment .pp-infobox-wrap .layout-3-wrapper, .about-value-alignment .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.about-value-alignment .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .about-value-alignment .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.about-value-alignment .pp-infobox-wrap .layout-2 .pp-infobox-description, .about-value-alignment .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .about-value-alignment .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .about-value-alignment .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .about-value-alignment .pp-infobox-wrap .layout-2 .pp-infobox-description, .about-value-alignment .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .about-value-alignment .pp-infobox-wrap .layout-3-wrapper, .about-value-alignment .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.about-value-alignment .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .about-value-alignment .pp-infobox-image img {
   width: 37px;
 }
@@ -1994,36 +1782,6 @@ img.mfp-img {
   border-bottom-left-radius: 14px;
   border-bottom-right-radius: 14px;
 }
-
-
-.about-value-alignment .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.about-value-alignment .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
-.fl-col-group-equal-height .about-value-reliability, .fl-col-group-equal-height .about-value-reliability .fl-module-content, .fl-col-group-equal-height .about-value-reliability .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .about-value-reliability .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .about-value-reliability .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .about-value-reliability .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 .fl-col-group-equal-height .about-value-reliability.fl-visible-large, .fl-col-group-equal-height .about-value-reliability.fl-visible-medium, .fl-col-group-equal-height .about-value-reliability.fl-visible-mobile {
   display: none;
 }
@@ -2092,13 +1850,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-
-.about-value-reliability .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .about-value-reliability .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 25px;
   margin-bottom: 0px;
@@ -2129,23 +1880,6 @@ img.mfp-img {
 
 .about-value-reliability .pp-infobox:hover .pp-infobox-description {
 }
-
-
-.about-value-reliability .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .about-value-reliability .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.about-value-reliability .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .about-value-reliability .pp-infobox-icon-inner span.pp-icon, .about-value-reliability .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -2163,63 +1897,6 @@ img.mfp-img {
 .about-value-reliability .pp-infobox:hover {
   background: rgba(245, 246, 248, 0);
 }
-
-
-.about-value-reliability .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.about-value-reliability .pp-infobox-wrap .layout-3-wrapper, .about-value-reliability .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.about-value-reliability .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .about-value-reliability .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.about-value-reliability .pp-infobox-wrap .layout-2 .pp-infobox-description, .about-value-reliability .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .about-value-reliability .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .about-value-reliability .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .about-value-reliability .pp-infobox-wrap .layout-2 .pp-infobox-description, .about-value-reliability .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .about-value-reliability .pp-infobox-wrap .layout-3-wrapper, .about-value-reliability .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.about-value-reliability .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .about-value-reliability .pp-infobox-image img {
   width: 37px;
 }
@@ -2235,18 +1912,6 @@ img.mfp-img {
   border-bottom-left-radius: 14px;
   border-bottom-right-radius: 14px;
 }
-
-
-.about-value-reliability .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.about-value-reliability .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
 .fl-builder-content .about-achievements-eyebrow .fl-module-content .fl-rich-text, .fl-builder-content .about-achievements-eyebrow .fl-module-content .fl-rich-text * {
   color: var(--color-primary);
 }

--- a/themes/beaver/assets/css/pages/careers.css
+++ b/themes/beaver/assets/css/pages/careers.css
@@ -1454,24 +1454,6 @@ img.mfp-img {
 
 @media (max-width: 860px) {
 }
-
-.fl-col-group-equal-height .careers-value-people-box, .fl-col-group-equal-height .careers-value-people-box .fl-module-content, .fl-col-group-equal-height .careers-value-people-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .careers-value-people-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .careers-value-people-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .careers-value-people-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
 .fl-col-group-equal-height .careers-value-people-box.fl-visible-large, .fl-col-group-equal-height .careers-value-people-box.fl-visible-medium, .fl-col-group-equal-height .careers-value-people-box.fl-visible-mobile {
   display: none;
 }
@@ -1533,11 +1515,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-.careers-value-people-box .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
 .careers-value-people-box .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 30px;
   margin-bottom: 0px;
@@ -1562,19 +1539,6 @@ img.mfp-img {
 
 .careers-value-people-box .pp-infobox:hover .pp-infobox-description {
 }
-
-.careers-value-people-box .pp-infobox-image {
-  text-align: left
-}
-
-.fl-builder-content .careers-value-people-box .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-.careers-value-people-box .pp-infobox:hover .pp-infobox-image img {
-}
-
 .careers-value-people-box .pp-infobox-icon-inner span.pp-icon, .careers-value-people-box .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -1588,54 +1552,6 @@ img.mfp-img {
 
 .careers-value-people-box .pp-infobox:hover {
 }
-
-.careers-value-people-box .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-.careers-value-people-box .pp-infobox-wrap .layout-3-wrapper, .careers-value-people-box .pp-infobox-wrap .layout-4-wrapper {
-}
-
-.careers-value-people-box .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .careers-value-people-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-.careers-value-people-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .careers-value-people-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-@media only screen and (max-width: 1115px) {
-  .careers-value-people-box .pp-infobox {
-    text-align: left;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .careers-value-people-box .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .careers-value-people-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .careers-value-people-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-@media only screen and (max-width: 480px) {
-  .careers-value-people-box .pp-infobox-wrap .layout-3-wrapper, .careers-value-people-box .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-.careers-value-people-box .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
 .fl-builder-content .careers-value-people-box .pp-infobox-image img {
   width: 35px;
 }
@@ -1655,32 +1571,6 @@ img.mfp-img {
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
-
-.careers-value-people-box .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-.careers-value-people-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-.fl-col-group-equal-height .careers-value-longterm-box, .fl-col-group-equal-height .careers-value-longterm-box .fl-module-content, .fl-col-group-equal-height .careers-value-longterm-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .careers-value-longterm-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .careers-value-longterm-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .careers-value-longterm-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
 .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-large, .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-medium, .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-mobile {
   display: none;
 }
@@ -1742,11 +1632,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-.careers-value-longterm-box .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
 .careers-value-longterm-box .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 30px;
   margin-bottom: 0px;
@@ -1771,19 +1656,6 @@ img.mfp-img {
 
 .careers-value-longterm-box .pp-infobox:hover .pp-infobox-description {
 }
-
-.careers-value-longterm-box .pp-infobox-image {
-  text-align: left
-}
-
-.fl-builder-content .careers-value-longterm-box .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-.careers-value-longterm-box .pp-infobox:hover .pp-infobox-image img {
-}
-
 .careers-value-longterm-box .pp-infobox-icon-inner span.pp-icon, .careers-value-longterm-box .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -1797,54 +1669,6 @@ img.mfp-img {
 
 .careers-value-longterm-box .pp-infobox:hover {
 }
-
-.careers-value-longterm-box .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-.careers-value-longterm-box .pp-infobox-wrap .layout-3-wrapper, .careers-value-longterm-box .pp-infobox-wrap .layout-4-wrapper {
-}
-
-.careers-value-longterm-box .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .careers-value-longterm-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-.careers-value-longterm-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .careers-value-longterm-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-@media only screen and (max-width: 1115px) {
-  .careers-value-longterm-box .pp-infobox {
-    text-align: left;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .careers-value-longterm-box .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .careers-value-longterm-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .careers-value-longterm-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-@media only screen and (max-width: 480px) {
-  .careers-value-longterm-box .pp-infobox-wrap .layout-3-wrapper, .careers-value-longterm-box .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-.careers-value-longterm-box .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
 .fl-builder-content .careers-value-longterm-box .pp-infobox-image img {
   width: 35px;
 }
@@ -1864,32 +1688,6 @@ img.mfp-img {
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
-
-.careers-value-longterm-box .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-.careers-value-longterm-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-.fl-col-group-equal-height .careers-value-team-box, .fl-col-group-equal-height .careers-value-team-box .fl-module-content, .fl-col-group-equal-height .careers-value-team-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .careers-value-team-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .careers-value-team-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .careers-value-team-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
 .fl-col-group-equal-height .careers-value-team-box.fl-visible-large, .fl-col-group-equal-height .careers-value-team-box.fl-visible-medium, .fl-col-group-equal-height .careers-value-team-box.fl-visible-mobile {
   display: none;
 }
@@ -1951,11 +1749,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-.careers-value-team-box .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
 .careers-value-team-box .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 30px;
   margin-bottom: 0px;
@@ -1980,19 +1773,6 @@ img.mfp-img {
 
 .careers-value-team-box .pp-infobox:hover .pp-infobox-description {
 }
-
-.careers-value-team-box .pp-infobox-image {
-  text-align: left
-}
-
-.fl-builder-content .careers-value-team-box .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-.careers-value-team-box .pp-infobox:hover .pp-infobox-image img {
-}
-
 .careers-value-team-box .pp-infobox-icon-inner span.pp-icon, .careers-value-team-box .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -2006,54 +1786,6 @@ img.mfp-img {
 
 .careers-value-team-box .pp-infobox:hover {
 }
-
-.careers-value-team-box .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-.careers-value-team-box .pp-infobox-wrap .layout-3-wrapper, .careers-value-team-box .pp-infobox-wrap .layout-4-wrapper {
-}
-
-.careers-value-team-box .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .careers-value-team-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-.careers-value-team-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .careers-value-team-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-@media only screen and (max-width: 1115px) {
-  .careers-value-team-box .pp-infobox {
-    text-align: left;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .careers-value-team-box .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .careers-value-team-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .careers-value-team-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-@media only screen and (max-width: 480px) {
-  .careers-value-team-box .pp-infobox-wrap .layout-3-wrapper, .careers-value-team-box .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-.careers-value-team-box .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
 .fl-builder-content .careers-value-team-box .pp-infobox-image img {
   width: 35px;
 }
@@ -2073,31 +1805,6 @@ img.mfp-img {
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
-
-.careers-value-team-box .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-.careers-value-team-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-.fl-col-group-equal-height .careers-value-flexibility-box, .fl-col-group-equal-height .careers-value-flexibility-box .fl-module-content, .fl-col-group-equal-height .careers-value-flexibility-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .careers-value-flexibility-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .careers-value-flexibility-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .careers-value-flexibility-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
 .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-large, .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-medium, .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-mobile {
   display: none;
 }
@@ -2159,11 +1866,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-.careers-value-flexibility-box .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
 .careers-value-flexibility-box .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 30px;
   margin-bottom: 0px;
@@ -2188,19 +1890,6 @@ img.mfp-img {
 
 .careers-value-flexibility-box .pp-infobox:hover .pp-infobox-description {
 }
-
-.careers-value-flexibility-box .pp-infobox-image {
-  text-align: left
-}
-
-.fl-builder-content .careers-value-flexibility-box .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-.careers-value-flexibility-box .pp-infobox:hover .pp-infobox-image img {
-}
-
 .careers-value-flexibility-box .pp-infobox-icon-inner span.pp-icon, .careers-value-flexibility-box .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -2214,54 +1903,6 @@ img.mfp-img {
 
 .careers-value-flexibility-box .pp-infobox:hover {
 }
-
-.careers-value-flexibility-box .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-.careers-value-flexibility-box .pp-infobox-wrap .layout-3-wrapper, .careers-value-flexibility-box .pp-infobox-wrap .layout-4-wrapper {
-}
-
-.careers-value-flexibility-box .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .careers-value-flexibility-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-.careers-value-flexibility-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .careers-value-flexibility-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-@media only screen and (max-width: 1115px) {
-  .careers-value-flexibility-box .pp-infobox {
-    text-align: left;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .careers-value-flexibility-box .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .careers-value-flexibility-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .careers-value-flexibility-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-@media only screen and (max-width: 480px) {
-  .careers-value-flexibility-box .pp-infobox-wrap .layout-3-wrapper, .careers-value-flexibility-box .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-.careers-value-flexibility-box .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
 .fl-builder-content .careers-value-flexibility-box .pp-infobox-image img {
   width: 35px;
 }
@@ -2281,32 +1922,6 @@ img.mfp-img {
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
-
-.careers-value-flexibility-box .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-.careers-value-flexibility-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-.fl-col-group-equal-height .careers-value-growth-box, .fl-col-group-equal-height .careers-value-growth-box .fl-module-content, .fl-col-group-equal-height .careers-value-growth-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .careers-value-growth-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .careers-value-growth-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .careers-value-growth-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
 .fl-col-group-equal-height .careers-value-growth-box.fl-visible-large, .fl-col-group-equal-height .careers-value-growth-box.fl-visible-medium, .fl-col-group-equal-height .careers-value-growth-box.fl-visible-mobile {
   display: none;
 }
@@ -2368,11 +1983,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-.careers-value-growth-box .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
 .careers-value-growth-box .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 30px;
   margin-bottom: 0px;
@@ -2397,19 +2007,6 @@ img.mfp-img {
 
 .careers-value-growth-box .pp-infobox:hover .pp-infobox-description {
 }
-
-.careers-value-growth-box .pp-infobox-image {
-  text-align: left
-}
-
-.fl-builder-content .careers-value-growth-box .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-.careers-value-growth-box .pp-infobox:hover .pp-infobox-image img {
-}
-
 .careers-value-growth-box .pp-infobox-icon-inner span.pp-icon, .careers-value-growth-box .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -2423,54 +2020,6 @@ img.mfp-img {
 
 .careers-value-growth-box .pp-infobox:hover {
 }
-
-.careers-value-growth-box .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-.careers-value-growth-box .pp-infobox-wrap .layout-3-wrapper, .careers-value-growth-box .pp-infobox-wrap .layout-4-wrapper {
-}
-
-.careers-value-growth-box .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .careers-value-growth-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-.careers-value-growth-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .careers-value-growth-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-@media only screen and (max-width: 1115px) {
-  .careers-value-growth-box .pp-infobox {
-    text-align: left;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .careers-value-growth-box .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .careers-value-growth-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .careers-value-growth-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-@media only screen and (max-width: 480px) {
-  .careers-value-growth-box .pp-infobox-wrap .layout-3-wrapper, .careers-value-growth-box .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-.careers-value-growth-box .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
 .fl-builder-content .careers-value-growth-box .pp-infobox-image img {
   width: 35px;
 }
@@ -2490,32 +2039,6 @@ img.mfp-img {
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
-
-.careers-value-growth-box .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-.careers-value-growth-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-.fl-col-group-equal-height .careers-value-training-box, .fl-col-group-equal-height .careers-value-training-box .fl-module-content, .fl-col-group-equal-height .careers-value-training-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .careers-value-training-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .careers-value-training-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .careers-value-training-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
 .fl-col-group-equal-height .careers-value-training-box.fl-visible-large, .fl-col-group-equal-height .careers-value-training-box.fl-visible-medium, .fl-col-group-equal-height .careers-value-training-box.fl-visible-mobile {
   display: none;
 }
@@ -2577,11 +2100,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-.careers-value-training-box .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
 .careers-value-training-box .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 30px;
   margin-bottom: 0px;
@@ -2606,19 +2124,6 @@ img.mfp-img {
 
 .careers-value-training-box .pp-infobox:hover .pp-infobox-description {
 }
-
-.careers-value-training-box .pp-infobox-image {
-  text-align: left
-}
-
-.fl-builder-content .careers-value-training-box .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-.careers-value-training-box .pp-infobox:hover .pp-infobox-image img {
-}
-
 .careers-value-training-box .pp-infobox-icon-inner span.pp-icon, .careers-value-training-box .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -2632,54 +2137,6 @@ img.mfp-img {
 
 .careers-value-training-box .pp-infobox:hover {
 }
-
-.careers-value-training-box .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-.careers-value-training-box .pp-infobox-wrap .layout-3-wrapper, .careers-value-training-box .pp-infobox-wrap .layout-4-wrapper {
-}
-
-.careers-value-training-box .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .careers-value-training-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-.careers-value-training-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .careers-value-training-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-@media only screen and (max-width: 1115px) {
-  .careers-value-training-box .pp-infobox {
-    text-align: left;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .careers-value-training-box .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .careers-value-training-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .careers-value-training-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-@media only screen and (max-width: 480px) {
-  .careers-value-training-box .pp-infobox-wrap .layout-3-wrapper, .careers-value-training-box .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-.careers-value-training-box .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
 .fl-builder-content .careers-value-training-box .pp-infobox-image img {
   width: 35px;
 }
@@ -2699,15 +2156,6 @@ img.mfp-img {
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
 }
-
-.careers-value-training-box .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-.careers-value-training-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
 .careers-testimonial-photo .fl-photo {
   text-align: left;
 }

--- a/themes/beaver/assets/css/pages/homepage.css
+++ b/themes/beaver/assets/css/pages/homepage.css
@@ -3404,34 +3404,7 @@ img.mfp-img {
 .pp-infobox-wrap .layout-4 .pp-heading-wrapper {
   flex: 1;
 }
-
-
-.fl-col-group-equal-height .home-service-cto-box, .fl-col-group-equal-height .home-service-cto-box .fl-module-content, .fl-col-group-equal-height .home-service-cto-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .home-service-cto-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .home-service-cto-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .home-service-cto-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 @mixin responsive-visibility dxali8vntcr0;
-
-
-.home-service-cto-box .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .home-service-cto-box .pp-infobox-title-wrapper .pp-infobox-title {
   color: #ffffff;
   margin-top: 30px;
@@ -3468,23 +3441,6 @@ img.mfp-img {
 .home-service-cto-box .pp-infobox .pp-infobox-description:hover {
   color: var(--color-dark);
 }
-
-
-.home-service-cto-box .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .home-service-cto-box .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.home-service-cto-box .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .home-service-cto-box .pp-infobox-icon-inner span.pp-icon, .home-service-cto-box .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -3538,63 +3494,6 @@ img.mfp-img {
 .home-service-cto-box .pp-infobox .pp-more-link .pp-button-icon-right {
   margin-left: 15px;
 }
-
-
-.home-service-cto-box .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.home-service-cto-box .pp-infobox-wrap .layout-3-wrapper, .home-service-cto-box .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.home-service-cto-box .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .home-service-cto-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.home-service-cto-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .home-service-cto-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .home-service-cto-box .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .home-service-cto-box .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .home-service-cto-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .home-service-cto-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .home-service-cto-box .pp-infobox-wrap .layout-3-wrapper, .home-service-cto-box .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.home-service-cto-box .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .home-service-cto-box .pp-infobox-image img {
   width: 36px;
 }
@@ -3628,44 +3527,7 @@ img.mfp-img {
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.home-service-cto-box .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.home-service-cto-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
-.fl-col-group-equal-height .home-service-web-dev-box, .fl-col-group-equal-height .home-service-web-dev-box .fl-module-content, .fl-col-group-equal-height .home-service-web-dev-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .home-service-web-dev-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .home-service-web-dev-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .home-service-web-dev-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 @mixin responsive-visibility 075ztwhd3cxn;
-
-
-.home-service-web-dev-box .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .home-service-web-dev-box .pp-infobox-title-wrapper .pp-infobox-title {
   color: #ffffff;
   margin-top: 30px;
@@ -3702,23 +3564,6 @@ img.mfp-img {
 .home-service-web-dev-box .pp-infobox .pp-infobox-description:hover {
   color: var(--color-dark);
 }
-
-
-.home-service-web-dev-box .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .home-service-web-dev-box .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.home-service-web-dev-box .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .home-service-web-dev-box .pp-infobox-icon-inner span.pp-icon, .home-service-web-dev-box .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -3772,63 +3617,6 @@ img.mfp-img {
 .home-service-web-dev-box .pp-infobox .pp-more-link .pp-button-icon-right {
   margin-left: 15px;
 }
-
-
-.home-service-web-dev-box .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.home-service-web-dev-box .pp-infobox-wrap .layout-3-wrapper, .home-service-web-dev-box .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.home-service-web-dev-box .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .home-service-web-dev-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.home-service-web-dev-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .home-service-web-dev-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .home-service-web-dev-box .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .home-service-web-dev-box .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .home-service-web-dev-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .home-service-web-dev-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .home-service-web-dev-box .pp-infobox-wrap .layout-3-wrapper, .home-service-web-dev-box .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.home-service-web-dev-box .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .home-service-web-dev-box .pp-infobox-image img {
   width: 36px;
 }
@@ -3862,44 +3650,7 @@ img.mfp-img {
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.home-service-web-dev-box .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.home-service-web-dev-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
-.fl-col-group-equal-height .home-service-qa-box, .fl-col-group-equal-height .home-service-qa-box .fl-module-content, .fl-col-group-equal-height .home-service-qa-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .home-service-qa-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .home-service-qa-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .home-service-qa-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 @mixin responsive-visibility lajty926uxf5;
-
-
-.home-service-qa-box .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .home-service-qa-box .pp-infobox-title-wrapper .pp-infobox-title {
   color: #ffffff;
   margin-top: 30px;
@@ -3936,23 +3687,6 @@ img.mfp-img {
 .home-service-qa-box .pp-infobox .pp-infobox-description:hover {
   color: var(--color-dark);
 }
-
-
-.home-service-qa-box .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .home-service-qa-box .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.home-service-qa-box .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .home-service-qa-box .pp-infobox-icon-inner span.pp-icon, .home-service-qa-box .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -4006,63 +3740,6 @@ img.mfp-img {
 .home-service-qa-box .pp-infobox .pp-more-link .pp-button-icon-right {
   margin-left: 15px;
 }
-
-
-.home-service-qa-box .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.home-service-qa-box .pp-infobox-wrap .layout-3-wrapper, .home-service-qa-box .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.home-service-qa-box .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .home-service-qa-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.home-service-qa-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .home-service-qa-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .home-service-qa-box .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .home-service-qa-box .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .home-service-qa-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .home-service-qa-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .home-service-qa-box .pp-infobox-wrap .layout-3-wrapper, .home-service-qa-box .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.home-service-qa-box .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .home-service-qa-box .pp-infobox-image img {
   width: 36px;
 }
@@ -4096,42 +3773,7 @@ img.mfp-img {
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.home-service-qa-box .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.home-service-qa-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-.fl-col-group-equal-height .home-service-product-box, .fl-col-group-equal-height .home-service-product-box .fl-module-content, .fl-col-group-equal-height .home-service-product-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .home-service-product-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .home-service-product-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .home-service-product-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 @mixin responsive-visibility do5fjakv8b29;
-
-
-.home-service-product-box .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .home-service-product-box .pp-infobox-title-wrapper .pp-infobox-title {
   color: #ffffff;
   margin-top: 30px;
@@ -4168,23 +3810,6 @@ img.mfp-img {
 .home-service-product-box .pp-infobox .pp-infobox-description:hover {
   color: var(--color-dark);
 }
-
-
-.home-service-product-box .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .home-service-product-box .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.home-service-product-box .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .home-service-product-box .pp-infobox-icon-inner span.pp-icon, .home-service-product-box .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -4238,63 +3863,6 @@ img.mfp-img {
 .home-service-product-box .pp-infobox .pp-more-link .pp-button-icon-right {
   margin-left: 15px;
 }
-
-
-.home-service-product-box .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.home-service-product-box .pp-infobox-wrap .layout-3-wrapper, .home-service-product-box .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.home-service-product-box .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .home-service-product-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.home-service-product-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .home-service-product-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .home-service-product-box .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .home-service-product-box .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .home-service-product-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .home-service-product-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .home-service-product-box .pp-infobox-wrap .layout-3-wrapper, .home-service-product-box .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.home-service-product-box .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .home-service-product-box .pp-infobox-image img {
   width: 36px;
 }
@@ -4328,44 +3896,7 @@ img.mfp-img {
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.home-service-product-box .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.home-service-product-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
-.fl-col-group-equal-height .home-service-staffing-box, .fl-col-group-equal-height .home-service-staffing-box .fl-module-content, .fl-col-group-equal-height .home-service-staffing-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .home-service-staffing-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .home-service-staffing-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .home-service-staffing-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 @mixin responsive-visibility 3eq5kcmfz0an;
-
-
-.home-service-staffing-box .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .home-service-staffing-box .pp-infobox-title-wrapper .pp-infobox-title {
   color: #ffffff;
   margin-top: 30px;
@@ -4402,23 +3933,6 @@ img.mfp-img {
 .home-service-staffing-box .pp-infobox .pp-infobox-description:hover {
   color: var(--color-dark);
 }
-
-
-.home-service-staffing-box .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .home-service-staffing-box .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.home-service-staffing-box .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .home-service-staffing-box .pp-infobox-icon-inner span.pp-icon, .home-service-staffing-box .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -4472,63 +3986,6 @@ img.mfp-img {
 .home-service-staffing-box .pp-infobox .pp-more-link .pp-button-icon-right {
   margin-left: 15px;
 }
-
-
-.home-service-staffing-box .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.home-service-staffing-box .pp-infobox-wrap .layout-3-wrapper, .home-service-staffing-box .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.home-service-staffing-box .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .home-service-staffing-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.home-service-staffing-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .home-service-staffing-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .home-service-staffing-box .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .home-service-staffing-box .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .home-service-staffing-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .home-service-staffing-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .home-service-staffing-box .pp-infobox-wrap .layout-3-wrapper, .home-service-staffing-box .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.home-service-staffing-box .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .home-service-staffing-box .pp-infobox-image img {
   width: 36px;
 }
@@ -4562,36 +4019,6 @@ img.mfp-img {
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.home-service-staffing-box .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.home-service-staffing-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
-.fl-col-group-equal-height .home-service-recruiting-box, .fl-col-group-equal-height .home-service-recruiting-box .fl-module-content, .fl-col-group-equal-height .home-service-recruiting-box .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .home-service-recruiting-box .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .home-service-recruiting-box .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .home-service-recruiting-box .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 .fl-col-group-equal-height .home-service-recruiting-box.fl-visible-large, .fl-col-group-equal-height .home-service-recruiting-box.fl-visible-medium, .fl-col-group-equal-height .home-service-recruiting-box.fl-visible-mobile {
   display: none;
 }
@@ -4660,13 +4087,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-
-.home-service-recruiting-box .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .home-service-recruiting-box .pp-infobox-title-wrapper .pp-infobox-title {
   color: #ffffff;
   margin-top: 30px;
@@ -4703,23 +4123,6 @@ img.mfp-img {
 .home-service-recruiting-box .pp-infobox .pp-infobox-description:hover {
   color: var(--color-dark);
 }
-
-
-.home-service-recruiting-box .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .home-service-recruiting-box .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.home-service-recruiting-box .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .home-service-recruiting-box .pp-infobox-icon-inner span.pp-icon, .home-service-recruiting-box .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -4773,63 +4176,6 @@ img.mfp-img {
 .home-service-recruiting-box .pp-infobox .pp-more-link .pp-button-icon-right {
   margin-left: 15px;
 }
-
-
-.home-service-recruiting-box .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.home-service-recruiting-box .pp-infobox-wrap .layout-3-wrapper, .home-service-recruiting-box .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.home-service-recruiting-box .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .home-service-recruiting-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.home-service-recruiting-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .home-service-recruiting-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .home-service-recruiting-box .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .home-service-recruiting-box .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .home-service-recruiting-box .pp-infobox-wrap .layout-2 .pp-infobox-description, .home-service-recruiting-box .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .home-service-recruiting-box .pp-infobox-wrap .layout-3-wrapper, .home-service-recruiting-box .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.home-service-recruiting-box .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .home-service-recruiting-box .pp-infobox-image img {
   width: 36px;
 }
@@ -4863,18 +4209,6 @@ img.mfp-img {
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.home-service-recruiting-box .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.home-service-recruiting-box .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
 .fl-builder-content .home-clients-eyebrow .fl-module-content .fl-rich-text, .fl-builder-content .home-clients-eyebrow .fl-module-content .fl-rich-text * {
   color: var(--color-primary);
 }

--- a/themes/beaver/assets/css/pages/services.css
+++ b/themes/beaver/assets/css/pages/services.css
@@ -1575,26 +1575,6 @@ img.mfp-img {
 .pp-infobox-wrap .layout-4 .pp-heading-wrapper {
   flex: 1;
 }
-
-
-.fl-col-group-equal-height .services-card-cto, .fl-col-group-equal-height .services-card-cto .fl-module-content, .fl-col-group-equal-height .services-card-cto .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .services-card-cto .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .services-card-cto .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .services-card-cto .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 .fl-col-group-equal-height .services-card-cto.fl-visible-large, .fl-col-group-equal-height .services-card-cto.fl-visible-medium, .fl-col-group-equal-height .services-card-cto.fl-visible-mobile {
   display: none;
 }
@@ -1663,13 +1643,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-
-.services-card-cto .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .services-card-cto .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 30px;
   margin-bottom: 0px;
@@ -1700,23 +1673,6 @@ img.mfp-img {
 
 .services-card-cto .pp-infobox .pp-infobox-description:hover {
 }
-
-
-.services-card-cto .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .services-card-cto .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.services-card-cto .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .services-card-cto .pp-infobox-icon-inner span.pp-icon, .services-card-cto .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -1769,63 +1725,6 @@ img.mfp-img {
 .services-card-cto .pp-infobox .pp-more-link .pp-button-icon-right {
   margin-left: 15px;
 }
-
-
-.services-card-cto .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.services-card-cto .pp-infobox-wrap .layout-3-wrapper, .services-card-cto .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.services-card-cto .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .services-card-cto .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.services-card-cto .pp-infobox-wrap .layout-2 .pp-infobox-description, .services-card-cto .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .services-card-cto .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .services-card-cto .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .services-card-cto .pp-infobox-wrap .layout-2 .pp-infobox-description, .services-card-cto .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .services-card-cto .pp-infobox-wrap .layout-3-wrapper, .services-card-cto .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.services-card-cto .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .services-card-cto .pp-infobox-image img {
   width: 36px;
 }
@@ -1859,36 +1758,6 @@ img.mfp-img {
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.services-card-cto .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.services-card-cto .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
-.fl-col-group-equal-height .services-card-webdev, .fl-col-group-equal-height .services-card-webdev .fl-module-content, .fl-col-group-equal-height .services-card-webdev .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .services-card-webdev .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .services-card-webdev .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .services-card-webdev .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 .fl-col-group-equal-height .services-card-webdev.fl-visible-large, .fl-col-group-equal-height .services-card-webdev.fl-visible-medium, .fl-col-group-equal-height .services-card-webdev.fl-visible-mobile {
   display: none;
 }
@@ -1957,13 +1826,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-
-.services-card-webdev .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .services-card-webdev .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 30px;
   margin-bottom: 0px;
@@ -1994,23 +1856,6 @@ img.mfp-img {
 
 .services-card-webdev .pp-infobox .pp-infobox-description:hover {
 }
-
-
-.services-card-webdev .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .services-card-webdev .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.services-card-webdev .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .services-card-webdev .pp-infobox-icon-inner span.pp-icon, .services-card-webdev .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -2063,63 +1908,6 @@ img.mfp-img {
 .services-card-webdev .pp-infobox .pp-more-link .pp-button-icon-right {
   margin-left: 15px;
 }
-
-
-.services-card-webdev .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.services-card-webdev .pp-infobox-wrap .layout-3-wrapper, .services-card-webdev .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.services-card-webdev .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .services-card-webdev .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.services-card-webdev .pp-infobox-wrap .layout-2 .pp-infobox-description, .services-card-webdev .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .services-card-webdev .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .services-card-webdev .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .services-card-webdev .pp-infobox-wrap .layout-2 .pp-infobox-description, .services-card-webdev .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .services-card-webdev .pp-infobox-wrap .layout-3-wrapper, .services-card-webdev .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.services-card-webdev .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .services-card-webdev .pp-infobox-image img {
   width: 30px;
 }
@@ -2153,36 +1941,6 @@ img.mfp-img {
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.services-card-webdev .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.services-card-webdev .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
-.fl-col-group-equal-height .services-card-qa, .fl-col-group-equal-height .services-card-qa .fl-module-content, .fl-col-group-equal-height .services-card-qa .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .services-card-qa .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .services-card-qa .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .services-card-qa .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 .fl-col-group-equal-height .services-card-qa.fl-visible-large, .fl-col-group-equal-height .services-card-qa.fl-visible-medium, .fl-col-group-equal-height .services-card-qa.fl-visible-mobile {
   display: none;
 }
@@ -2251,13 +2009,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-
-.services-card-qa .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .services-card-qa .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 30px;
   margin-bottom: 0px;
@@ -2288,23 +2039,6 @@ img.mfp-img {
 
 .services-card-qa .pp-infobox .pp-infobox-description:hover {
 }
-
-
-.services-card-qa .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .services-card-qa .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.services-card-qa .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .services-card-qa .pp-infobox-icon-inner span.pp-icon, .services-card-qa .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -2357,63 +2091,6 @@ img.mfp-img {
 .services-card-qa .pp-infobox .pp-more-link .pp-button-icon-right {
   margin-left: 15px;
 }
-
-
-.services-card-qa .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.services-card-qa .pp-infobox-wrap .layout-3-wrapper, .services-card-qa .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.services-card-qa .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .services-card-qa .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.services-card-qa .pp-infobox-wrap .layout-2 .pp-infobox-description, .services-card-qa .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .services-card-qa .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .services-card-qa .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .services-card-qa .pp-infobox-wrap .layout-2 .pp-infobox-description, .services-card-qa .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .services-card-qa .pp-infobox-wrap .layout-3-wrapper, .services-card-qa .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.services-card-qa .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .services-card-qa .pp-infobox-image img {
   width: 36px;
 }
@@ -2447,34 +2124,6 @@ img.mfp-img {
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.services-card-qa .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.services-card-qa .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-.fl-col-group-equal-height .services-card-product, .fl-col-group-equal-height .services-card-product .fl-module-content, .fl-col-group-equal-height .services-card-product .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .services-card-product .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .services-card-product .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .services-card-product .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 .fl-col-group-equal-height .services-card-product.fl-visible-large, .fl-col-group-equal-height .services-card-product.fl-visible-medium, .fl-col-group-equal-height .services-card-product.fl-visible-mobile {
   display: none;
 }
@@ -2543,13 +2192,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-
-.services-card-product .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .services-card-product .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 30px;
   margin-bottom: 0px;
@@ -2580,23 +2222,6 @@ img.mfp-img {
 
 .services-card-product .pp-infobox .pp-infobox-description:hover {
 }
-
-
-.services-card-product .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .services-card-product .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.services-card-product .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .services-card-product .pp-infobox-icon-inner span.pp-icon, .services-card-product .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -2649,63 +2274,6 @@ img.mfp-img {
 .services-card-product .pp-infobox .pp-more-link .pp-button-icon-right {
   margin-left: 15px;
 }
-
-
-.services-card-product .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.services-card-product .pp-infobox-wrap .layout-3-wrapper, .services-card-product .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.services-card-product .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .services-card-product .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.services-card-product .pp-infobox-wrap .layout-2 .pp-infobox-description, .services-card-product .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .services-card-product .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .services-card-product .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .services-card-product .pp-infobox-wrap .layout-2 .pp-infobox-description, .services-card-product .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .services-card-product .pp-infobox-wrap .layout-3-wrapper, .services-card-product .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.services-card-product .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .services-card-product .pp-infobox-image img {
   width: 36px;
 }
@@ -2739,36 +2307,6 @@ img.mfp-img {
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.services-card-product .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.services-card-product .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
-.fl-col-group-equal-height .services-card-staffing, .fl-col-group-equal-height .services-card-staffing .fl-module-content, .fl-col-group-equal-height .services-card-staffing .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .services-card-staffing .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .services-card-staffing .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .services-card-staffing .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 .fl-col-group-equal-height .services-card-staffing.fl-visible-large, .fl-col-group-equal-height .services-card-staffing.fl-visible-medium, .fl-col-group-equal-height .services-card-staffing.fl-visible-mobile {
   display: none;
 }
@@ -2837,13 +2375,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-
-.services-card-staffing .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .services-card-staffing .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 30px;
   margin-bottom: 0px;
@@ -2874,23 +2405,6 @@ img.mfp-img {
 
 .services-card-staffing .pp-infobox .pp-infobox-description:hover {
 }
-
-
-.services-card-staffing .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .services-card-staffing .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.services-card-staffing .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .services-card-staffing .pp-infobox-icon-inner span.pp-icon, .services-card-staffing .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -2943,63 +2457,6 @@ img.mfp-img {
 .services-card-staffing .pp-infobox .pp-more-link .pp-button-icon-right {
   margin-left: 15px;
 }
-
-
-.services-card-staffing .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.services-card-staffing .pp-infobox-wrap .layout-3-wrapper, .services-card-staffing .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.services-card-staffing .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .services-card-staffing .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.services-card-staffing .pp-infobox-wrap .layout-2 .pp-infobox-description, .services-card-staffing .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .services-card-staffing .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .services-card-staffing .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .services-card-staffing .pp-infobox-wrap .layout-2 .pp-infobox-description, .services-card-staffing .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .services-card-staffing .pp-infobox-wrap .layout-3-wrapper, .services-card-staffing .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.services-card-staffing .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .services-card-staffing .pp-infobox-image img {
   width: 36px;
 }
@@ -3033,36 +2490,6 @@ img.mfp-img {
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.services-card-staffing .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.services-card-staffing .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
-.fl-col-group-equal-height .services-card-recruiting, .fl-col-group-equal-height .services-card-recruiting .fl-module-content, .fl-col-group-equal-height .services-card-recruiting .fl-module-content .pp-infobox-wrap, .fl-col-group-equal-height .services-card-recruiting .fl-module-content .pp-infobox-wrap .pp-infobox, .fl-col-group-equal-height .services-card-recruiting .fl-module-content .pp-infobox-wrap > .pp-infobox-link, .fl-col-group-equal-height .services-card-recruiting .fl-module-content .pp-infobox-wrap > .pp-more-link {
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  flex-shrink: 1;
-  min-width: 1px;
-  max-width: 100%;
-  -webkit-box-flex: 1 1 auto;
-  -moz-box-flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-
 .fl-col-group-equal-height .services-card-recruiting.fl-visible-large, .fl-col-group-equal-height .services-card-recruiting.fl-visible-medium, .fl-col-group-equal-height .services-card-recruiting.fl-visible-mobile {
   display: none;
 }
@@ -3131,13 +2558,6 @@ img.mfp-img {
     display: flex;
   }
 }
-
-
-.services-card-recruiting .pp-infobox .pp-infobox-title-prefix {
-  display: none;
-}
-
-
 .services-card-recruiting .pp-infobox-title-wrapper .pp-infobox-title {
   margin-top: 30px;
   margin-bottom: 0px;
@@ -3168,23 +2588,6 @@ img.mfp-img {
 
 .services-card-recruiting .pp-infobox .pp-infobox-description:hover {
 }
-
-
-.services-card-recruiting .pp-infobox-image {
-  text-align: left
-}
-
-
-.fl-builder-content .services-card-recruiting .pp-infobox-image img {
-  height: auto;
-  max-width: 100%;
-}
-
-
-.services-card-recruiting .pp-infobox:hover .pp-infobox-image img {
-}
-
-
 .services-card-recruiting .pp-infobox-icon-inner span.pp-icon, .services-card-recruiting .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
@@ -3237,63 +2640,6 @@ img.mfp-img {
 .services-card-recruiting .pp-infobox .pp-more-link .pp-button-icon-right {
   margin-left: 15px;
 }
-
-
-.services-card-recruiting .pp-infobox .animated {
-  -webkit-animation-duration: 500ms;
-  -moz-animation-duration: 500ms;
-  -o-animation-duration: 500ms;
-  -ms-animation-duration: 500ms;
-  animation-duration: 500ms;
-}
-
-
-.services-card-recruiting .pp-infobox-wrap .layout-3-wrapper, .services-card-recruiting .pp-infobox-wrap .layout-4-wrapper {
-}
-
-
-.services-card-recruiting .pp-infobox-wrap .layout-1 .pp-heading-wrapper, .services-card-recruiting .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  display: flex;
-  align-items: center;
-}
-
-
-.services-card-recruiting .pp-infobox-wrap .layout-2 .pp-infobox-description, .services-card-recruiting .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-  float: left;
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .services-card-recruiting .pp-infobox {
-    text-align: left;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .services-card-recruiting .pp-infobox-wrap .pp-infobox {
-    text-align: left;
-  }
-
-  .services-card-recruiting .pp-infobox-wrap .layout-2 .pp-infobox-description, .services-card-recruiting .pp-infobox-wrap .layout-2 .pp-heading-wrapper {
-    float: left;
-  }
-}
-
-
-@media only screen and (max-width: 480px) {
-  .services-card-recruiting .pp-infobox-wrap .layout-3-wrapper, .services-card-recruiting .pp-infobox-wrap .layout-4-wrapper {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-
-.services-card-recruiting .pp-infobox-title-wrapper .pp-infobox-title {
-  font-size: 22px;
-}
-
-
 .fl-builder-content .services-card-recruiting .pp-infobox-image img {
   width: 36px;
 }
@@ -3327,18 +2673,6 @@ img.mfp-img {
   margin-bottom: 0px;
   margin-left: 0px;
 }
-
-
-.services-card-recruiting .pp-infobox-wrap .layout-3 .pp-icon-wrapper {
-  margin-right: 10px;
-}
-
-
-.services-card-recruiting .pp-infobox-wrap .layout-4 .pp-icon-wrapper {
-  margin-left: 10px;
-}
-
-
 img.mfp-img {
   padding-bottom: 40px !important;
 }

--- a/themes/beaver/layouts/home.html
+++ b/themes/beaver/layouts/home.html
@@ -336,7 +336,7 @@
                           data-node="paujk1bwfe0l">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox home-service-cto-box jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card home-service-cto-box jt-service-box"
                               data-node="dxali8vntcr0">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -390,7 +390,7 @@
                           data-node="9xrz1vbyfomu">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox home-service-web-dev-box jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card home-service-web-dev-box jt-service-box"
                               data-node="075ztwhd3cxn">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -444,7 +444,7 @@
                           data-node="dcks70njr95q">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox home-service-qa-box jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card home-service-qa-box jt-service-box"
                               data-node="lajty926uxf5">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -519,7 +519,7 @@
                           data-node="reqazbvwfnj9">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox home-service-product-box jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card home-service-product-box jt-service-box"
                               data-node="do5fjakv8b29">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -573,7 +573,7 @@
                           data-node="5syfq06jvt8x">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox home-service-staffing-box jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card home-service-staffing-box jt-service-box"
                               data-node="3eq5kcmfz0an">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -627,7 +627,7 @@
                           data-node="r5mpnlqz427o">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox home-service-recruiting-box jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card home-service-recruiting-box jt-service-box"
                               data-node="v3gpr4klqmob">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">

--- a/themes/beaver/layouts/page/about.html
+++ b/themes/beaver/layouts/page/about.html
@@ -3,6 +3,7 @@
     (resources.Get "css/critical/base.css")
     (resources.Get "css/critical/about-us-critical.css")
     (resources.Get "css/components/testimonials.css")
+    (resources.Get "css/components/info-card.css")
     (resources.Get "css/components/cta-banner.css")
     (resources.Get "css/pages/about-us.css")
     (resources.Get "css/legacy-theme-skin.css")
@@ -205,7 +206,7 @@
                           data-node="h1byus7aprfd">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox about-value-trust"
+                              class="fl-module fl-module-pp-infobox jt-info-card about-value-trust"
                               data-node="5tmpu20yerbq">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -242,7 +243,7 @@
                           data-node="p3acnwe42skd">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox about-value-alignment"
+                              class="fl-module fl-module-pp-infobox jt-info-card about-value-alignment"
                               data-node="k0y7grmbj6n8">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -279,7 +280,7 @@
                           data-node="bzo12nhdvj97">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox about-value-reliability"
+                              class="fl-module fl-module-pp-infobox jt-info-card about-value-reliability"
                               data-node="g5t28lcnjfkh">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">

--- a/themes/beaver/layouts/page/careers.html
+++ b/themes/beaver/layouts/page/careers.html
@@ -175,7 +175,7 @@
                           data-node="yx43bujcaiqn">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox careers-value-people-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-people-box"
                               data-node="2qjtxd5mnu0o">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -211,7 +211,7 @@
                           data-node="ktz4ipj39vd6">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox careers-value-longterm-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-longterm-box"
                               data-node="fsx06y1qr7am">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -248,7 +248,7 @@
                           data-node="m39uvorzy5g8">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox careers-value-team-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-team-box"
                               data-node="t9y6kecruwx0">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -308,7 +308,7 @@
                           data-node="oxvacq3nkrmt">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox careers-value-flexibility-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-flexibility-box"
                               data-node="7dpf8coyqrj1">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -346,7 +346,7 @@
                           data-node="j89kuaibv574">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox careers-value-growth-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-growth-box"
                               data-node="silug3152ocd">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -383,7 +383,7 @@
                           data-node="gz025t4lvoui">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox careers-value-training-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-training-box"
                               data-node="xowkfsrzlcn8">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">

--- a/themes/beaver/layouts/page/services.html
+++ b/themes/beaver/layouts/page/services.html
@@ -3,6 +3,7 @@
     (resources.Get "css/critical/base.css")
     (resources.Get "css/critical/services-critical.css")
     (resources.Get "css/components/testimonials.css")
+    (resources.Get "css/components/info-card.css")
     (resources.Get "css/components/cta-banner.css")
     (resources.Get "css/components/header-cta.css")
     (resources.Get "css/pages/services.css")
@@ -104,7 +105,7 @@
                           data-node="7jz6cas305te">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox services-card-cto jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card services-card-cto jt-service-box"
                               data-node="0pigeztak1xl">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -158,7 +159,7 @@
                           data-node="rxpuo06w93bn">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox services-card-webdev jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card services-card-webdev jt-service-box"
                               data-node="ugiypbhnvlfw">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -212,7 +213,7 @@
                           data-node="aj2ch9vn5k1w">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox services-card-qa jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card services-card-qa jt-service-box"
                               data-node="h2wjp3zb7afk">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -287,7 +288,7 @@
                           data-node="r0jkz1qcfsgp">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox services-card-product jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card services-card-product jt-service-box"
                               data-node="nwx7eiysakvl">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -341,7 +342,7 @@
                           data-node="w4f3716ghpvs">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox services-card-staffing jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card services-card-staffing jt-service-box"
                               data-node="a5khmr6nto3z">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -395,7 +396,7 @@
                           data-node="6ogabjsdei1h">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox services-card-recruiting jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card services-card-recruiting jt-service-box"
                               data-node="2ufxtslray80">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">

--- a/themes/beaver/layouts/partials/assets/careers-css-resources.html
+++ b/themes/beaver/layouts/partials/assets/careers-css-resources.html
@@ -3,7 +3,8 @@
 {{- return (slice
   (resources.Get "css/critical/careers-critical.css")
   (resources.Get "css/careers.css")
-  (resources.Get "css/components/info-card.css")  (resources.Get "css/pages/careers.css")
+  (resources.Get "css/components/info-card.css")
+  (resources.Get "css/pages/careers.css")
   (resources.Get "css/dynamic-icons.css" | resources.ExecuteAsTemplate "css/dynamic586.css" .)
   (resources.Get "css/586.css")
   (resources.Get "css/homepage.css")

--- a/themes/beaver/layouts/partials/assets/careers-css-resources.html
+++ b/themes/beaver/layouts/partials/assets/careers-css-resources.html
@@ -3,7 +3,7 @@
 {{- return (slice
   (resources.Get "css/critical/careers-critical.css")
   (resources.Get "css/careers.css")
-  (resources.Get "css/pages/careers.css")
+  (resources.Get "css/components/info-card.css")  (resources.Get "css/pages/careers.css")
   (resources.Get "css/dynamic-icons.css" | resources.ExecuteAsTemplate "css/dynamic586.css" .)
   (resources.Get "css/586.css")
   (resources.Get "css/homepage.css")

--- a/themes/beaver/layouts/partials/assets/homepage-css-resources.html
+++ b/themes/beaver/layouts/partials/assets/homepage-css-resources.html
@@ -8,6 +8,7 @@
   (resources.Get "css/homepage.css")
   (resources.Get "css/dynamic-404.css" | resources.ExecuteAsTemplate "css/dynamic.css" .)
   (resources.Get "css/components/testimonials.css")
+  (resources.Get "css/components/info-card.css")
   (resources.Get "css/components/cta-banner.css")
   (resources.Get "css/pages/homepage.css")
   (resources.Get "css/legacy-theme-skin.css")


### PR DESCRIPTION
## What this is

**Phase E — the paved path**, per Paul's mandate: a person must be able to create a new page from scratch reusing existing components, consistently.

## E1 — `components/info-card.css` (`.jt-info-card`)

The pp-infobox card pattern repeated **21×** across homepage (6), services (6), about-us (3), careers (6), each under page-specific class names. The measured 16-rule intersection of all 21 instances now lives once, applied via the **additive** `jt-info-card` class on each card module — 336 rule-instances deleted from the four page files. Page variants (hover colors, equal-height framework, media tweaks) stay page-side and win by concat position; the tie-scan found one systematic selector+property tie (text-align) with identical values on both sides. Greedy purge entry `/^jt-info-card/` added per the C2 lesson.

**Gates**: only the 4 card-page bundles' fingerprints changed; scoped screenshot gate green on all four; full macOS suite 65/119 zero failures, zero baseline changes; Linux `dtest-all` EXIT=0.

## E3 — `docs/workflows/new-page.md`

The complete recipe: template shell, the load-bearing bundle-slice order, the component reuse table (testimonials, cta-banner, **info-card**, header-cta, technologies), design tokens, and the traps that each bit a real sprint — `@import` only works in the prelude, `bundleName` collisions race, the PurgeCSS greedy-prefix requirement, qtest/tests/ownership-map wiring, the baseline-overwrite recovery.

## Still in Phase E (tracker):

- E2 stat-row component (about/home/service counter rows) — same measured-intersection protocol.
- E4 (optional): collapse the 6 inline CTA template copies onto the partial — copies diverge at outer wrappers, needs per-page params + visual gates; the partial is already usable for new pages today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYRU9wGepomJo5hSuqtu7V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared styling for information cards across the About, Careers, Home, and Services pages.
  - Standardized card layouts, icon sizing, rounded corners, spacing, and responsive behavior.
  - Improved equal-height card presentation across desktop, tablet, and mobile breakpoints.

- **Bug Fixes**
  - Preserved required component styles from being removed during CSS optimization.

- **Documentation**
  - Added guidance for creating new pages with reusable components, responsive styles, testing, and visual verification.
  - Documented required CSS ordering and page configuration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->