### PR TITLE
Wave M2: decision-aid + F-pattern retrofits

### DIFF
--- a/content/course/tech-for-non-technical-founders-2026/hire-track-supplementary-reference/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/hire-track-supplementary-reference/index.md
@@ -274,6 +274,14 @@ Of the eight, milestone acceptance is where founders consistently lose the most 
 
 The fix is one paragraph. A milestone is delivered when (a) the acceptance criteria listed in Exhibit B pass in CI, (b) the Founder or her delegate has clicked the feature end-to-end on the staging URL, and (c) the Founder has signed off in writing within seven business days. The acceptance criteria belong in the SOW, not in a Slack message after the work is done. The five-day silent-acceptance window becomes a seven-day active-acceptance window. The invoice does not clear until the Founder signs.
 
+Side by side, the difference reads like this:
+
+| | The clause as agencies write it | Your redline |
+|---|---|---|
+| **Milestone trigger** | Code deployed to a staging URL | Exhibit B criteria pass in CI AND you click the feature end-to-end on staging |
+| **Acceptance window** | 5 days, silent - no reply means accepted | 7 business days, active - accepted only when you sign |
+| **Invoice clears** | On deploy | On your written sign-off |
+
 If the agency pushes back on this language, that is the conversation you want to have before signing, not after $78K has been wired.
 
 ### When the SOW is already signed

