### PR TITLE
Wave M1: hand-drawn SVGs for the 4 visual-less core lessons

### DIFF
--- a/content/course/tech-for-non-technical-founders-2026/find-10-people-with-problem-outreach-2026/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/find-10-people-with-problem-outreach-2026/index.md
@@ -77,6 +77,8 @@ Teresa Torres names three reasons a stranger turns down an interview ask, and th
 
 Work through the 30-name list first, then extend it with Part 1's second-degree searches until 10 interviews are booked - plan on 50-100 messages total. Target a reply rate of 20% or higher. Under 10% means your opener is too generic or you're in the wrong channel - rewrite the Day-0 message before sending more. 10-20% is workable: let the sequence run and tighten the subject line on the next batch. Of the replies who say yes, expect roughly half or more to actually show. If your show rate drops below 50%, add a 24-hour reminder message and confirm the meeting time the day before.
 
+![The honest outreach funnel for one batch of 30 - sent, replied at 20-30%, and 2-3 booked calls, with a warning callout for reply rates under 10%](outreach-funnel-strip.svg)
+
 ## Three tracks to 10 booked calls
 
 Cold outreach is the main track. Two others run alongside it when they fit:

--- a/content/course/tech-for-non-technical-founders-2026/find-10-people-with-problem-outreach-2026/outreach-funnel-strip.svg
+++ b/content/course/tech-for-non-technical-founders-2026/find-10-people-with-problem-outreach-2026/outreach-funnel-strip.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 340" role="img" aria-labelledby="funnel-title">
+  <title id="funnel-title">The honest outreach funnel - 30 sent messages down to booked calls</title>
+  <defs>
+    <style>
+      .heading    { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 26px; fill: #1a1a1a; font-weight: 700; }
+      .sub        { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #444; font-style: italic; }
+      .stage-num  { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 34px; fill: #1a1a1a; font-weight: 700; }
+      .stage-label{ font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 17px; fill: #1a1a1a; font-weight: 700; }
+      .drop       { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #333; }
+      .warn-text  { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #1a1a1a; }
+      .sent       { fill: #faf7f2; stroke: #1a1a1a; stroke-width: 2.5; }
+      .replied    { fill: #faf7f2; stroke: #1a1a1a; stroke-width: 2.5; }
+      .booked     { fill: #f0f9f0; stroke: #2f9e44; stroke-width: 3; }
+      .warn-box   { fill: #fff8e0; stroke: #b8860b; stroke-width: 2.5; }
+      .arrow      { stroke: #333; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
+    </style>
+    <marker id="arrowhead" markerWidth="9" markerHeight="9" refX="7" refY="3.5" orient="auto">
+      <polygon points="0 0, 9 3.5, 0 7" fill="#333"/>
+    </marker>
+  </defs>
+
+  <text x="500" y="32" class="heading" text-anchor="middle">The honest outreach funnel, one batch</text>
+  <text x="500" y="54" class="sub" text-anchor="middle">30 staggered by hand - not a single bulk-send.</text>
+
+  <!-- Sent -->
+  <rect x="30" y="75" width="230" height="140" rx="14" class="sent" transform="rotate(-0.3 145 145)"/>
+  <text x="145" y="130" class="stage-label" text-anchor="middle">SENT</text>
+  <text x="145" y="172" class="stage-num" text-anchor="middle">30</text>
+  <text x="145" y="198" class="drop" text-anchor="middle">by hand, staggered</text>
+
+  <path d="M 265 145 L 350 145" class="arrow"/>
+  <text x="307" y="130" class="drop" text-anchor="middle">20-30%</text>
+
+  <!-- Replied -->
+  <rect x="355" y="75" width="230" height="140" rx="14" class="replied" transform="rotate(0.3 470 145)"/>
+  <text x="470" y="130" class="stage-label" text-anchor="middle">REPLIED</text>
+  <text x="470" y="172" class="stage-num" text-anchor="middle">~7</text>
+  <text x="470" y="198" class="drop" text-anchor="middle">named post = replies</text>
+
+  <path d="M 590 145 L 675 145" class="arrow"/>
+  <text x="632" y="130" class="drop" text-anchor="middle">~50%+</text>
+
+  <!-- Booked -->
+  <rect x="680" y="75" width="230" height="140" rx="14" class="booked" transform="rotate(-0.3 795 145)"/>
+  <text x="795" y="130" class="stage-label" text-anchor="middle">BOOKED</text>
+  <text x="795" y="172" class="stage-num" text-anchor="middle">2-3</text>
+  <text x="795" y="198" class="drop" text-anchor="middle">stack batches to 10</text>
+
+  <!-- Warning callout -->
+  <rect x="60" y="245" width="880" height="70" rx="12" class="warn-box"/>
+  <text x="500" y="272" class="warn-text" text-anchor="middle" font-weight="700">Under 10% replies? The opener is too generic - rewrite it.</text>
+  <text x="500" y="296" class="warn-text" text-anchor="middle">10-20% is workable. 20-30% means the reference line is landing.</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/first-ten-customers-outreach-message/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/first-ten-customers-outreach-message/index.md
@@ -52,6 +52,8 @@ Every message follows the same 4-part structure. What changes by bucket is the o
 | **Warm** | "Hey [NAME], have not caught up since [the last specific touchpoint]. Working on something I think you might have a take on." |
 | **Cold** | "Hey [NAME], a true one-line reference ('we were both in the Acme batch')." |
 
+![A fill-in worksheet with columns for name, last contact, and warm-intro path, plus an example row and 7 blank rows to audit your first 8 names before writing openers](network-audit-grid.svg)
+
 If no real reference exists for a cold-bucket name, move them to [Lesson 5.7 cold outbound](/course/tech-for-non-technical-founders-2026/outbound-without-sales-team/) instead.
 
 **Part 2: One line on the problem, in their language.** Use the verbatim Q3 answers from your [Lesson 5.1 survey](/course/tech-for-non-technical-founders-2026/must-have-segment-pmf-test/). "I am building a tool that lets B2B marketers run an end-to-end attribution model without an analyst."

--- a/content/course/tech-for-non-technical-founders-2026/first-ten-customers-outreach-message/network-audit-grid.svg
+++ b/content/course/tech-for-non-technical-founders-2026/first-ten-customers-outreach-message/network-audit-grid.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 520" role="img" aria-labelledby="audit-title">
+  <title id="audit-title">Fill-in worksheet - audit your first 8 names before writing openers</title>
+  <defs>
+    <style>
+      .heading   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 26px; fill: #1a1a1a; font-weight: 700; }
+      .sub       { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #444; font-style: italic; }
+      .col-head  { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 17px; fill: #1a1a1a; font-weight: 700; }
+      .row-num   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #666; }
+      .example   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 14px; fill: #6b21a8; font-style: italic; }
+      .note      { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 14px; fill: #1a1a1a; }
+      .card      { fill: #faf7f2; stroke: #1a1a1a; stroke-width: 2.5; }
+      .example-row { fill: #fbe9ff; }
+      .divider   { stroke: #999; stroke-width: 1.5; stroke-dasharray: 4 3; }
+      .blank     { stroke: #999; stroke-width: 1.5; stroke-dasharray: 2 3; }
+      .bottom    { fill: #fbe9ff; stroke: #a855f7; stroke-width: 2.5; }
+    </style>
+  </defs>
+
+  <text x="500" y="32" class="heading" text-anchor="middle">Audit your first 8, before you write</text>
+  <text x="500" y="54" class="sub" text-anchor="middle">The facts every bracket in your opener needs.</text>
+
+  <rect x="50" y="72" width="900" height="360" rx="14" class="card"/>
+
+  <!-- column headers -->
+  <text x="185" y="100" class="col-head" text-anchor="middle">NAME</text>
+  <text x="500" y="100" class="col-head" text-anchor="middle">LAST CONTACT</text>
+  <text x="800" y="100" class="col-head" text-anchor="middle">WARM-INTRO PATH</text>
+
+  <!-- vertical dividers -->
+  <line x1="330" y1="112" x2="330" y2="420" class="divider"/>
+  <line x1="650" y1="112" x2="650" y2="420" class="divider"/>
+
+  <!-- example row -->
+  <rect x="60" y="112" width="880" height="32" class="example-row"/>
+  <text x="75" y="133" class="row-num">1.</text>
+  <text x="100" y="133" class="example">Jordan T. (example)</text>
+  <text x="360" y="133" class="example">3 months ago, LinkedIn</text>
+  <text x="665" y="133" class="example">via Casey - champion #2</text>
+
+  <!-- blank rows 2-8 -->
+  <text x="75" y="169" class="row-num">2.</text>
+  <line x1="100" y1="160" x2="315" y2="160" class="blank"/>
+  <line x1="360" y1="160" x2="635" y2="160" class="blank"/>
+  <line x1="665" y1="160" x2="925" y2="160" class="blank"/>
+
+  <text x="75" y="205" class="row-num">3.</text>
+  <line x1="100" y1="196" x2="315" y2="196" class="blank"/>
+  <line x1="360" y1="196" x2="635" y2="196" class="blank"/>
+  <line x1="665" y1="196" x2="925" y2="196" class="blank"/>
+
+  <text x="75" y="241" class="row-num">4.</text>
+  <line x1="100" y1="232" x2="315" y2="232" class="blank"/>
+  <line x1="360" y1="232" x2="635" y2="232" class="blank"/>
+  <line x1="665" y1="232" x2="925" y2="232" class="blank"/>
+
+  <text x="75" y="277" class="row-num">5.</text>
+  <line x1="100" y1="268" x2="315" y2="268" class="blank"/>
+  <line x1="360" y1="268" x2="635" y2="268" class="blank"/>
+  <line x1="665" y1="268" x2="925" y2="268" class="blank"/>
+
+  <text x="75" y="313" class="row-num">6.</text>
+  <line x1="100" y1="304" x2="315" y2="304" class="blank"/>
+  <line x1="360" y1="304" x2="635" y2="304" class="blank"/>
+  <line x1="665" y1="304" x2="925" y2="304" class="blank"/>
+
+  <text x="75" y="349" class="row-num">7.</text>
+  <line x1="100" y1="340" x2="315" y2="340" class="blank"/>
+  <line x1="360" y1="340" x2="635" y2="340" class="blank"/>
+  <line x1="665" y1="340" x2="925" y2="340" class="blank"/>
+
+  <text x="75" y="385" class="row-num">8.</text>
+  <line x1="100" y1="376" x2="315" y2="376" class="blank"/>
+  <line x1="360" y1="376" x2="635" y2="376" class="blank"/>
+  <line x1="665" y1="376" x2="925" y2="376" class="blank"/>
+
+  <!-- bottom callout -->
+  <rect x="50" y="450" width="900" height="55" rx="12" class="bottom"/>
+  <text x="500" y="483" class="note" text-anchor="middle">Recent contact = hot opener. 6-24 months = warm. No path = cold, or drop them.</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/first-ten-customers-send-track/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/first-ten-customers-send-track/index.md
@@ -49,6 +49,8 @@ The send sequence in one glance:
 2. Send the 15 warm messages a day or two later.
 3. Send the 20 cold messages once the first replies are in.
 
+![A send-day rhythm card - Day 1 champions and hot, Day 2-3 warm, Day 4+ cold, with a gate of 10+ replies logged and 3-5 demos booked](send-day-rhythm-card.svg)
+
 You will hear back from 15-25 of the 50 messages once replies settle. Expect far more replies than any cold list will ever give you - these are people who know you. It is the warmest outreach you will run.
 
 Add four tracking columns to your Sheet: Reply received (date), Reply sentiment (yes/maybe/no/silent), Demo booked (date), Pilot proposed (yes/no).

--- a/content/course/tech-for-non-technical-founders-2026/first-ten-customers-send-track/send-day-rhythm-card.svg
+++ b/content/course/tech-for-non-technical-founders-2026/first-ten-customers-send-track/send-day-rhythm-card.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 350" role="img" aria-labelledby="rhythm-title">
+  <title id="rhythm-title">The send-day rhythm - champions and hot today, warm next, cold last</title>
+  <defs>
+    <style>
+      .heading   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 26px; fill: #1a1a1a; font-weight: 700; }
+      .sub       { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #444; font-style: italic; }
+      .day       { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 20px; fill: #1a1a1a; font-weight: 700; }
+      .buckets   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 16px; fill: #1a1a1a; font-weight: 700; }
+      .rule      { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 14px; fill: #444; }
+      .gate-text { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 17px; fill: #1a1a1a; font-weight: 700; }
+      .gate-note { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 14px; fill: #1a1a1a; }
+      .day1      { fill: #fff5f5; stroke: #cc342d; stroke-width: 2.5; }
+      .day23     { fill: #faf7f2; stroke: #1a1a1a; stroke-width: 2.5; }
+      .day4      { fill: #f0f0f0; stroke: #666; stroke-width: 2; stroke-dasharray: 5 3; }
+      .gate      { fill: #f0f9f0; stroke: #2f9e44; stroke-width: 3; }
+    </style>
+  </defs>
+
+  <text x="500" y="32" class="heading" text-anchor="middle">The send-day rhythm</text>
+  <text x="500" y="54" class="sub" text-anchor="middle">A daily handful, oldest relationship first - track every reply.</text>
+
+  <!-- Day 1 -->
+  <rect x="40" y="72" width="280" height="150" rx="14" class="day1" transform="rotate(-0.3 180 147)"/>
+  <text x="180" y="105" class="day" text-anchor="middle">DAY 1</text>
+  <text x="180" y="138" class="buckets" text-anchor="middle">Champions (5) + Hot (10)</text>
+  <text x="180" y="164" class="rule" text-anchor="middle">Send today - LinkedIn DM</text>
+  <text x="180" y="184" class="rule" text-anchor="middle">or Gmail, same Loom link.</text>
+
+  <!-- Day 2-3 -->
+  <rect x="360" y="72" width="280" height="150" rx="14" class="day23" transform="rotate(0.3 500 147)"/>
+  <text x="500" y="105" class="day" text-anchor="middle">DAY 2-3</text>
+  <text x="500" y="138" class="buckets" text-anchor="middle">Warm (15)</text>
+  <text x="500" y="164" class="rule" text-anchor="middle">Send once Day 1 is out</text>
+  <text x="500" y="184" class="rule" text-anchor="middle">and the first replies land.</text>
+
+  <!-- Day 4+ -->
+  <rect x="680" y="72" width="280" height="150" rx="14" class="day4" transform="rotate(-0.3 820 147)"/>
+  <text x="820" y="105" class="day" text-anchor="middle">DAY 4+</text>
+  <text x="820" y="138" class="buckets" text-anchor="middle">Cold (20)</text>
+  <text x="820" y="164" class="rule" text-anchor="middle">Send once early replies</text>
+  <text x="820" y="184" class="rule" text-anchor="middle">settle in from Day 1-3.</text>
+
+  <!-- Gate -->
+  <rect x="60" y="252" width="880" height="78" rx="12" class="gate"/>
+  <text x="500" y="282" class="gate-text" text-anchor="middle">Gate: 10+ replies logged, 3-5 demos booked.</text>
+  <text x="500" y="306" class="gate-note" text-anchor="middle">Fewer than 5 replies? Tighten the opener before the next batch goes out.</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/vibe-prd-template/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/vibe-prd-template/index.md
@@ -55,6 +55,8 @@ related_posts: false
 > 4. Success metric (one metric, one target number)
 > 5. What you're not building (the no-go list)
 
+![The one-page brief skeleton - five labeled cards for problem, user and context, what you're building (outcome-shaped, not a feature list), success metric, and the no-go list](vibe-prd-skeleton.svg)
+
 ## Why this exists
 
 An AI app builder fills every blank you leave with a reasonable default - that is the whole reason a one-page brief exists. Feed it a bare problem statement and "build the simplest version of this," and twelve hours later you are deleting a settings page, a billing dashboard, three integrations, and a pile of toggles you never asked for, and that deleting runs three weeks. Give the same builder a one-page brief with a no-go list, and it ships the smallest end-to-end thing in 90 minutes. The page you fill in between those two attempts is the difference: the agent fills blanks with defaults, and the brief is your only way to forbid them.

--- a/content/course/tech-for-non-technical-founders-2026/vibe-prd-template/vibe-prd-skeleton.svg
+++ b/content/course/tech-for-non-technical-founders-2026/vibe-prd-template/vibe-prd-skeleton.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 480" role="img" aria-labelledby="skeleton-title">
+  <title id="skeleton-title">The one-page brief skeleton - five labeled sections</title>
+  <defs>
+    <style>
+      .heading   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 26px; fill: #1a1a1a; font-weight: 700; }
+      .sub       { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #444; font-style: italic; }
+      .sec-num   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 17px; fill: #1a1a1a; font-weight: 700; }
+      .sec-rule  { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 14px; fill: #444; }
+      .cue-good  { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 13px; fill: #1a7a3c; font-weight: 700; }
+      .cue-bad   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 13px; fill: #cc342d; font-weight: 700; }
+      .card      { fill: #faf7f2; stroke: #1a1a1a; stroke-width: 2.5; }
+      .metric    { fill: #f0f9f0; stroke: #2f9e44; stroke-width: 3; }
+      .nogo      { fill: #fff5f5; stroke: #cc342d; stroke-width: 2.5; }
+    </style>
+  </defs>
+
+  <text x="500" y="32" class="heading" text-anchor="middle">The one-page brief, five sections</text>
+  <text x="500" y="54" class="sub" text-anchor="middle">Sections 1-2 from research. 3-5 written fresh. 90 minutes, hard cap.</text>
+
+  <!-- Row 1: sections 1-3 -->
+  <rect x="30" y="72" width="300" height="170" rx="14" class="card" transform="rotate(-0.3 180 157)"/>
+  <text x="180" y="105" class="sec-num" text-anchor="middle">1 - THE PROBLEM</text>
+  <text x="180" y="135" class="sec-rule" text-anchor="middle">Copied word for word from</text>
+  <text x="180" y="155" class="sec-rule" text-anchor="middle">your validated statement -</text>
+  <text x="180" y="175" class="sec-rule" text-anchor="middle">do not soften it.</text>
+
+  <rect x="350" y="72" width="300" height="170" rx="14" class="card" transform="rotate(0.3 500 157)"/>
+  <text x="500" y="105" class="sec-num" text-anchor="middle">2 - USER + CONTEXT</text>
+  <text x="500" y="135" class="sec-rule" text-anchor="middle">The 60 seconds before and</text>
+  <text x="500" y="155" class="sec-rule" text-anchor="middle">after they reach for it -</text>
+  <text x="500" y="175" class="sec-rule" text-anchor="middle">moment of use, not TAM.</text>
+
+  <rect x="670" y="72" width="300" height="170" rx="14" class="card" transform="rotate(-0.3 820 157)"/>
+  <text x="820" y="105" class="sec-num" text-anchor="middle">3 - WHAT YOU'RE BUILDING</text>
+  <text x="820" y="132" class="sec-rule" text-anchor="middle">One verb-led paragraph.</text>
+  <text x="820" y="160" class="cue-good" text-anchor="middle">✓ outcome-shaped</text>
+  <text x="820" y="180" class="cue-bad" text-anchor="middle">✗ feature list</text>
+
+  <!-- Row 2: sections 4-5 -->
+  <rect x="30" y="262" width="455" height="170" rx="14" class="metric" transform="rotate(0.3 257 347)"/>
+  <text x="257" y="300" class="sec-num" text-anchor="middle">4 - SUCCESS METRIC</text>
+  <text x="257" y="335" class="sec-rule" text-anchor="middle">One metric. One target number.</text>
+  <text x="257" y="358" class="sec-rule" text-anchor="middle">One 30-day calendar reminder.</text>
+
+  <rect x="515" y="262" width="455" height="170" rx="14" class="nogo" transform="rotate(-0.3 743 347)"/>
+  <text x="743" y="300" class="sec-num" text-anchor="middle">5 - WHAT YOU'RE NOT BUILDING</text>
+  <text x="743" y="335" class="sec-rule" text-anchor="middle">The no-go list - name what a</text>
+  <text x="743" y="358" class="sec-rule" text-anchor="middle">competent agent would add.</text>
+</svg>


### PR DESCRIPTION
## Summary

Wave M1 of the media modernization backlog (TASK-TRACKER): one informational hand-drawn SVG for each core lesson that had a cover but zero in-body visual.

| Page | SVG | Placement |
|---|---|---|
| 2.4 find-10-people-with-problem-outreach | outreach-funnel-strip (30 sent -> ~7 replied -> 2-3 booked, amber low-reply warning) | after "Volume targets" |
| 5.4 first-ten-customers-outreach-message | network-audit-grid (fill-in worksheet: name / last contact / warm-intro path) | after bucket-opener table |
| 5.5 first-ten-customers-send-track | send-day-rhythm-card (Day 1 / 2-3 / 4+ cadence + green success gate) | after send-sequence list |
| M3 vibe-prd-template | vibe-prd-skeleton (5 section cards, outcome-shaped vs feature-list cue) | after the 5-section list |

House visual spec followed (paper tones, 2-2.5px strokes, semantic colors, labels inside shapes, Comic Sans text budgets checked per-element with >=10px margins). All numbers taken from each page's own stated targets - two spec-wording errors in the backlog were caught and corrected against page content (5.5 gate uses the page's real "10+ replies, 3-5 demos booked").

## Verification
- bin/hugo-build green after each SVG commit; bin/rake test:critical 34 runs 0 failures, 53 snap_diff clean
- Visual gate: team-lead walked all 4 pages in Chrome at 1280x800 - rendering, placement, and text fit verified per-SVG (screenshots in session)
- Built by the wave-m1 designer agent in an isolated worktree; independent visual review by team lead

🤖 Generated with [Claude Code](https://claude.com/claude-code)