### PR TITLE
chore(ci): upgrade Hugo 0.161.1 → 0.164.0, run Node tools on real Node 22

### DIFF
--- a/.github/actions/setup-hugo/action.yml
+++ b/.github/actions/setup-hugo/action.yml
@@ -4,7 +4,7 @@ description: 'Install Hugo + Bun, cache dependencies and build artifacts'
 inputs:
   hugo-version:
     description: 'Hugo version'
-    default: '0.161.1'
+    default: '0.164.0'
   environment:
     description: 'Hugo build environment'
     default: 'production'
@@ -38,15 +38,14 @@ runs:
     - run: bun install --frozen-lockfile
       shell: bash
 
-    # Use Bun as the "node" runtime for Hugo's PostCSS pipeline.
-    # Hugo 0.161+ runs Node tools with --permission flags; Bun ignores
-    # them. Symlink bun → node so Hugo's hardcoded "node" lookup finds bun.
-    - name: Use Bun as Node runtime for Hugo
-      shell: bash
-      run: |
-        mkdir -p "$HOME/.bun-as-node"
-        ln -sf "$(which bun)" "$HOME/.bun-as-node/node"
-        echo "$HOME/.bun-as-node" >> "$GITHUB_PATH"
+    # Hugo 0.164 loads Node tools through node:module registerHooks,
+    # which Bun does not implement — the old bun→node symlink now fails
+    # with "Export named 'registerHooks' not found". Use real Node 22
+    # (>=22.15 has registerHooks); the --permission flags Hugo passes are
+    # satisfied by [security.node.permissions] allowRead in hugo.toml.
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
 
     - name: Cache Hugo build
       uses: actions/cache@v5

--- a/.github/workflows/_hugo.yml
+++ b/.github/workflows/_hugo.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: jetthoughts/actions-hugo@v3
         with:
-          hugo-version: 0.161.1
+          hugo-version: 0.164.0
           extended: true
 
       - name: Checkout
@@ -45,15 +45,14 @@ jobs:
           bun-version: 1.3.13
       - run: bun install --frozen-lockfile
 
-      # Use Bun as the "node" runtime for Hugo's PostCSS pipeline.
-      # Hugo 0.161+ runs Node tools with --permission flags; Bun ignores
-      # them and runs PostCSS without filesystem-permission grief.
-      # Symlink bun → node so Hugo's hardcoded "node" lookup finds bun.
-      - name: Use Bun as Node runtime for Hugo
-        run: |
-          mkdir -p "$HOME/.bun-as-node"
-          ln -sf "$(which bun)" "$HOME/.bun-as-node/node"
-          echo "$HOME/.bun-as-node" >> "$GITHUB_PATH"
+      # Hugo 0.164 loads Node tools through node:module registerHooks,
+      # which Bun does not implement — the old bun→node symlink now fails
+      # with "Export named 'registerHooks' not found". Use real Node 22
+      # (>=22.15 has registerHooks); the --permission flags Hugo passes are
+      # satisfied by [security.node.permissions] allowRead in hugo.toml.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
 
       # Tier 2a: Hugo image cache (survives CSS/HTML changes)
       - uses: actions/cache@v6


### PR DESCRIPTION
## Summary

Follow-up to #391: upgrades the Hugo pin from **0.161.1** (April 2026) to **0.164.0** (July 6, 2026) in the two CI locations that carry it — `.github/actions/setup-hugo/action.yml` (composite action default, used by test/publish/link-check workflows) and `.github/workflows/_hugo.yml`.

### Why the bun→node symlink had to go

Hugo 0.164 loads its Node tools (the PostCSS pipeline) through `node:module` `registerHooks`. Bun doesn't implement that API, so the existing "Use Bun as Node runtime" symlink shim fails hard:

```
SyntaxError: Export named 'registerHooks' not found in module 'node:module'.
```

Both files replace the symlink step with `actions/setup-node` pinned to Node 22 (`registerHooks` ships in ≥22.15). The filesystem-permission issue the shim originally worked around is already solved by `[security.node.permissions] allowRead` in `config/_default/hugo.toml`, which I confirmed by building with real Node. Bun remains the dependency installer — only Hugo's node runtime changes.

## Verification (local, hugo_extended 0.164.0 + Node 22.22)

- Production `bin/hugo-build`: green, identical output shape to 0.161.1 — 1128 pages, 447 aliases, 177 processed images
- Build is ~35% faster (47s vs 72s on the same machine)
- `bin/rake test:critical`: 34 runs, 85 assertions, 0 errors — failure profile byte-identical to master in this container (the 25 screenshot diffs are the known local-Chromium-vs-CI-baseline environment delta, present on master too)
- Only warning is the pre-existing `.Site.Data` deprecation (since 0.156), unchanged by this PR — worth a separate cleanup before it becomes an error in a future Hugo

CI on this PR exercises the real proof: the build job runs the new setup path end-to-end.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXHeUErqoiyH9xN1mjC8cH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXHeUErqoiyH9xN1mjC8cH)_