--- a/content/course/tech-for-non-technical-founders-2026/salvage-vs-rebuild-decision-tree/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/salvage-vs-rebuild-decision-tree/index.md
@@ -59,6 +59,32 @@ Score each question 1 or 0 and write one sentence of evidence next to it. The wh
 | Q5 | **Onboarding time** - if you hired a senior engineer Monday morning, would they ship one real pull request to staging by Friday? | There is a written README that gets a developer from `git clone` to a running local app in under two hours. | Onboarding needs "let me get on a call and walk you through it" - that is a knowledge silo, not a codebase. |
 | Q6 | **Customer signal** - are real users (not your team, not your investors, not friends doing favors) using the app every week, in volume that materially affects your business? | You can name 10+ paying or actively engaged weekly users by handle or company. | Usage is mostly the team and a few pilot accounts who have not logged in this month. |
 
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'fontFamily':'Caveat, Patrick Hand, Comic Sans MS, cursive', 'primaryColor':'#faf7f2', 'primaryBorderColor':'#333', 'lineColor':'#333', 'primaryTextColor':'#1a1a1a'}}}%%
+flowchart LR
+    Q1["Q1 - Bus factor"] --> SUM
+    Q2["Q2 - Test coverage signal"] --> SUM
+    Q3["Q3 - Database health"] --> SUM
+    Q4["Q4 - Architecture sanity"] --> SUM
+    Q5["Q5 - Onboarding time"] --> SUM
+    Q6["Q6 - Customer signal"] --> SUM
+    SUM["Add the six scores"] --> Keep["Score 5-6 - KEEP and harden"]
+    SUM --> Freeze["Score 3-4 - FREEZE and stabilize"]
+    SUM --> Rebuild["Score 0-2 - REBUILD core paths"]
+
+    classDef question fill:#fff5f5,stroke:#cc342d,stroke-width:2px,color:#1a1a1a
+    classDef sum fill:#faf7f2,stroke:#333,stroke-width:2.5px,color:#1a1a1a
+    classDef keep fill:#f0f9f0,stroke:#2e7d32,stroke-width:2.5px,color:#1a1a1a
+    classDef freeze fill:#fffbe6,stroke:#d97706,stroke-width:2.5px,color:#1a1a1a
+    classDef rebuild fill:#fff5f5,stroke:#cc342d,stroke-width:2.5px,color:#1a1a1a
+
+    class Q1,Q2,Q3,Q4,Q5,Q6 question
+    class SUM sum
+    class Keep keep
+    class Freeze freeze
+    class Rebuild rebuild
+```
+
 ## The verdict
 
 Add up the scores.

--- a/content/course/tech-for-non-technical-founders-2026/self-serve-stack-walkthrough/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/self-serve-stack-walkthrough/index.md
@@ -381,13 +381,15 @@ The bad pattern ships an MVP where any user with the right URL pattern can fake 
 
 ## Common mistakes (and how to avoid them)
 
-- **Skipping Row-Level Security in Supabase.** Every coach sees every coach's data the first time you forget. Enable RLS on every table the day you create it. Write the policies before you write the first row of seed data.
-- **Letting Lovable hold your domain.** Buy the domain on a registrar you control (Porkbun, Cloudflare, Namecheap). Point it at Lovable via DNS. If you cancel Lovable, your domain still points at whatever you put behind it next.
-- **Skipping the GitHub sync.** Lovable can sync to GitHub on every save. Set this up in the first session of Phase 1. The day you cancel the subscription is not the day to discover your code only lives inside Lovable's UI.
-- **Building 5 features instead of 1.** The phased plan ships ONE workflow end-to-end. The second feature comes after the first 5 ICP users have clicked through the first one. Skip this rule and you're the founder who spends 11 weeks on Lovable with 4 half-built features and no paid signups.
-- **Trusting the Stripe redirect instead of the webhook.** The webhook is the truth. The redirect is UX. Verify the webhook signature.
-- **Demoing only to friends.** Friends will be polite. The final Phase 4 demo must include at least 3 ICP prospects (not friends, not advisors, not your spouse). Their reaction is the data; everyone else is a warm-up.
-- **Iterating on imagined feedback.** When you finish Phase 4 and only 1 of 5 clicked, the temptation is to "improve the dashboard." Do not. Iterate on the metric that failed: the click rate (rewrite the cold message), the signup rate (rewrite the landing screen), or the paid rate (rethink the paywall position). Imagined improvements ship the same MVP forever.
+| | Mistake | The rule |
+|---|---|---|
+| **Ownership** | Skipping Row-Level Security in Supabase | Enable RLS on every table the day you create it - write the policies before the first row of seed data. Every coach sees every coach's data the first time you forget. |
+| | Letting Lovable hold your domain | Buy the domain on a registrar you control (Porkbun, Cloudflare, Namecheap) and point it at Lovable via DNS. If you cancel Lovable, the domain still points at whatever you put behind it next. |
+| | Skipping the GitHub sync | Turn on Lovable's sync-to-GitHub in the first session of Phase 1. The day you cancel the subscription is not the day to discover your code only lives inside Lovable's UI. |
+| **Scope** | Building 5 features instead of 1 | The phased plan ships ONE workflow end-to-end; the second feature comes after the first 5 ICP users click through the first. Skip this rule and you're the founder with 11 weeks on Lovable, 4 half-built features, and no paid signups. |
+| | Iterating on imagined feedback | When only 1 of 5 clicked, iterate on the metric that failed - click rate (rewrite the cold message), signup rate (rewrite the landing screen), or paid rate (rethink the paywall position). "Improving the dashboard" ships the same MVP forever. |
+| **Truth** | Trusting the Stripe redirect instead of the webhook | The webhook is the truth; the redirect is UX. Verify the webhook signature. |
+| | Demoing only to friends | The final Phase 4 demo needs at least 3 ICP prospects - not friends, advisors, or your spouse. Their reaction is the data; everyone else is a warm-up. |
 
 ## What to do after Phase 4
 

--- a/content/course/tech-for-non-technical-founders-2026/where-to-hire-developer-2026-map/hiring-region-map.svg
+++ b/content/course/tech-for-non-technical-founders-2026/where-to-hire-developer-2026-map/hiring-region-map.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 500" role="img" aria-labelledby="hiremap-title">
+  <title id="hiremap-title">Where to hire in 2026: four region cards - Onshore US/EU, Nearshore LATAM, Tier-2 India, Mass-market Upwork - each with rate band, pick-when, and watch-out.</title>
+  <desc>A 2x2 grid of region cards. Onshore US/EU: $130K-$210K+/yr, 30-60 days, pick for regulated industry or board-mandated US team, watch for low accept rate and worst cost-to-output. Nearshore LATAM, tagged Default 2026: $45-$100/hr ($90K-$200K/yr annualized), 2-5 days, pick for real-time overlap, watch for rates compressed in top metros. Tier-2 India: $15-$70/hr ($30K-$140K/yr annualized), 1-5 days, pick for backend-heavy async-OK work in Jaipur, Kochi, Indore, or Coimbatore, watch for no 9am Pacific standups and async PR culture. Mass-market Upwork: $35-$120/hr project-based, 1-3 days, pick for a one-off landing page, logo, or scraper, watch that it is not for backend, payments, or auth. A legend below explains the four border colors and that green text marks the pay rate.</desc>
+  <defs>
+    <style>
+      .h       { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; }
+      .title   { font-size: 27px; font-weight: 700; fill: #1a1a1a; }
+      .sub     { font-size: 16px; fill: #666; font-style: italic; }
+      .region  { font-size: 19px; font-weight: 700; fill: #1a1a1a; }
+      .rate    { font-size: 15px; font-weight: 700; fill: #2e7d32; }
+      .line    { font-size: 14px; fill: #333; }
+      .badge   { font-size: 11px; font-weight: 700; fill: #1a1a1a; }
+      .legend  { font-size: 12px; fill: #333; }
+      .card-red    { fill: #fff5f5; stroke: #cc342d; stroke-width: 2.5; }
+      .card-def    { fill: #faf7f2; stroke: #333; stroke-width: 2.5; }
+      .card-purple { fill: #fbe9ff; stroke: #7c3aed; stroke-width: 2.5; }
+      .card-amber  { fill: #fffbeb; stroke: #b8860b; stroke-width: 2.5; }
+      .badgebox    { fill: #fffbeb; stroke: #b8860b; stroke-width: 1.5; }
+    </style>
+  </defs>
+
+  <!-- Header -->
+  <text x="480" y="32" text-anchor="middle" class="h title">Where to hire in 2026</text>
+  <text x="480" y="56" text-anchor="middle" class="h sub">4 regions - rate band, pick-when, watch-out</text>
+
+  <!-- Card 1: Onshore US/EU -->
+  <g transform="translate(20,76) rotate(-0.5 225 84)">
+    <rect width="450" height="168" rx="14" class="card-red"/>
+    <text x="24" y="34" class="h region">Onshore (US / EU)</text>
+    <text x="24" y="64" class="h rate">$130K-$210K+/yr - 30-60 days</text>
+    <text x="24" y="94" class="h line">Pick: regulated industry or board-mandated</text>
+    <text x="24" y="112" class="h line">US team</text>
+    <text x="24" y="142" class="h line">Watch: low accept rate, worst cost-to-output</text>
+  </g>
+
+  <!-- Card 2: Nearshore LATAM (default 2026) -->
+  <g transform="translate(490,76) rotate(0.5 225 84)">
+    <rect width="450" height="168" rx="14" class="card-def"/>
+    <rect x="330" y="12" width="102" height="24" rx="8" class="badgebox"/>
+    <text x="381" y="28" text-anchor="middle" class="h badge">Default 2026</text>
+    <text x="24" y="34" class="h region">Nearshore (LATAM)</text>
+    <text x="24" y="64" class="h rate">$45-$100/hr ($90K-$200K/yr) - 2-5 days</text>
+    <text x="24" y="94" class="h line">Pick: real-time overlap for pairing,</text>
+    <text x="24" y="112" class="h line">customer calls, standups</text>
+    <text x="24" y="142" class="h line">Watch: rates compress in top metros -</text>
+    <text x="24" y="158" class="h line">screen English fluency</text>
+  </g>
+
+  <!-- Card 3: Tier-2 India -->
+  <g transform="translate(20,264) rotate(0.5 225 84)">
+    <rect width="450" height="168" rx="14" class="card-purple"/>
+    <text x="24" y="34" class="h region">Tier-2 India</text>
+    <text x="24" y="64" class="h rate">$15-$70/hr ($30K-$140K/yr) - 1-5 days</text>
+    <text x="24" y="94" class="h line">Pick: backend-heavy, async OK - Jaipur,</text>
+    <text x="24" y="112" class="h line">Kochi, Indore, Coimbatore (not Bangalore)</text>
+    <text x="24" y="142" class="h line">Watch: no 9am Pacific standups - async</text>
+    <text x="24" y="158" class="h line">PR culture</text>
+  </g>
+
+  <!-- Card 4: Mass-market Upwork -->
+  <g transform="translate(490,264) rotate(-0.5 225 84)">
+    <rect width="450" height="168" rx="14" class="card-amber"/>
+    <text x="24" y="34" class="h region">Mass-market (Upwork)</text>
+    <text x="24" y="64" class="h rate">$35-$120/hr project-based - 1-3 days</text>
+    <text x="24" y="94" class="h line">Pick: one-off landing page, logo, or</text>
+    <text x="24" y="112" class="h line">scraper</text>
+    <text x="24" y="142" class="h line">Watch: not for backend, payments, or auth</text>
+  </g>
+
+  <!-- Legend -->
+  <g transform="translate(20,452)">
+    <rect width="222" height="32" rx="8" class="card-red"/>
+    <text x="14" y="21" class="h legend">Red - highest cost, most caution</text>
+
+    <rect x="234" width="222" height="32" rx="8" class="card-def"/>
+    <text x="248" y="21" class="h legend">Neutral - recommended default</text>
+
+    <rect x="468" width="222" height="32" rx="8" class="card-purple"/>
+    <text x="482" y="21" class="h legend">Purple - alt async path</text>
+
+    <rect x="702" width="222" height="32" rx="8" class="card-amber"/>
+    <text x="716" y="21" class="h legend">Amber - heaviest watch-outs</text>
+  </g>
+  <text x="480" y="497" text-anchor="middle" class="h legend" style="fill:#2e7d32; font-weight:700;">Green text = the pay rate</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/where-to-hire-developer-2026-map/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/where-to-hire-developer-2026-map/index.md
@@ -46,6 +46,8 @@ If you find yourself comparing all four regions for an hour, you are negotiating
 
 Total time budget: 30 minutes alone, 30 minutes posting, 0 minutes second-guessing.
 
+![Where to hire in 2026: four region cards showing rate band, pick-when, and watch-out for Onshore US/EU, Nearshore LATAM, Tier-2 India, and Mass-market Upwork](hiring-region-map.svg)
+
 ## The 4 regions
 
 Walk the four rows in order. Circle the one your scope and budget land in, then move to the platform list.

--- a/docs/projects/2605-tech-for-non-technical-founders/TASK-TRACKER.md
+++ b/docs/projects/2605-tech-for-non-technical-founders/TASK-TRACKER.md
@@ -148,6 +148,21 @@ artifacts bundled, investor-showable) - Phase 2, gated on pilot demand.
 
 ### Wave M2 - decision-aid + F-pattern retrofits (~1 day)
 
+**State (2026-07-30): SHIPPED** - branch course-wave-m2-decision-aids.
+Delivered: salvage-vs-rebuild mermaid decision tree (title finally kept its
+promise); where-to-hire 4-region hand-drawn map SVG; hire-track
+trap-vs-redline milestone table; self-serve-stack mistakes bullets ->
+grouped Ownership/Scope/Truth table. 4-eyes critic: 4/4 PASS (fact
+fidelity, AI-feel, voice, nothing-lost).
+**Stale items closed without work** (already fixed by earlier sprints):
+item 4's outreach-sequence blockquote collapse (done in the PR #351
+rewrite) and the "$0 path" callout de-stack (budget-stance fix already
+landed). **Audit-metric lesson**: the words-per-visual count can't see
+blockquote scripts/Bad-Good pairs as breaks - 3 of the 4 flagged
+"word walls" (churn, outbound-full, most of self-serve + hire-track
+sections) were already healthy at section level. Assess per-H2 before
+building; only 2 real gaps existed and both are now filled.
+
 Apply the 10.05 Part 2 rules to existing prose in the highest-traffic lessons:
 1. Sweep all core lessons for if-X-then-Y prose sections -> compact decision
    table or labeled flowchart (pattern: M3's I4 "2 forks" retrofit).


### PR DESCRIPTION
## Summary

Wave M2 of the media modernization backlog: decision aids where the reader decides, F-pattern fixes where format monotony triggered the give-up rule.

| Page | Change |
|---|---|
| salvage-vs-rebuild-decision-tree | Mermaid decision flowchart (6 questions -> sum -> KEEP/FREEZE/REBUILD bands, verbatim from the page) - the title finally shows a tree |
| where-to-hire-developer-2026-map | Hand-drawn 4-region map SVG (rates/pick/watch verbatim, green = rates only, house spec) - the title finally shows a map |
| hire-track-supplementary-reference | Trap-vs-redline table for the milestone-acceptance clause (the SOW section's missing visual break) |
| self-serve-stack-walkthrough | 7 identical-format mistake bullets -> grouped Ownership/Scope/Truth table (6+ monotony rule); all vivid details preserved |

**Stale backlog items closed without work** (verified already fixed by earlier sprints): outreach-sequence blockquote collapse, "$0 path" callout de-stack. **Board lesson recorded**: the words-per-visual audit metric can't see blockquote scripts/Bad-Good pairs as visual breaks - 3 of 4 flagged word-walls were healthy at section level.

## Verification
- bin/hugo-build + 8 course validators + banned-string ratchet green; bin/rake test:critical 34 runs 0 failures, 53 snap_diff clean
- Team-lead browser walk: both new visuals + both new tables verified rendering at 1280x800 (mermaid ~530px, SVG text budgets hold)
- 4-eyes critic: fact fidelity / AI-feel / voice / nothing-lost - 4/4 PASS
- Split work: designer agent (worktree) built the two visuals; team lead built the two table retrofits and reviewed everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a side-by-side comparison of standard and founder-friendly milestone acceptance terms.
  * Added a visual decision tree for choosing whether to keep, freeze, or rebuild a product.
  * Added a regional hiring map to complement the developer hiring guide.

* **Improvements**
  * Reorganized the self-serve stack’s common mistakes into an easier-to-scan table covering Ownership, Scope, and Truth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->