### PR TITLE
CSS Sprint E-2: component library finished - 450-copy card consolidation, jt-reviews-box restored, starter template

### DIFF
--- a/bin/qtest
+++ b/bin/qtest
@@ -47,9 +47,15 @@ PAGE_TESTS = {
 
 # extend as C1 adds components
 TESTIMONIALS_CONSUMERS = %w[about-us clients services homepage single-use-cases single-service use-cases].freeze
+CARD_PAGES = %w[homepage services about-us careers].freeze
+CTA_PAGES = %w[about-us homepage services single-service single-use-cases use-cases].freeze
 COMPONENT_CONSUMERS = {
   "themes/beaver/assets/css/components/testimonials.css" => TESTIMONIALS_CONSUMERS,
-  "themes/beaver/layouts/partials/page/testimonials.html" => TESTIMONIALS_CONSUMERS
+  "themes/beaver/layouts/partials/page/testimonials.html" => TESTIMONIALS_CONSUMERS,
+  "themes/beaver/assets/css/components/info-card.css" => CARD_PAGES,
+  "themes/beaver/assets/css/components/cta-banner.css" => CTA_PAGES,
+  "themes/beaver/layouts/partials/page/cta.html" => CTA_PAGES,
+  "themes/beaver/assets/css/components/header-cta.css" => %w[use-cases clients services]
 }.freeze
 
 def pages_for(file)

--- a/docs/workflows/new-page.md
+++ b/docs/workflows/new-page.md
@@ -55,7 +55,7 @@ TRAPS:
 |---|---|---|
 | Testimonials section | `{{ partial "page/testimonials.html" . }}` | `components/testimonials.css` |
 | CTA banner ("Let's get started now") | `{{ partial "page/cta.html" . }}` | `components/cta-banner.css` |
-| Info card (pp-infobox) | `<div class="fl-module fl-module-pp-infobox jt-info-card <name>-card-x">` + pp-infobox markup (copy one instance from `page/services.html`) | `components/info-card.css` |
+| Info card (pp-infobox) | `<div class="fl-module fl-module-pp-infobox jt-info-card <name>-card <name>-card-x">` + pp-infobox markup (copy one instance from `page/services.html`) | `components/info-card.css` |
 | Header CTA trio | (only if the page renders the bf72bba header variant) | `components/header-cta.css` |
 | Technologies strip | `{{ partial "technologies.html" (dict "colorVariant" "dark") }}` | `technologies.css` |
 
@@ -97,3 +97,20 @@ bin/test && bin/dtest     # both platforms before the PR
 FORCE_SCREENSHOT_UPDATE=true regenerates baselines (commit macos/ AND
 linux/ together). A failing screenshot run overwrites baselines — restore
 via `git checkout -- test/fixtures/screenshots` before rerunning.
+
+## Patterns that are deliberately NOT components (measured 2026-07-19)
+
+- **Heroes**: cross-page intersection is 1 trivial rule - heroes are
+  page-unique by design. Build yours under `.<name>-hero` with tokens;
+  copy the closest existing hero as a starting point.
+- **Stat/counter rows**: pages structure them differently (per-stat
+  classes vs one shared class) - no forced component. Recipe: a col per
+  stat, `jt-counter-number` on the number (JS hook), label below, all
+  styled under your page prefix.
+
+## Card class tiers
+
+`jt-info-card <page>-card <instance>` - global 16-rule core (component)
+-> page core (in pages/<name>.css) -> instance tweaks. Copy an instance
+from page/services.html; the starter template shows the shape
+(themes/beaver/layouts/page/starter-example.html.txt).

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -55,6 +55,11 @@ const purgecss = createPurgeCss({
       // runtime classes like pp-swiper-button/pp-review-image are never in
       // hugo_stats.json, so without this the renamed rules get purged).
       /^testimonials-/, /^cta-banner/, /^jt-info-card/, /^career-/, /^clients-/,
+      // jt-reviews-box restoration (decision: Claude per Paul delegation
+      // 2026-07-19): the intended testimonial-slider design (arrow nav,
+      // card refinements) was silently purged because pp-swiper/pp-review
+      // runtime classes had no shield. Restored deliberately.
+      /^pp-swiper/, /^pp-review/,
       /^notfound-/, /^use-case-/, /^services-/, /^service-/, /^about-/, /^home-/, /^careers-/,
       // Brand CTA buttons — preserve any selector mentioning these classes.
       // Standard safelist didn't catch tag+class compound selectors like

--- a/themes/beaver/assets/css/pages/about-us.css
+++ b/themes/beaver/assets/css/pages/about-us.css
@@ -1525,230 +1525,8 @@ img.mfp-img {
 .pp-infobox-wrap .layout-4 .pp-heading-wrapper {
   flex: 1;
 }
-.fl-col-group-equal-height .about-value-trust.fl-visible-large, .fl-col-group-equal-height .about-value-trust.fl-visible-medium, .fl-col-group-equal-height .about-value-trust.fl-visible-mobile {
-  display: none;
-}
-
-
-.fl-col-group-equal-height .about-value-trust.fl-visible-desktop {
-  display: flex;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-center .about-value-trust .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-top .about-value-trust .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .about-value-trust .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .about-value-trust.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-trust.fl-visible-large {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .about-value-trust.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-trust.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-trust.fl-visible-medium {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .about-value-trust.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-trust.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-trust.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-trust.fl-visible-mobile {
-    display: flex;
-  }
-}
-.about-value-trust .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 25px;
-  margin-bottom: 0px;
-}
-
-
-.about-value-trust .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-
-.about-value-trust .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.about-value-trust .pp-infobox:hover .pp-infobox-title-prefix {
-}
-
-
-.about-value-trust .pp-infobox:hover .pp-infobox-title {
-}
-
-
-.about-value-trust .pp-infobox:hover .pp-infobox-title a {
-}
-
-
-.about-value-trust .pp-infobox:hover .pp-infobox-description {
-}
 .about-value-trust .pp-infobox-icon-inner span.pp-icon, .about-value-trust .pp-infobox-image img {
   border-radius: px;
-}
-
-
-.about-value-trust .pp-infobox-wrap .pp-infobox {
-  background: rgba(245, 246, 248, 0);
-  text-align: left;
-}
-
-
-.about-value-trust .pp-infobox:hover {
-  background: rgba(245, 246, 248, 0);
-}
-.fl-builder-content .about-value-trust .pp-infobox-image img {
-  width: 37px;
-}
-
-
-.about-value-trust .pp-infobox {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-.fl-col-group-equal-height .about-value-alignment.fl-visible-large, .fl-col-group-equal-height .about-value-alignment.fl-visible-medium, .fl-col-group-equal-height .about-value-alignment.fl-visible-mobile {
-  display: none;
-}
-
-
-.fl-col-group-equal-height .about-value-alignment.fl-visible-desktop {
-  display: flex;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-center .about-value-alignment .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-top .about-value-alignment .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .about-value-alignment .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .about-value-alignment.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-alignment.fl-visible-large {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .about-value-alignment.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-alignment.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-alignment.fl-visible-medium {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .about-value-alignment.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-alignment.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-alignment.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-alignment.fl-visible-mobile {
-    display: flex;
-  }
-}
-.about-value-alignment .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 25px;
-  margin-bottom: 0px;
-}
-
-
-.about-value-alignment .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-
-.about-value-alignment .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.about-value-alignment .pp-infobox:hover .pp-infobox-title-prefix {
-}
-
-
-.about-value-alignment .pp-infobox:hover .pp-infobox-title {
-}
-
-
-.about-value-alignment .pp-infobox:hover .pp-infobox-title a {
-}
-
-
-.about-value-alignment .pp-infobox:hover .pp-infobox-description {
 }
 .about-value-alignment .pp-infobox-icon-inner span.pp-icon, .about-value-alignment .pp-infobox-image img {
   border-top-left-radius: px;
@@ -1756,161 +1534,11 @@ img.mfp-img {
   border-bottom-left-radius: px;
   border-bottom-right-radius: px;
 }
-
-
-.about-value-alignment .pp-infobox-wrap .pp-infobox {
-  background: rgba(245, 246, 248, 0);
-  text-align: left;
-}
-
-
-.about-value-alignment .pp-infobox:hover {
-  background: rgba(245, 246, 248, 0);
-}
-.fl-builder-content .about-value-alignment .pp-infobox-image img {
-  width: 37px;
-}
-
-
-.about-value-alignment .pp-infobox {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-.fl-col-group-equal-height .about-value-reliability.fl-visible-large, .fl-col-group-equal-height .about-value-reliability.fl-visible-medium, .fl-col-group-equal-height .about-value-reliability.fl-visible-mobile {
-  display: none;
-}
-
-
-.fl-col-group-equal-height .about-value-reliability.fl-visible-desktop {
-  display: flex;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-center .about-value-reliability .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-top .about-value-reliability .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .about-value-reliability .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .about-value-reliability.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-reliability.fl-visible-large {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .about-value-reliability.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-reliability.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-reliability.fl-visible-medium {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .about-value-reliability.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-reliability.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-reliability.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .about-value-reliability.fl-visible-mobile {
-    display: flex;
-  }
-}
-.about-value-reliability .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 25px;
-  margin-bottom: 0px;
-}
-
-
-.about-value-reliability .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-
-.about-value-reliability .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.about-value-reliability .pp-infobox:hover .pp-infobox-title-prefix {
-}
-
-
-.about-value-reliability .pp-infobox:hover .pp-infobox-title {
-}
-
-
-.about-value-reliability .pp-infobox:hover .pp-infobox-title a {
-}
-
-
-.about-value-reliability .pp-infobox:hover .pp-infobox-description {
-}
 .about-value-reliability .pp-infobox-icon-inner span.pp-icon, .about-value-reliability .pp-infobox-image img {
   border-top-left-radius: px;
   border-top-right-radius: px;
   border-bottom-left-radius: px;
   border-bottom-right-radius: px;
-}
-
-
-.about-value-reliability .pp-infobox-wrap .pp-infobox {
-  background: rgba(245, 246, 248, 0);
-  text-align: left;
-}
-
-
-.about-value-reliability .pp-infobox:hover {
-  background: rgba(245, 246, 248, 0);
-}
-.fl-builder-content .about-value-reliability .pp-infobox-image img {
-  width: 37px;
-}
-
-
-.about-value-reliability .pp-infobox {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
 }
 .fl-builder-content .about-achievements-eyebrow .fl-module-content .fl-rich-text, .fl-builder-content .about-achievements-eyebrow .fl-module-content .fl-rich-text * {
   color: var(--color-primary);
@@ -2645,4 +2273,149 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 
 .about-testimonials-cta .fl-row-content {
   min-width: 0px;
+}
+/* Page card core - shared by the 3 about-value-card instances (Phase E-2);
+   per-instance keeps stay under their own classes and win by later position. */
+
+.fl-col-group-equal-height .about-value-card.fl-visible-large, .fl-col-group-equal-height .about-value-card.fl-visible-medium, .fl-col-group-equal-height .about-value-card.fl-visible-mobile {
+  display: none;
+}
+
+
+
+.fl-col-group-equal-height .about-value-card.fl-visible-desktop {
+  display: flex;
+}
+
+
+
+.fl-col-group-equal-height.fl-col-group-align-center .about-value-card .fl-module-content .pp-infobox-wrap .pp-infobox {
+  justify-content: center;
+}
+
+
+
+.fl-col-group-equal-height.fl-col-group-align-top .about-value-card .fl-module-content .pp-infobox-wrap .pp-infobox {
+  justify-content: flex-start;
+}
+
+
+
+.fl-col-group-equal-height.fl-col-group-align-bottom .about-value-card .fl-module-content .pp-infobox-wrap .pp-infobox {
+  justify-content: flex-end;
+}
+@media only screen and (max-width: 1200px) {
+
+  .fl-col-group-equal-height .about-value-card.fl-visible-desktop {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .about-value-card.fl-visible-large {
+    display: flex;
+  }
+}
+@media only screen and (max-width: 1115px) {
+
+  .fl-col-group-equal-height .about-value-card.fl-visible-desktop {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .about-value-card.fl-visible-large {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .about-value-card.fl-visible-medium {
+    display: flex;
+  }
+}
+@media only screen and (max-width: 860px) {
+
+  .fl-col-group-equal-height .about-value-card.fl-visible-desktop {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .about-value-card.fl-visible-large {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .about-value-card.fl-visible-medium {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .about-value-card.fl-visible-mobile {
+    display: flex;
+  }
+}
+
+.about-value-card .pp-infobox-title-wrapper .pp-infobox-title {
+  margin-top: 25px;
+  margin-bottom: 0px;
+}
+
+
+
+.about-value-card .pp-infobox-title-wrapper .pp-infobox-title a {
+}
+
+
+
+.about-value-card .pp-infobox-description {
+  margin-top: 15px;
+  margin-bottom: 0px;
+}
+
+
+
+.about-value-card .pp-infobox:hover .pp-infobox-title-prefix {
+}
+
+
+
+.about-value-card .pp-infobox:hover .pp-infobox-title {
+}
+
+
+
+.about-value-card .pp-infobox:hover .pp-infobox-title a {
+}
+
+
+
+.about-value-card .pp-infobox:hover .pp-infobox-description {
+}
+
+
+
+.about-value-card .pp-infobox-wrap .pp-infobox {
+  background: rgba(245, 246, 248, 0);
+  text-align: left;
+}
+
+
+
+.about-value-card .pp-infobox:hover {
+  background: rgba(245, 246, 248, 0);
+}
+
+.fl-builder-content .about-value-card .pp-infobox-image img {
+  width: 37px;
+}
+
+
+
+.about-value-card .pp-infobox {
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-left-radius: 14px;
+  border-bottom-right-radius: 14px;
 }

--- a/themes/beaver/assets/css/pages/careers.css
+++ b/themes/beaver/assets/css/pages/careers.css
@@ -1454,708 +1454,6 @@ img.mfp-img {
 
 @media (max-width: 860px) {
 }
-.fl-col-group-equal-height .careers-value-people-box.fl-visible-large, .fl-col-group-equal-height .careers-value-people-box.fl-visible-medium, .fl-col-group-equal-height .careers-value-people-box.fl-visible-mobile {
-  display: none;
-}
-
-.fl-col-group-equal-height .careers-value-people-box.fl-visible-desktop {
-  display: flex;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-center .careers-value-people-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-top .careers-value-people-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .careers-value-people-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .careers-value-people-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-people-box.fl-visible-large {
-    display: flex;
-  }
-}
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .careers-value-people-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-people-box.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-people-box.fl-visible-medium {
-    display: flex;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .careers-value-people-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-people-box.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-people-box.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-people-box.fl-visible-mobile {
-    display: flex;
-  }
-}
-.careers-value-people-box .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-.careers-value-people-box .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-.careers-value-people-box .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-.careers-value-people-box .pp-infobox:hover .pp-infobox-title-prefix {
-}
-
-.careers-value-people-box .pp-infobox:hover .pp-infobox-title {
-}
-
-.careers-value-people-box .pp-infobox:hover .pp-infobox-title a {
-}
-
-.careers-value-people-box .pp-infobox:hover .pp-infobox-description {
-}
-.careers-value-people-box .pp-infobox-icon-inner span.pp-icon, .careers-value-people-box .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-.careers-value-people-box .pp-infobox-wrap .pp-infobox {
-  text-align: left;
-}
-
-.careers-value-people-box .pp-infobox:hover {
-}
-.fl-builder-content .careers-value-people-box .pp-infobox-image img {
-  width: 35px;
-}
-
-.careers-value-people-box .pp-infobox {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-.careers-value-people-box .pp-more-link {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  font-weight: 700;
-}
-.fl-col-group-equal-height .careers-value-longterm-box.fl-visible-large, .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-medium, .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-mobile {
-  display: none;
-}
-
-.fl-col-group-equal-height .careers-value-longterm-box.fl-visible-desktop {
-  display: flex;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-center .careers-value-longterm-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-top .careers-value-longterm-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .careers-value-longterm-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-large {
-    display: flex;
-  }
-}
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-medium {
-    display: flex;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-longterm-box.fl-visible-mobile {
-    display: flex;
-  }
-}
-.careers-value-longterm-box .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-.careers-value-longterm-box .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-.careers-value-longterm-box .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-.careers-value-longterm-box .pp-infobox:hover .pp-infobox-title-prefix {
-}
-
-.careers-value-longterm-box .pp-infobox:hover .pp-infobox-title {
-}
-
-.careers-value-longterm-box .pp-infobox:hover .pp-infobox-title a {
-}
-
-.careers-value-longterm-box .pp-infobox:hover .pp-infobox-description {
-}
-.careers-value-longterm-box .pp-infobox-icon-inner span.pp-icon, .careers-value-longterm-box .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-.careers-value-longterm-box .pp-infobox-wrap .pp-infobox {
-  text-align: left;
-}
-
-.careers-value-longterm-box .pp-infobox:hover {
-}
-.fl-builder-content .careers-value-longterm-box .pp-infobox-image img {
-  width: 35px;
-}
-
-.careers-value-longterm-box .pp-infobox {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-.careers-value-longterm-box .pp-more-link {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  font-weight: 700;
-}
-.fl-col-group-equal-height .careers-value-team-box.fl-visible-large, .fl-col-group-equal-height .careers-value-team-box.fl-visible-medium, .fl-col-group-equal-height .careers-value-team-box.fl-visible-mobile {
-  display: none;
-}
-
-.fl-col-group-equal-height .careers-value-team-box.fl-visible-desktop {
-  display: flex;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-center .careers-value-team-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-top .careers-value-team-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .careers-value-team-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .careers-value-team-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-team-box.fl-visible-large {
-    display: flex;
-  }
-}
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .careers-value-team-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-team-box.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-team-box.fl-visible-medium {
-    display: flex;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .careers-value-team-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-team-box.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-team-box.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-team-box.fl-visible-mobile {
-    display: flex;
-  }
-}
-.careers-value-team-box .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-.careers-value-team-box .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-.careers-value-team-box .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-.careers-value-team-box .pp-infobox:hover .pp-infobox-title-prefix {
-}
-
-.careers-value-team-box .pp-infobox:hover .pp-infobox-title {
-}
-
-.careers-value-team-box .pp-infobox:hover .pp-infobox-title a {
-}
-
-.careers-value-team-box .pp-infobox:hover .pp-infobox-description {
-}
-.careers-value-team-box .pp-infobox-icon-inner span.pp-icon, .careers-value-team-box .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-.careers-value-team-box .pp-infobox-wrap .pp-infobox {
-  text-align: left;
-}
-
-.careers-value-team-box .pp-infobox:hover {
-}
-.fl-builder-content .careers-value-team-box .pp-infobox-image img {
-  width: 35px;
-}
-
-.careers-value-team-box .pp-infobox {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-.careers-value-team-box .pp-more-link {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  font-weight: 700;
-}
-.fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-large, .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-medium, .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-mobile {
-  display: none;
-}
-
-.fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-desktop {
-  display: flex;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-center .careers-value-flexibility-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-top .careers-value-flexibility-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .careers-value-flexibility-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-large {
-    display: flex;
-  }
-}
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-medium {
-    display: flex;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-flexibility-box.fl-visible-mobile {
-    display: flex;
-  }
-}
-.careers-value-flexibility-box .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-.careers-value-flexibility-box .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-.careers-value-flexibility-box .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-.careers-value-flexibility-box .pp-infobox:hover .pp-infobox-title-prefix {
-}
-
-.careers-value-flexibility-box .pp-infobox:hover .pp-infobox-title {
-}
-
-.careers-value-flexibility-box .pp-infobox:hover .pp-infobox-title a {
-}
-
-.careers-value-flexibility-box .pp-infobox:hover .pp-infobox-description {
-}
-.careers-value-flexibility-box .pp-infobox-icon-inner span.pp-icon, .careers-value-flexibility-box .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-.careers-value-flexibility-box .pp-infobox-wrap .pp-infobox {
-  text-align: left;
-}
-
-.careers-value-flexibility-box .pp-infobox:hover {
-}
-.fl-builder-content .careers-value-flexibility-box .pp-infobox-image img {
-  width: 35px;
-}
-
-.careers-value-flexibility-box .pp-infobox {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-.careers-value-flexibility-box .pp-more-link {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  font-weight: 700;
-}
-.fl-col-group-equal-height .careers-value-growth-box.fl-visible-large, .fl-col-group-equal-height .careers-value-growth-box.fl-visible-medium, .fl-col-group-equal-height .careers-value-growth-box.fl-visible-mobile {
-  display: none;
-}
-
-.fl-col-group-equal-height .careers-value-growth-box.fl-visible-desktop {
-  display: flex;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-center .careers-value-growth-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-top .careers-value-growth-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .careers-value-growth-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .careers-value-growth-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-growth-box.fl-visible-large {
-    display: flex;
-  }
-}
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .careers-value-growth-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-growth-box.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-growth-box.fl-visible-medium {
-    display: flex;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .careers-value-growth-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-growth-box.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-growth-box.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-growth-box.fl-visible-mobile {
-    display: flex;
-  }
-}
-.careers-value-growth-box .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-.careers-value-growth-box .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-.careers-value-growth-box .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-.careers-value-growth-box .pp-infobox:hover .pp-infobox-title-prefix {
-}
-
-.careers-value-growth-box .pp-infobox:hover .pp-infobox-title {
-}
-
-.careers-value-growth-box .pp-infobox:hover .pp-infobox-title a {
-}
-
-.careers-value-growth-box .pp-infobox:hover .pp-infobox-description {
-}
-.careers-value-growth-box .pp-infobox-icon-inner span.pp-icon, .careers-value-growth-box .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-.careers-value-growth-box .pp-infobox-wrap .pp-infobox {
-  text-align: left;
-}
-
-.careers-value-growth-box .pp-infobox:hover {
-}
-.fl-builder-content .careers-value-growth-box .pp-infobox-image img {
-  width: 35px;
-}
-
-.careers-value-growth-box .pp-infobox {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-.careers-value-growth-box .pp-more-link {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  font-weight: 700;
-}
-.fl-col-group-equal-height .careers-value-training-box.fl-visible-large, .fl-col-group-equal-height .careers-value-training-box.fl-visible-medium, .fl-col-group-equal-height .careers-value-training-box.fl-visible-mobile {
-  display: none;
-}
-
-.fl-col-group-equal-height .careers-value-training-box.fl-visible-desktop {
-  display: flex;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-center .careers-value-training-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-top .careers-value-training-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .careers-value-training-box .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .careers-value-training-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-training-box.fl-visible-large {
-    display: flex;
-  }
-}
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .careers-value-training-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-training-box.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-training-box.fl-visible-medium {
-    display: flex;
-  }
-}
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .careers-value-training-box.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-training-box.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-training-box.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .careers-value-training-box.fl-visible-mobile {
-    display: flex;
-  }
-}
-.careers-value-training-box .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-.careers-value-training-box .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-.careers-value-training-box .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-.careers-value-training-box .pp-infobox:hover .pp-infobox-title-prefix {
-}
-
-.careers-value-training-box .pp-infobox:hover .pp-infobox-title {
-}
-
-.careers-value-training-box .pp-infobox:hover .pp-infobox-title a {
-}
-
-.careers-value-training-box .pp-infobox:hover .pp-infobox-description {
-}
-.careers-value-training-box .pp-infobox-icon-inner span.pp-icon, .careers-value-training-box .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-.careers-value-training-box .pp-infobox-wrap .pp-infobox {
-  text-align: left;
-}
-
-.careers-value-training-box .pp-infobox:hover {
-}
-.fl-builder-content .careers-value-training-box .pp-infobox-image img {
-  width: 35px;
-}
-
-.careers-value-training-box .pp-infobox {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-.careers-value-training-box .pp-more-link {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  font-weight: 700;
-}
 .careers-testimonial-photo .fl-photo {
   text-align: left;
 }
@@ -4256,4 +3554,148 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
   .pp-gf-content .gform_wrapper .gform_body {
     width: 68% !important;
   }
+}
+
+/* Page card core - shared by the 6 careers-value-card instances (Phase E-2);
+   per-instance keeps stay under their own classes and win by later position. */
+
+.fl-col-group-equal-height .careers-value-card.fl-visible-large, .fl-col-group-equal-height .careers-value-card.fl-visible-medium, .fl-col-group-equal-height .careers-value-card.fl-visible-mobile {
+  display: none;
+}
+
+
+.fl-col-group-equal-height .careers-value-card.fl-visible-desktop {
+  display: flex;
+}
+
+
+.fl-col-group-equal-height.fl-col-group-align-center .careers-value-card .fl-module-content .pp-infobox-wrap .pp-infobox {
+  justify-content: center;
+}
+
+
+.fl-col-group-equal-height.fl-col-group-align-top .careers-value-card .fl-module-content .pp-infobox-wrap .pp-infobox {
+  justify-content: flex-start;
+}
+
+
+.fl-col-group-equal-height.fl-col-group-align-bottom .careers-value-card .fl-module-content .pp-infobox-wrap .pp-infobox {
+  justify-content: flex-end;
+}
+@media only screen and (max-width: 1200px) {
+
+  .fl-col-group-equal-height .careers-value-card.fl-visible-desktop {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .careers-value-card.fl-visible-large {
+    display: flex;
+  }
+}
+@media only screen and (max-width: 1115px) {
+
+  .fl-col-group-equal-height .careers-value-card.fl-visible-desktop {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .careers-value-card.fl-visible-large {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .careers-value-card.fl-visible-medium {
+    display: flex;
+  }
+}
+@media only screen and (max-width: 860px) {
+
+  .fl-col-group-equal-height .careers-value-card.fl-visible-desktop {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .careers-value-card.fl-visible-large {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .careers-value-card.fl-visible-medium {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .careers-value-card.fl-visible-mobile {
+    display: flex;
+  }
+}
+
+.careers-value-card .pp-infobox-title-wrapper .pp-infobox-title {
+  margin-top: 30px;
+  margin-bottom: 0px;
+}
+
+
+.careers-value-card .pp-infobox-title-wrapper .pp-infobox-title a {
+}
+
+
+.careers-value-card .pp-infobox-description {
+  margin-top: 15px;
+  margin-bottom: 0px;
+}
+
+
+.careers-value-card .pp-infobox:hover .pp-infobox-title-prefix {
+}
+
+
+.careers-value-card .pp-infobox:hover .pp-infobox-title {
+}
+
+
+.careers-value-card .pp-infobox:hover .pp-infobox-title a {
+}
+
+
+.careers-value-card .pp-infobox:hover .pp-infobox-description {
+}
+
+.careers-value-card .pp-infobox-icon-inner span.pp-icon, .careers-value-card .pp-infobox-image img {
+  border-top-left-radius: px;
+  border-top-right-radius: px;
+  border-bottom-left-radius: px;
+  border-bottom-right-radius: px;
+}
+
+
+.careers-value-card .pp-infobox-wrap .pp-infobox {
+  text-align: left;
+}
+
+
+.careers-value-card .pp-infobox:hover {
+}
+
+.fl-builder-content .careers-value-card .pp-infobox-image img {
+  width: 35px;
+}
+
+
+.careers-value-card .pp-infobox {
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-left-radius: 14px;
+  border-bottom-right-radius: 14px;
+}
+
+
+.careers-value-card .pp-more-link {
+  font-family: var(--font-system-ui);
+  font-weight: 700;
 }

--- a/themes/beaver/assets/css/pages/homepage.css
+++ b/themes/beaver/assets/css/pages/homepage.css
@@ -3405,620 +3405,10 @@ img.mfp-img {
   flex: 1;
 }
 @mixin responsive-visibility dxali8vntcr0;
-.home-service-cto-box .pp-infobox-title-wrapper .pp-infobox-title {
-  color: #ffffff;
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-
-.home-service-cto-box .pp-infobox-title-wrapper .pp-infobox-title a {
-  color: #ffffff;
-}
-
-
-.home-service-cto-box .pp-infobox-description {
-  color: #ffffff;
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.home-service-cto-box .pp-infobox .pp-infobox-title-prefix:hover {
-}
-
-
-.home-service-cto-box .pp-infobox .pp-infobox-title:hover {
-  color: var(--color-dark);
-}
-
-
-.home-service-cto-box .pp-infobox .pp-infobox-title a:hover {
-  color: var(--color-dark);
-}
-
-
-.home-service-cto-box .pp-infobox .pp-infobox-description:hover {
-  color: var(--color-dark);
-}
-.home-service-cto-box .pp-infobox-icon-inner span.pp-icon, .home-service-cto-box .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-
-.home-service-cto-box .pp-infobox-wrap .pp-infobox {
-  background: rgba(255, 255, 255, 0);
-  text-align: left;
-}
-
-
-.home-service-cto-box .pp-infobox:hover {
-  background: #ffffff;
-}
-
-
-.home-service-cto-box .pp-infobox .pp-more-link {
-  color: #ffffff;
-  background-color: rgba(255, 0, 0, 0);
-  text-decoration: none;
-  text-align: center;
-  margin: 0 auto;
-}
-
-
-.home-service-cto-box .pp-infobox .pp-more-link:hover {
-  color: var(--color-primary);
-  background-color: rgba(255, 0, 0, 0);
-}
-
-
-.home-service-cto-box .pp-infobox .pp-more-link .pp-button-icon {
-  font-size: 22px;
-  color: #ffffff;
-}
-
-
-.home-service-cto-box .pp-infobox .pp-more-link:hover .pp-button-icon {
-  color: var(--color-primary);
-}
-
-
-.home-service-cto-box .pp-infobox .pp-more-link .pp-button-icon-left {
-  margin-right: 15px;
-}
-
-
-.home-service-cto-box .pp-infobox .pp-more-link .pp-button-icon-right {
-  margin-left: 15px;
-}
-.fl-builder-content .home-service-cto-box .pp-infobox-image img {
-  width: 36px;
-}
-
-
-.home-service-cto-box .pp-infobox {
-  padding-top: 30px;
-  padding-right: 30px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-
-.home-service-cto-box .pp-more-link {
-  font-family: var(--font-system-ui);
-  font-weight: 700;
-}
-
-
-.home-service-cto-box .pp-infobox .pp-more-link {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  margin-top: 32px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-}
 @mixin responsive-visibility 075ztwhd3cxn;
-.home-service-web-dev-box .pp-infobox-title-wrapper .pp-infobox-title {
-  color: #ffffff;
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-
-.home-service-web-dev-box .pp-infobox-title-wrapper .pp-infobox-title a {
-  color: #ffffff;
-}
-
-
-.home-service-web-dev-box .pp-infobox-description {
-  color: #ffffff;
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.home-service-web-dev-box .pp-infobox .pp-infobox-title-prefix:hover {
-}
-
-
-.home-service-web-dev-box .pp-infobox .pp-infobox-title:hover {
-  color: var(--color-dark);
-}
-
-
-.home-service-web-dev-box .pp-infobox .pp-infobox-title a:hover {
-  color: var(--color-dark);
-}
-
-
-.home-service-web-dev-box .pp-infobox .pp-infobox-description:hover {
-  color: var(--color-dark);
-}
-.home-service-web-dev-box .pp-infobox-icon-inner span.pp-icon, .home-service-web-dev-box .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-
-.home-service-web-dev-box .pp-infobox-wrap .pp-infobox {
-  background: rgba(255, 255, 255, 0);
-  text-align: left;
-}
-
-
-.home-service-web-dev-box .pp-infobox:hover {
-  background: #ffffff;
-}
-
-
-.home-service-web-dev-box .pp-infobox .pp-more-link {
-  color: #ffffff;
-  background-color: rgba(255, 0, 0, 0);
-  text-decoration: none;
-  text-align: center;
-  margin: 0 auto;
-}
-
-
-.home-service-web-dev-box .pp-infobox .pp-more-link:hover {
-  color: var(--color-primary);
-  background-color: rgba(255, 0, 0, 0);
-}
-
-
-.home-service-web-dev-box .pp-infobox .pp-more-link .pp-button-icon {
-  font-size: 22px;
-  color: #ffffff;
-}
-
-
-.home-service-web-dev-box .pp-infobox .pp-more-link:hover .pp-button-icon {
-  color: var(--color-primary);
-}
-
-
-.home-service-web-dev-box .pp-infobox .pp-more-link .pp-button-icon-left {
-  margin-right: 15px;
-}
-
-
-.home-service-web-dev-box .pp-infobox .pp-more-link .pp-button-icon-right {
-  margin-left: 15px;
-}
-.fl-builder-content .home-service-web-dev-box .pp-infobox-image img {
-  width: 36px;
-}
-
-
-.home-service-web-dev-box .pp-infobox {
-  padding-top: 30px;
-  padding-right: 30px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-
-.home-service-web-dev-box .pp-more-link {
-  font-family: var(--font-system-ui);
-  font-weight: 700;
-}
-
-
-.home-service-web-dev-box .pp-infobox .pp-more-link {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  margin-top: 32px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-}
 @mixin responsive-visibility lajty926uxf5;
-.home-service-qa-box .pp-infobox-title-wrapper .pp-infobox-title {
-  color: #ffffff;
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-
-.home-service-qa-box .pp-infobox-title-wrapper .pp-infobox-title a {
-  color: #ffffff;
-}
-
-
-.home-service-qa-box .pp-infobox-description {
-  color: #ffffff;
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.home-service-qa-box .pp-infobox .pp-infobox-title-prefix:hover {
-}
-
-
-.home-service-qa-box .pp-infobox .pp-infobox-title:hover {
-  color: var(--color-dark);
-}
-
-
-.home-service-qa-box .pp-infobox .pp-infobox-title a:hover {
-  color: var(--color-dark);
-}
-
-
-.home-service-qa-box .pp-infobox .pp-infobox-description:hover {
-  color: var(--color-dark);
-}
-.home-service-qa-box .pp-infobox-icon-inner span.pp-icon, .home-service-qa-box .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-
-.home-service-qa-box .pp-infobox-wrap .pp-infobox {
-  background: rgba(255, 255, 255, 0);
-  text-align: left;
-}
-
-
-.home-service-qa-box .pp-infobox:hover {
-  background: #ffffff;
-}
-
-
-.home-service-qa-box .pp-infobox .pp-more-link {
-  color: #ffffff;
-  background-color: rgba(255, 0, 0, 0);
-  text-decoration: none;
-  text-align: center;
-  margin: 0 auto;
-}
-
-
-.home-service-qa-box .pp-infobox .pp-more-link:hover {
-  color: var(--color-primary);
-  background-color: rgba(255, 0, 0, 0);
-}
-
-
-.home-service-qa-box .pp-infobox .pp-more-link .pp-button-icon {
-  font-size: 22px;
-  color: #ffffff;
-}
-
-
-.home-service-qa-box .pp-infobox .pp-more-link:hover .pp-button-icon {
-  color: var(--color-primary);
-}
-
-
-.home-service-qa-box .pp-infobox .pp-more-link .pp-button-icon-left {
-  margin-right: 15px;
-}
-
-
-.home-service-qa-box .pp-infobox .pp-more-link .pp-button-icon-right {
-  margin-left: 15px;
-}
-.fl-builder-content .home-service-qa-box .pp-infobox-image img {
-  width: 36px;
-}
-
-
-.home-service-qa-box .pp-infobox {
-  padding-top: 30px;
-  padding-right: 30px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-
-.home-service-qa-box .pp-more-link {
-  font-family: var(--font-system-ui);
-  font-weight: 700;
-}
-
-
-.home-service-qa-box .pp-infobox .pp-more-link {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  margin-top: 32px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-}
 @mixin responsive-visibility do5fjakv8b29;
-.home-service-product-box .pp-infobox-title-wrapper .pp-infobox-title {
-  color: #ffffff;
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-
-.home-service-product-box .pp-infobox-title-wrapper .pp-infobox-title a {
-  color: #ffffff;
-}
-
-
-.home-service-product-box .pp-infobox-description {
-  color: #ffffff;
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.home-service-product-box .pp-infobox .pp-infobox-title-prefix:hover {
-}
-
-
-.home-service-product-box .pp-infobox .pp-infobox-title:hover {
-  color: var(--color-dark);
-}
-
-
-.home-service-product-box .pp-infobox .pp-infobox-title a:hover {
-  color: var(--color-dark);
-}
-
-
-.home-service-product-box .pp-infobox .pp-infobox-description:hover {
-  color: var(--color-dark);
-}
-.home-service-product-box .pp-infobox-icon-inner span.pp-icon, .home-service-product-box .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-
-.home-service-product-box .pp-infobox-wrap .pp-infobox {
-  background: rgba(255, 255, 255, 0);
-  text-align: left;
-}
-
-
-.home-service-product-box .pp-infobox:hover {
-  background: #ffffff;
-}
-
-
-.home-service-product-box .pp-infobox .pp-more-link {
-  color: #ffffff;
-  background-color: rgba(255, 0, 0, 0);
-  text-decoration: none;
-  text-align: center;
-  margin: 0 auto;
-}
-
-
-.home-service-product-box .pp-infobox .pp-more-link:hover {
-  color: var(--color-primary);
-  background-color: rgba(255, 0, 0, 0);
-}
-
-
-.home-service-product-box .pp-infobox .pp-more-link .pp-button-icon {
-  font-size: 22px;
-  color: #ffffff;
-}
-
-
-.home-service-product-box .pp-infobox .pp-more-link:hover .pp-button-icon {
-  color: var(--color-primary);
-}
-
-
-.home-service-product-box .pp-infobox .pp-more-link .pp-button-icon-left {
-  margin-right: 15px;
-}
-
-
-.home-service-product-box .pp-infobox .pp-more-link .pp-button-icon-right {
-  margin-left: 15px;
-}
-.fl-builder-content .home-service-product-box .pp-infobox-image img {
-  width: 36px;
-}
-
-
-.home-service-product-box .pp-infobox {
-  padding-top: 30px;
-  padding-right: 30px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-
-.home-service-product-box .pp-more-link {
-  font-family: var(--font-system-ui);
-  font-weight: 700;
-}
-
-
-.home-service-product-box .pp-infobox .pp-more-link {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  margin-top: 32px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-}
 @mixin responsive-visibility 3eq5kcmfz0an;
-.home-service-staffing-box .pp-infobox-title-wrapper .pp-infobox-title {
-  color: #ffffff;
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-
-.home-service-staffing-box .pp-infobox-title-wrapper .pp-infobox-title a {
-  color: #ffffff;
-}
-
-
-.home-service-staffing-box .pp-infobox-description {
-  color: #ffffff;
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.home-service-staffing-box .pp-infobox .pp-infobox-title-prefix:hover {
-}
-
-
-.home-service-staffing-box .pp-infobox .pp-infobox-title:hover {
-  color: var(--color-dark);
-}
-
-
-.home-service-staffing-box .pp-infobox .pp-infobox-title a:hover {
-  color: var(--color-dark);
-}
-
-
-.home-service-staffing-box .pp-infobox .pp-infobox-description:hover {
-  color: var(--color-dark);
-}
-.home-service-staffing-box .pp-infobox-icon-inner span.pp-icon, .home-service-staffing-box .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-
-.home-service-staffing-box .pp-infobox-wrap .pp-infobox {
-  background: rgba(255, 255, 255, 0);
-  text-align: left;
-}
-
-
-.home-service-staffing-box .pp-infobox:hover {
-  background: #ffffff;
-}
-
-
-.home-service-staffing-box .pp-infobox .pp-more-link {
-  color: #ffffff;
-  background-color: rgba(255, 0, 0, 0);
-  text-decoration: none;
-  text-align: center;
-  margin: 0 auto;
-}
-
-
-.home-service-staffing-box .pp-infobox .pp-more-link:hover {
-  color: var(--color-primary);
-  background-color: rgba(255, 0, 0, 0);
-}
-
-
-.home-service-staffing-box .pp-infobox .pp-more-link .pp-button-icon {
-  font-size: 22px;
-  color: #ffffff;
-}
-
-
-.home-service-staffing-box .pp-infobox .pp-more-link:hover .pp-button-icon {
-  color: var(--color-primary);
-}
-
-
-.home-service-staffing-box .pp-infobox .pp-more-link .pp-button-icon-left {
-  margin-right: 15px;
-}
-
-
-.home-service-staffing-box .pp-infobox .pp-more-link .pp-button-icon-right {
-  margin-left: 15px;
-}
-.fl-builder-content .home-service-staffing-box .pp-infobox-image img {
-  width: 36px;
-}
-
-
-.home-service-staffing-box .pp-infobox {
-  padding-top: 30px;
-  padding-right: 30px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-
-.home-service-staffing-box .pp-more-link {
-  font-family: var(--font-system-ui);
-  font-weight: 700;
-}
-
-
-.home-service-staffing-box .pp-infobox .pp-more-link {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  margin-top: 32px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-}
 .fl-col-group-equal-height .home-service-recruiting-box.fl-visible-large, .fl-col-group-equal-height .home-service-recruiting-box.fl-visible-medium, .fl-col-group-equal-height .home-service-recruiting-box.fl-visible-mobile {
   display: none;
 }
@@ -4086,128 +3476,6 @@ img.mfp-img {
   .fl-col-group-equal-height .home-service-recruiting-box.fl-visible-mobile {
     display: flex;
   }
-}
-.home-service-recruiting-box .pp-infobox-title-wrapper .pp-infobox-title {
-  color: #ffffff;
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-
-.home-service-recruiting-box .pp-infobox-title-wrapper .pp-infobox-title a {
-  color: #ffffff;
-}
-
-
-.home-service-recruiting-box .pp-infobox-description {
-  color: #ffffff;
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.home-service-recruiting-box .pp-infobox .pp-infobox-title-prefix:hover {
-}
-
-
-.home-service-recruiting-box .pp-infobox .pp-infobox-title:hover {
-  color: var(--color-dark);
-}
-
-
-.home-service-recruiting-box .pp-infobox .pp-infobox-title a:hover {
-  color: var(--color-dark);
-}
-
-
-.home-service-recruiting-box .pp-infobox .pp-infobox-description:hover {
-  color: var(--color-dark);
-}
-.home-service-recruiting-box .pp-infobox-icon-inner span.pp-icon, .home-service-recruiting-box .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-
-.home-service-recruiting-box .pp-infobox-wrap .pp-infobox {
-  background: rgba(255, 255, 255, 0);
-  text-align: left;
-}
-
-
-.home-service-recruiting-box .pp-infobox:hover {
-  background: #ffffff;
-}
-
-
-.home-service-recruiting-box .pp-infobox .pp-more-link {
-  color: #ffffff;
-  background-color: rgba(255, 0, 0, 0);
-  text-decoration: none;
-  text-align: center;
-  margin: 0 auto;
-}
-
-
-.home-service-recruiting-box .pp-infobox .pp-more-link:hover {
-  color: var(--color-primary);
-  background-color: rgba(255, 0, 0, 0);
-}
-
-
-.home-service-recruiting-box .pp-infobox .pp-more-link .pp-button-icon {
-  font-size: 22px;
-  color: #ffffff;
-}
-
-
-.home-service-recruiting-box .pp-infobox .pp-more-link:hover .pp-button-icon {
-  color: var(--color-primary);
-}
-
-
-.home-service-recruiting-box .pp-infobox .pp-more-link .pp-button-icon-left {
-  margin-right: 15px;
-}
-
-
-.home-service-recruiting-box .pp-infobox .pp-more-link .pp-button-icon-right {
-  margin-left: 15px;
-}
-.fl-builder-content .home-service-recruiting-box .pp-infobox-image img {
-  width: 36px;
-}
-
-
-.home-service-recruiting-box .pp-infobox {
-  padding-top: 30px;
-  padding-right: 30px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-
-.home-service-recruiting-box .pp-more-link {
-  font-family: var(--font-system-ui);
-  font-weight: 700;
-}
-
-
-.home-service-recruiting-box .pp-infobox .pp-more-link {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  margin-top: 32px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
 }
 .fl-builder-content .home-clients-eyebrow .fl-module-content .fl-rich-text, .fl-builder-content .home-clients-eyebrow .fl-module-content .fl-rich-text * {
   color: var(--color-primary);
@@ -8247,4 +7515,148 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
     padding-top: 20px;
     margin-top: 0;
   }
+}
+/* Page card core - shared by the 6 home-service-card instances (Phase E-2);
+   per-instance keeps stay under their own classes and win by later position. */
+
+.home-service-card .pp-infobox-title-wrapper .pp-infobox-title {
+  color: #ffffff;
+  margin-top: 30px;
+  margin-bottom: 0px;
+}
+
+
+
+.home-service-card .pp-infobox-title-wrapper .pp-infobox-title a {
+  color: #ffffff;
+}
+
+
+
+.home-service-card .pp-infobox-description {
+  color: #ffffff;
+  margin-top: 15px;
+  margin-bottom: 0px;
+}
+
+
+
+.home-service-card .pp-infobox .pp-infobox-title-prefix:hover {
+}
+
+
+
+.home-service-card .pp-infobox .pp-infobox-title:hover {
+  color: var(--color-dark);
+}
+
+
+
+.home-service-card .pp-infobox .pp-infobox-title a:hover {
+  color: var(--color-dark);
+}
+
+
+
+.home-service-card .pp-infobox .pp-infobox-description:hover {
+  color: var(--color-dark);
+}
+
+.home-service-card .pp-infobox-icon-inner span.pp-icon, .home-service-card .pp-infobox-image img {
+  border-top-left-radius: px;
+  border-top-right-radius: px;
+  border-bottom-left-radius: px;
+  border-bottom-right-radius: px;
+}
+
+
+
+.home-service-card .pp-infobox-wrap .pp-infobox {
+  background: rgba(255, 255, 255, 0);
+  text-align: left;
+}
+
+
+
+.home-service-card .pp-infobox:hover {
+  background: #ffffff;
+}
+
+
+
+.home-service-card .pp-infobox .pp-more-link {
+  color: #ffffff;
+  background-color: rgba(255, 0, 0, 0);
+  text-decoration: none;
+  text-align: center;
+  margin: 0 auto;
+}
+
+
+
+.home-service-card .pp-infobox .pp-more-link:hover {
+  color: var(--color-primary);
+  background-color: rgba(255, 0, 0, 0);
+}
+
+
+
+.home-service-card .pp-infobox .pp-more-link .pp-button-icon {
+  font-size: 22px;
+  color: #ffffff;
+}
+
+
+
+.home-service-card .pp-infobox .pp-more-link:hover .pp-button-icon {
+  color: var(--color-primary);
+}
+
+
+
+.home-service-card .pp-infobox .pp-more-link .pp-button-icon-left {
+  margin-right: 15px;
+}
+
+
+
+.home-service-card .pp-infobox .pp-more-link .pp-button-icon-right {
+  margin-left: 15px;
+}
+
+.fl-builder-content .home-service-card .pp-infobox-image img {
+  width: 36px;
+}
+
+
+
+.home-service-card .pp-infobox {
+  padding-top: 30px;
+  padding-right: 30px;
+  padding-bottom: 30px;
+  padding-left: 30px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-left-radius: 14px;
+  border-bottom-right-radius: 14px;
+}
+
+
+
+.home-service-card .pp-more-link {
+  font-family: var(--font-system-ui);
+  font-weight: 700;
+}
+
+
+
+.home-service-card .pp-infobox .pp-more-link {
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  margin-top: 32px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
 }

--- a/themes/beaver/assets/css/pages/services.css
+++ b/themes/beaver/assets/css/pages/services.css
@@ -1575,1103 +1575,23 @@ img.mfp-img {
 .pp-infobox-wrap .layout-4 .pp-heading-wrapper {
   flex: 1;
 }
-.fl-col-group-equal-height .services-card-cto.fl-visible-large, .fl-col-group-equal-height .services-card-cto.fl-visible-medium, .fl-col-group-equal-height .services-card-cto.fl-visible-mobile {
-  display: none;
-}
-
-
-.fl-col-group-equal-height .services-card-cto.fl-visible-desktop {
-  display: flex;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-center .services-card-cto .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-top .services-card-cto .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .services-card-cto .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .services-card-cto.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-cto.fl-visible-large {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .services-card-cto.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-cto.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-cto.fl-visible-medium {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .services-card-cto.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-cto.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-cto.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-cto.fl-visible-mobile {
-    display: flex;
-  }
-}
-.services-card-cto .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-
-.services-card-cto .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-
-.services-card-cto .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.services-card-cto .pp-infobox .pp-infobox-title-prefix:hover {
-}
-
-
-.services-card-cto .pp-infobox .pp-infobox-title:hover {
-}
-
-
-.services-card-cto .pp-infobox .pp-infobox-title a:hover {
-}
-
-
-.services-card-cto .pp-infobox .pp-infobox-description:hover {
-}
-.services-card-cto .pp-infobox-icon-inner span.pp-icon, .services-card-cto .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-
-.services-card-cto .pp-infobox-wrap .pp-infobox {
-  text-align: left;
-}
-
-
-.services-card-cto .pp-infobox:hover {
-  background: #F5F6F8;
-}
-
-
-.services-card-cto .pp-infobox .pp-more-link {
-  color: var(--color-primary);
-  background-color: rgba(255, 0, 0, 0);
-  text-decoration: none;
-  text-align: center;
-  margin: 0 auto;
-}
-
-
-.services-card-cto .pp-infobox .pp-more-link:hover {
-  color: #007af4;
-  background-color: rgba(255, 0, 0, 0);
-}
-
-
-.services-card-cto .pp-infobox .pp-more-link .pp-button-icon {
-  font-size: 22px;
-  color: var(--color-primary);
-}
-
-
-.services-card-cto .pp-infobox .pp-more-link:hover .pp-button-icon {
-  color: #007af4;
-}
-
-
-.services-card-cto .pp-infobox .pp-more-link .pp-button-icon-left {
-  margin-right: 15px;
-}
-
-
-.services-card-cto .pp-infobox .pp-more-link .pp-button-icon-right {
-  margin-left: 15px;
-}
 .fl-builder-content .services-card-cto .pp-infobox-image img {
   width: 36px;
-}
-
-
-.services-card-cto .pp-infobox {
-  padding-top: 30px;
-  padding-right: 30px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-
-.services-card-cto .pp-more-link {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  font-weight: 700;
-}
-
-
-.services-card-cto .pp-infobox .pp-more-link {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  margin-top: 32px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-}
-.fl-col-group-equal-height .services-card-webdev.fl-visible-large, .fl-col-group-equal-height .services-card-webdev.fl-visible-medium, .fl-col-group-equal-height .services-card-webdev.fl-visible-mobile {
-  display: none;
-}
-
-
-.fl-col-group-equal-height .services-card-webdev.fl-visible-desktop {
-  display: flex;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-center .services-card-webdev .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-top .services-card-webdev .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .services-card-webdev .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .services-card-webdev.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-webdev.fl-visible-large {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .services-card-webdev.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-webdev.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-webdev.fl-visible-medium {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .services-card-webdev.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-webdev.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-webdev.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-webdev.fl-visible-mobile {
-    display: flex;
-  }
-}
-.services-card-webdev .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-
-.services-card-webdev .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-
-.services-card-webdev .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.services-card-webdev .pp-infobox .pp-infobox-title-prefix:hover {
-}
-
-
-.services-card-webdev .pp-infobox .pp-infobox-title:hover {
-}
-
-
-.services-card-webdev .pp-infobox .pp-infobox-title a:hover {
-}
-
-
-.services-card-webdev .pp-infobox .pp-infobox-description:hover {
-}
-.services-card-webdev .pp-infobox-icon-inner span.pp-icon, .services-card-webdev .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-
-.services-card-webdev .pp-infobox-wrap .pp-infobox {
-  text-align: left;
-}
-
-
-.services-card-webdev .pp-infobox:hover {
-  background: #F5F6F8;
-}
-
-
-.services-card-webdev .pp-infobox .pp-more-link {
-  color: var(--color-primary);
-  background-color: rgba(255, 0, 0, 0);
-  text-decoration: none;
-  text-align: center;
-  margin: 0 auto;
-}
-
-
-.services-card-webdev .pp-infobox .pp-more-link:hover {
-  color: #007af4;
-  background-color: rgba(255, 0, 0, 0);
-}
-
-
-.services-card-webdev .pp-infobox .pp-more-link .pp-button-icon {
-  font-size: 22px;
-  color: var(--color-primary);
-}
-
-
-.services-card-webdev .pp-infobox .pp-more-link:hover .pp-button-icon {
-  color: #007af4;
-}
-
-
-.services-card-webdev .pp-infobox .pp-more-link .pp-button-icon-left {
-  margin-right: 15px;
-}
-
-
-.services-card-webdev .pp-infobox .pp-more-link .pp-button-icon-right {
-  margin-left: 15px;
 }
 .fl-builder-content .services-card-webdev .pp-infobox-image img {
   width: 30px;
 }
-
-
-.services-card-webdev .pp-infobox {
-  padding-top: 30px;
-  padding-right: 30px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-
-.services-card-webdev .pp-more-link {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  font-weight: 700;
-}
-
-
-.services-card-webdev .pp-infobox .pp-more-link {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  margin-top: 32px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-}
-.fl-col-group-equal-height .services-card-qa.fl-visible-large, .fl-col-group-equal-height .services-card-qa.fl-visible-medium, .fl-col-group-equal-height .services-card-qa.fl-visible-mobile {
-  display: none;
-}
-
-
-.fl-col-group-equal-height .services-card-qa.fl-visible-desktop {
-  display: flex;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-center .services-card-qa .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-top .services-card-qa .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .services-card-qa .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .services-card-qa.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-qa.fl-visible-large {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .services-card-qa.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-qa.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-qa.fl-visible-medium {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .services-card-qa.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-qa.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-qa.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-qa.fl-visible-mobile {
-    display: flex;
-  }
-}
-.services-card-qa .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-
-.services-card-qa .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-
-.services-card-qa .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.services-card-qa .pp-infobox .pp-infobox-title-prefix:hover {
-}
-
-
-.services-card-qa .pp-infobox .pp-infobox-title:hover {
-}
-
-
-.services-card-qa .pp-infobox .pp-infobox-title a:hover {
-}
-
-
-.services-card-qa .pp-infobox .pp-infobox-description:hover {
-}
-.services-card-qa .pp-infobox-icon-inner span.pp-icon, .services-card-qa .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-
-.services-card-qa .pp-infobox-wrap .pp-infobox {
-  text-align: left;
-}
-
-
-.services-card-qa .pp-infobox:hover {
-  background: #F5F6F8;
-}
-
-
-.services-card-qa .pp-infobox .pp-more-link {
-  color: var(--color-primary);
-  background-color: rgba(255, 0, 0, 0);
-  text-decoration: none;
-  text-align: center;
-  margin: 0 auto;
-}
-
-
-.services-card-qa .pp-infobox .pp-more-link:hover {
-  color: #007af4;
-  background-color: rgba(255, 0, 0, 0);
-}
-
-
-.services-card-qa .pp-infobox .pp-more-link .pp-button-icon {
-  font-size: 22px;
-  color: var(--color-primary);
-}
-
-
-.services-card-qa .pp-infobox .pp-more-link:hover .pp-button-icon {
-  color: #007af4;
-}
-
-
-.services-card-qa .pp-infobox .pp-more-link .pp-button-icon-left {
-  margin-right: 15px;
-}
-
-
-.services-card-qa .pp-infobox .pp-more-link .pp-button-icon-right {
-  margin-left: 15px;
-}
 .fl-builder-content .services-card-qa .pp-infobox-image img {
   width: 36px;
-}
-
-
-.services-card-qa .pp-infobox {
-  padding-top: 30px;
-  padding-right: 30px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-
-.services-card-qa .pp-more-link {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  font-weight: 700;
-}
-
-
-.services-card-qa .pp-infobox .pp-more-link {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  margin-top: 32px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-}
-.fl-col-group-equal-height .services-card-product.fl-visible-large, .fl-col-group-equal-height .services-card-product.fl-visible-medium, .fl-col-group-equal-height .services-card-product.fl-visible-mobile {
-  display: none;
-}
-
-
-.fl-col-group-equal-height .services-card-product.fl-visible-desktop {
-  display: flex;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-center .services-card-product .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-top .services-card-product .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .services-card-product .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .services-card-product.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-product.fl-visible-large {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .services-card-product.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-product.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-product.fl-visible-medium {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .services-card-product.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-product.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-product.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-product.fl-visible-mobile {
-    display: flex;
-  }
-}
-.services-card-product .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-
-.services-card-product .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-
-.services-card-product .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.services-card-product .pp-infobox .pp-infobox-title-prefix:hover {
-}
-
-
-.services-card-product .pp-infobox .pp-infobox-title:hover {
-}
-
-
-.services-card-product .pp-infobox .pp-infobox-title a:hover {
-}
-
-
-.services-card-product .pp-infobox .pp-infobox-description:hover {
-}
-.services-card-product .pp-infobox-icon-inner span.pp-icon, .services-card-product .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-
-.services-card-product .pp-infobox-wrap .pp-infobox {
-  text-align: left;
-}
-
-
-.services-card-product .pp-infobox:hover {
-  background: #F5F6F8;
-}
-
-
-.services-card-product .pp-infobox .pp-more-link {
-  color: var(--color-primary);
-  background-color: rgba(255, 0, 0, 0);
-  text-decoration: none;
-  text-align: center;
-  margin: 0 auto;
-}
-
-
-.services-card-product .pp-infobox .pp-more-link:hover {
-  color: #007af4;
-  background-color: rgba(255, 0, 0, 0);
-}
-
-
-.services-card-product .pp-infobox .pp-more-link .pp-button-icon {
-  font-size: 22px;
-  color: var(--color-primary);
-}
-
-
-.services-card-product .pp-infobox .pp-more-link:hover .pp-button-icon {
-  color: #007af4;
-}
-
-
-.services-card-product .pp-infobox .pp-more-link .pp-button-icon-left {
-  margin-right: 15px;
-}
-
-
-.services-card-product .pp-infobox .pp-more-link .pp-button-icon-right {
-  margin-left: 15px;
 }
 .fl-builder-content .services-card-product .pp-infobox-image img {
   width: 36px;
 }
-
-
-.services-card-product .pp-infobox {
-  padding-top: 30px;
-  padding-right: 30px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-
-.services-card-product .pp-more-link {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  font-weight: 700;
-}
-
-
-.services-card-product .pp-infobox .pp-more-link {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  margin-top: 32px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-}
-.fl-col-group-equal-height .services-card-staffing.fl-visible-large, .fl-col-group-equal-height .services-card-staffing.fl-visible-medium, .fl-col-group-equal-height .services-card-staffing.fl-visible-mobile {
-  display: none;
-}
-
-
-.fl-col-group-equal-height .services-card-staffing.fl-visible-desktop {
-  display: flex;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-center .services-card-staffing .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-top .services-card-staffing .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .services-card-staffing .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .services-card-staffing.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-staffing.fl-visible-large {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .services-card-staffing.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-staffing.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-staffing.fl-visible-medium {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .services-card-staffing.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-staffing.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-staffing.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-staffing.fl-visible-mobile {
-    display: flex;
-  }
-}
-.services-card-staffing .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-
-.services-card-staffing .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-
-.services-card-staffing .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.services-card-staffing .pp-infobox .pp-infobox-title-prefix:hover {
-}
-
-
-.services-card-staffing .pp-infobox .pp-infobox-title:hover {
-}
-
-
-.services-card-staffing .pp-infobox .pp-infobox-title a:hover {
-}
-
-
-.services-card-staffing .pp-infobox .pp-infobox-description:hover {
-}
-.services-card-staffing .pp-infobox-icon-inner span.pp-icon, .services-card-staffing .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-
-.services-card-staffing .pp-infobox-wrap .pp-infobox {
-  text-align: left;
-}
-
-
-.services-card-staffing .pp-infobox:hover {
-  background: #F5F6F8;
-}
-
-
-.services-card-staffing .pp-infobox .pp-more-link {
-  color: var(--color-primary);
-  background-color: rgba(255, 0, 0, 0);
-  text-decoration: none;
-  text-align: center;
-  margin: 0 auto;
-}
-
-
-.services-card-staffing .pp-infobox .pp-more-link:hover {
-  color: #007af4;
-  background-color: rgba(255, 0, 0, 0);
-}
-
-
-.services-card-staffing .pp-infobox .pp-more-link .pp-button-icon {
-  font-size: 22px;
-  color: var(--color-primary);
-}
-
-
-.services-card-staffing .pp-infobox .pp-more-link:hover .pp-button-icon {
-  color: #007af4;
-}
-
-
-.services-card-staffing .pp-infobox .pp-more-link .pp-button-icon-left {
-  margin-right: 15px;
-}
-
-
-.services-card-staffing .pp-infobox .pp-more-link .pp-button-icon-right {
-  margin-left: 15px;
-}
 .fl-builder-content .services-card-staffing .pp-infobox-image img {
   width: 36px;
 }
-
-
-.services-card-staffing .pp-infobox {
-  padding-top: 30px;
-  padding-right: 30px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-
-.services-card-staffing .pp-more-link {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  font-weight: 700;
-}
-
-
-.services-card-staffing .pp-infobox .pp-more-link {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  margin-top: 32px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-}
-.fl-col-group-equal-height .services-card-recruiting.fl-visible-large, .fl-col-group-equal-height .services-card-recruiting.fl-visible-medium, .fl-col-group-equal-height .services-card-recruiting.fl-visible-mobile {
-  display: none;
-}
-
-
-.fl-col-group-equal-height .services-card-recruiting.fl-visible-desktop {
-  display: flex;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-center .services-card-recruiting .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: center;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-top .services-card-recruiting .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-start;
-}
-
-
-.fl-col-group-equal-height.fl-col-group-align-bottom .services-card-recruiting .fl-module-content .pp-infobox-wrap .pp-infobox {
-  justify-content: flex-end;
-}
-
-
-@media only screen and (max-width: 1200px) {
-  .fl-col-group-equal-height .services-card-recruiting.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-recruiting.fl-visible-large {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 1115px) {
-  .fl-col-group-equal-height .services-card-recruiting.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-recruiting.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-recruiting.fl-visible-medium {
-    display: flex;
-  }
-}
-
-
-@media only screen and (max-width: 860px) {
-  .fl-col-group-equal-height .services-card-recruiting.fl-visible-desktop {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-recruiting.fl-visible-large {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-recruiting.fl-visible-medium {
-    display: none;
-  }
-
-  .fl-col-group-equal-height .services-card-recruiting.fl-visible-mobile {
-    display: flex;
-  }
-}
-.services-card-recruiting .pp-infobox-title-wrapper .pp-infobox-title {
-  margin-top: 30px;
-  margin-bottom: 0px;
-}
-
-
-.services-card-recruiting .pp-infobox-title-wrapper .pp-infobox-title a {
-}
-
-
-.services-card-recruiting .pp-infobox-description {
-  margin-top: 15px;
-  margin-bottom: 0px;
-}
-
-
-.services-card-recruiting .pp-infobox .pp-infobox-title-prefix:hover {
-}
-
-
-.services-card-recruiting .pp-infobox .pp-infobox-title:hover {
-}
-
-
-.services-card-recruiting .pp-infobox .pp-infobox-title a:hover {
-}
-
-
-.services-card-recruiting .pp-infobox .pp-infobox-description:hover {
-}
-.services-card-recruiting .pp-infobox-icon-inner span.pp-icon, .services-card-recruiting .pp-infobox-image img {
-  border-top-left-radius: px;
-  border-top-right-radius: px;
-  border-bottom-left-radius: px;
-  border-bottom-right-radius: px;
-}
-
-
-.services-card-recruiting .pp-infobox-wrap .pp-infobox {
-  text-align: left;
-}
-
-
-.services-card-recruiting .pp-infobox:hover {
-  background: #F5F6F8;
-}
-
-
-.services-card-recruiting .pp-infobox .pp-more-link {
-  color: var(--color-primary);
-  background-color: rgba(255, 0, 0, 0);
-  text-decoration: none;
-  text-align: center;
-  margin: 0 auto;
-}
-
-
-.services-card-recruiting .pp-infobox .pp-more-link:hover {
-  color: #007af4;
-  background-color: rgba(255, 0, 0, 0);
-}
-
-
-.services-card-recruiting .pp-infobox .pp-more-link .pp-button-icon {
-  font-size: 22px;
-  color: var(--color-primary);
-}
-
-
-.services-card-recruiting .pp-infobox .pp-more-link:hover .pp-button-icon {
-  color: #007af4;
-}
-
-
-.services-card-recruiting .pp-infobox .pp-more-link .pp-button-icon-left {
-  margin-right: 15px;
-}
-
-
-.services-card-recruiting .pp-infobox .pp-more-link .pp-button-icon-right {
-  margin-left: 15px;
-}
 .fl-builder-content .services-card-recruiting .pp-infobox-image img {
   width: 36px;
-}
-
-
-.services-card-recruiting .pp-infobox {
-  padding-top: 30px;
-  padding-right: 30px;
-  padding-bottom: 30px;
-  padding-left: 30px;
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-
-
-.services-card-recruiting .pp-more-link {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  font-weight: 700;
-}
-
-
-.services-card-recruiting .pp-infobox .pp-more-link {
-  padding-top: 0px;
-  padding-right: 0px;
-  padding-bottom: 0px;
-  padding-left: 0px;
-  margin-top: 32px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
 }
 img.mfp-img {
   padding-bottom: 40px !important;
@@ -4030,4 +2950,213 @@ div.gform_wrapper .field_sublabel_below .ginput_complex.ginput_container label {
 
 .services-showcase .fl-row-content {
   min-width: 0px;
+}
+/* Page card core - shared by the 6 services-card instances (Phase E-2);
+   per-instance keeps stay under their own classes and win by later position. */
+
+.fl-col-group-equal-height .services-card.fl-visible-large, .fl-col-group-equal-height .services-card.fl-visible-medium, .fl-col-group-equal-height .services-card.fl-visible-mobile {
+  display: none;
+}
+
+
+
+.fl-col-group-equal-height .services-card.fl-visible-desktop {
+  display: flex;
+}
+
+
+
+.fl-col-group-equal-height.fl-col-group-align-center .services-card .fl-module-content .pp-infobox-wrap .pp-infobox {
+  justify-content: center;
+}
+
+
+
+.fl-col-group-equal-height.fl-col-group-align-top .services-card .fl-module-content .pp-infobox-wrap .pp-infobox {
+  justify-content: flex-start;
+}
+
+
+
+.fl-col-group-equal-height.fl-col-group-align-bottom .services-card .fl-module-content .pp-infobox-wrap .pp-infobox {
+  justify-content: flex-end;
+}
+@media only screen and (max-width: 1200px) {
+
+  .fl-col-group-equal-height .services-card.fl-visible-desktop {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .services-card.fl-visible-large {
+    display: flex;
+  }
+}
+@media only screen and (max-width: 1115px) {
+
+  .fl-col-group-equal-height .services-card.fl-visible-desktop {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .services-card.fl-visible-large {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .services-card.fl-visible-medium {
+    display: flex;
+  }
+}
+@media only screen and (max-width: 860px) {
+
+  .fl-col-group-equal-height .services-card.fl-visible-desktop {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .services-card.fl-visible-large {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .services-card.fl-visible-medium {
+    display: none;
+  }
+
+
+  .fl-col-group-equal-height .services-card.fl-visible-mobile {
+    display: flex;
+  }
+}
+
+.services-card .pp-infobox-title-wrapper .pp-infobox-title {
+  margin-top: 30px;
+  margin-bottom: 0px;
+}
+
+
+
+.services-card .pp-infobox-title-wrapper .pp-infobox-title a {
+}
+
+
+
+.services-card .pp-infobox-description {
+  margin-top: 15px;
+  margin-bottom: 0px;
+}
+
+
+
+.services-card .pp-infobox .pp-infobox-title-prefix:hover {
+}
+
+
+
+.services-card .pp-infobox .pp-infobox-title:hover {
+}
+
+
+
+.services-card .pp-infobox .pp-infobox-title a:hover {
+}
+
+
+
+.services-card .pp-infobox .pp-infobox-description:hover {
+}
+
+.services-card .pp-infobox-icon-inner span.pp-icon, .services-card .pp-infobox-image img {
+  border-top-left-radius: px;
+  border-top-right-radius: px;
+  border-bottom-left-radius: px;
+  border-bottom-right-radius: px;
+}
+
+
+
+.services-card .pp-infobox-wrap .pp-infobox {
+  text-align: left;
+}
+
+
+
+.services-card .pp-infobox:hover {
+  background: #F5F6F8;
+}
+
+
+
+.services-card .pp-infobox .pp-more-link {
+  color: var(--color-primary);
+  background-color: rgba(255, 0, 0, 0);
+  text-decoration: none;
+  text-align: center;
+  margin: 0 auto;
+}
+
+
+
+.services-card .pp-infobox .pp-more-link:hover {
+  color: #007af4;
+  background-color: rgba(255, 0, 0, 0);
+}
+
+
+
+.services-card .pp-infobox .pp-more-link .pp-button-icon {
+  font-size: 22px;
+  color: var(--color-primary);
+}
+
+
+
+.services-card .pp-infobox .pp-more-link:hover .pp-button-icon {
+  color: #007af4;
+}
+
+
+
+.services-card .pp-infobox .pp-more-link .pp-button-icon-left {
+  margin-right: 15px;
+}
+
+
+
+.services-card .pp-infobox .pp-more-link .pp-button-icon-right {
+  margin-left: 15px;
+}
+
+
+
+.services-card .pp-infobox {
+  padding-top: 30px;
+  padding-right: 30px;
+  padding-bottom: 30px;
+  padding-left: 30px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-left-radius: 14px;
+  border-bottom-right-radius: 14px;
+}
+
+
+
+.services-card .pp-more-link {
+  font-family: var(--font-system-ui);
+  font-weight: 700;
+}
+
+
+
+.services-card .pp-infobox .pp-more-link {
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  margin-top: 32px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
 }

--- a/themes/beaver/layouts/home.html
+++ b/themes/beaver/layouts/home.html
@@ -336,7 +336,7 @@
                           data-node="paujk1bwfe0l">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card home-service-cto-box jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card home-service-card home-service-cto-box jt-service-box"
                               data-node="dxali8vntcr0">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -390,7 +390,7 @@
                           data-node="9xrz1vbyfomu">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card home-service-web-dev-box jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card home-service-card home-service-web-dev-box jt-service-box"
                               data-node="075ztwhd3cxn">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -444,7 +444,7 @@
                           data-node="dcks70njr95q">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card home-service-qa-box jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card home-service-card home-service-qa-box jt-service-box"
                               data-node="lajty926uxf5">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -519,7 +519,7 @@
                           data-node="reqazbvwfnj9">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card home-service-product-box jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card home-service-card home-service-product-box jt-service-box"
                               data-node="do5fjakv8b29">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -573,7 +573,7 @@
                           data-node="5syfq06jvt8x">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card home-service-staffing-box jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card home-service-card home-service-staffing-box jt-service-box"
                               data-node="3eq5kcmfz0an">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -627,7 +627,7 @@
                           data-node="r5mpnlqz427o">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card home-service-recruiting-box jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card home-service-card home-service-recruiting-box jt-service-box"
                               data-node="v3gpr4klqmob">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">

--- a/themes/beaver/layouts/page/about.html
+++ b/themes/beaver/layouts/page/about.html
@@ -206,7 +206,7 @@
                           data-node="h1byus7aprfd">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card about-value-trust"
+                              class="fl-module fl-module-pp-infobox jt-info-card about-value-card about-value-trust"
                               data-node="5tmpu20yerbq">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -243,7 +243,7 @@
                           data-node="p3acnwe42skd">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card about-value-alignment"
+                              class="fl-module fl-module-pp-infobox jt-info-card about-value-card about-value-alignment"
                               data-node="k0y7grmbj6n8">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -280,7 +280,7 @@
                           data-node="bzo12nhdvj97">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card about-value-reliability"
+                              class="fl-module fl-module-pp-infobox jt-info-card about-value-card about-value-reliability"
                               data-node="g5t28lcnjfkh">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">

--- a/themes/beaver/layouts/page/careers.html
+++ b/themes/beaver/layouts/page/careers.html
@@ -175,7 +175,7 @@
                           data-node="yx43bujcaiqn">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-people-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-card careers-value-people-box"
                               data-node="2qjtxd5mnu0o">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -211,7 +211,7 @@
                           data-node="ktz4ipj39vd6">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-longterm-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-card careers-value-longterm-box"
                               data-node="fsx06y1qr7am">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -248,7 +248,7 @@
                           data-node="m39uvorzy5g8">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-team-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-card careers-value-team-box"
                               data-node="t9y6kecruwx0">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -308,7 +308,7 @@
                           data-node="oxvacq3nkrmt">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-flexibility-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-card careers-value-flexibility-box"
                               data-node="7dpf8coyqrj1">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -346,7 +346,7 @@
                           data-node="j89kuaibv574">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-growth-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-card careers-value-growth-box"
                               data-node="silug3152ocd">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -383,7 +383,7 @@
                           data-node="gz025t4lvoui">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-training-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card careers-value-card careers-value-training-box"
                               data-node="xowkfsrzlcn8">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">

--- a/themes/beaver/layouts/page/services.html
+++ b/themes/beaver/layouts/page/services.html
@@ -105,7 +105,7 @@
                           data-node="7jz6cas305te">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card services-card-cto jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card services-card services-card-cto jt-service-box"
                               data-node="0pigeztak1xl">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -159,7 +159,7 @@
                           data-node="rxpuo06w93bn">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card services-card-webdev jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card services-card services-card-webdev jt-service-box"
                               data-node="ugiypbhnvlfw">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -213,7 +213,7 @@
                           data-node="aj2ch9vn5k1w">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card services-card-qa jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card services-card services-card-qa jt-service-box"
                               data-node="h2wjp3zb7afk">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -288,7 +288,7 @@
                           data-node="r0jkz1qcfsgp">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card services-card-product jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card services-card services-card-product jt-service-box"
                               data-node="nwx7eiysakvl">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -342,7 +342,7 @@
                           data-node="w4f3716ghpvs">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card services-card-staffing jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card services-card services-card-staffing jt-service-box"
                               data-node="a5khmr6nto3z">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">
@@ -396,7 +396,7 @@
                           data-node="6ogabjsdei1h">
                           <div class="fl-col-content fl-node-content">
                             <div
-                              class="fl-module fl-module-pp-infobox jt-info-card services-card-recruiting jt-service-box"
+                              class="fl-module fl-module-pp-infobox jt-info-card services-card services-card-recruiting jt-service-box"
                               data-node="2ufxtslray80">
                               <div class="fl-module-content fl-node-content">
                                 <div class="pp-infobox-wrap">

--- a/themes/beaver/layouts/page/starter-example.html.txt
+++ b/themes/beaver/layouts/page/starter-example.html.txt
@@ -1,0 +1,78 @@
+{{/*
+  STARTER TEMPLATE — copy to themes/beaver/layouts/page/<name>.html and
+  rename every "starter" token. Companion doc: docs/workflows/new-page.md
+  (read it - it lists the traps: prelude-only @import, bundleName
+  uniqueness, purge greedy prefix, qtest map entry).
+
+  Kept as .txt so Hugo does not treat the example as a live layout.
+*/}}
+{{ define "header" }}
+  {{- $resources := slice
+    (resources.Get "css/critical/base.css")
+    (resources.Get "css/components/testimonials.css")
+    (resources.Get "css/components/cta-banner.css")
+    (resources.Get "css/components/info-card.css")
+    (resources.Get "css/pages/starter.css")
+    (resources.Get "css/dynamic-icons.css" | resources.ExecuteAsTemplate "css/dynamic586.css" .)
+    (resources.Get "css/586.css")
+    (resources.Get "css/vendors/base-4.min.css")
+    (resources.Get "css/style.css")
+    (resources.Get "css/legacy-theme-skin.css")
+    (resources.Get "css/footer.css")
+  -}}
+  {{ partialCached "assets/css-processor.html" (dict "resources" $resources "bundleName" "starter") "starter" }}
+{{ end }}
+
+{{ define "main" }}
+  <div id="fl-main-content" class="fl-page-content" role="main">
+    <div class="fl-content-full container">
+      <div class="row">
+        <div class="fl-content col-md-12">
+          <div class="fl-builder-content fl-builder-content-primary">
+
+            {{/* HERO — page-unique by design; style under .starter-hero in pages/starter.css */}}
+            <div class="fl-row fl-row-full-width fl-row-bg-photo starter-hero fl-row-default-height fl-row-align-center">
+              <div class="fl-row-content-wrap">
+                <div class="fl-row-content fl-row-fixed-width fl-node-content">
+                  <div class="fl-col-group">
+                    <div class="fl-col starter-hero-col">
+                      <div class="fl-col-content fl-node-content">
+                        <div class="fl-module fl-module-heading starter-heading">
+                          <div class="fl-module-content fl-node-content">
+                            <h1 class="fl-heading"><span class="fl-heading-text">Page title</span></h1>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {{/* CARD GRID — three-tier card classes: global core + page core + instance */}}
+            <div class="fl-row fl-row-fixed-width starter-cards">
+              <div class="fl-row-content-wrap">
+                <div class="fl-row-content fl-row-fixed-width fl-node-content">
+                  <div class="fl-col-group fl-col-group-equal-height fl-col-group-custom-width">
+                    <div class="fl-col starter-card-first-col">
+                      <div class="fl-col-content fl-node-content">
+                        <div class="fl-module fl-module-pp-infobox jt-info-card starter-card starter-card-first">
+                          {{/* copy pp-infobox inner markup from page/services.html (one card) */}}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {{/* SHARED SECTIONS — partial + slice line, never copies */}}
+            {{ partial "page/testimonials.html" . }}
+            {{ partial "page/cta.html" . }}
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{{ end }}


### PR DESCRIPTION
## What this is

**Sprint E-2** from the groomed schedule — finishing the component library for the paved-path goal.

## Shipped

- **Per-page card consolidation (450 rule-copies collapsed)**: within each page the card instances were ~97% identical. Four per-page cores (`services-card` ×6/33 rules, `home-service-card` ×6/20, `about-value-card` ×3/25, `careers-value-card` ×6/27), additive on the modules. A card now reads `jt-info-card <page>-card <instance>` — global core → page core → instance tweaks. Value-different tie scan clean on all four pages; only the 4 card-page bundle fingerprints changed; screenshots green.
- **`jt-reviews-box` slider design restored** (decision per Paul's delegation): the intended testimonial arrow-nav + card refinements were silently purged (runtime `pp-swiper`/`pp-review` classes, no shield — same accident class as the skip-link). Greedy entries restore it; assets verified; static captures unchanged (the design lives in hover/multi-slide states) — full critical suite green with zero baseline changes.
- **Starter template**: `themes/beaver/layouts/page/starter-example.html.txt` — the copy-me page shell (slice recipe, hero, three-tier card, shared partials), kept `.txt` so Hugo ignores it.
- **`bin/qtest` component maps**: info-card/cta-banner/header-cta + the cta partial map to their consumer pages instead of escalating to `--all`.
- **Measured "not-a-component" verdicts documented**: heroes (cross-page intersection: 1 trivial rule) and stat rows (intersection: 0 — structurally different builds) stay page-unique by design; recipes in `new-page.md` instead. No forced abstractions.

## Verification

Full macOS system suite 65/119 zero failures, zero baseline changes; Linux `bin/dtest-all` EXIT=0; scoped gates per commit.

## Next per the groomed schedule

Sprint E-3 (one CTA source): parametrize the cta partial, collapse the 6 inline template copies, fix the duplicate data-node attr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYRU9wGepomJo5hSuqtu7V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized card layouts, spacing, typography, hover states, icons, and responsive behavior across homepage, services, careers, and about pages.
  - Improved testimonial slider styling so related components remain available after CSS optimization.
  - Refined page-specific card styling and visual consistency.

- **Documentation**
  - Clarified reusable component guidance, page-specific design patterns, and card styling conventions.
  - Added a starter page template example with hero, card grid, testimonials, and CTA sections.

- **Tests**
  - Expanded scoped screenshot coverage for card and CTA-related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->