### PR TITLE
Wave G3: pilot-gated campaign briefs (prep only)

### DIFF
--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/agency-uses-ai-follow-up-questions.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/agency-uses-ai-follow-up-questions.md
@@ -1,0 +1,18 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: When Your Agency Says "We Use AI" (ABSORBED - no new post needed)
+
+**Source**: 20.07 content plan, entry NEW-E (status: Deferred pending validation, 44/50)
+**Stream**: Founders
+**Planned slug**: `agency-uses-ai-follow-up-questions`
+**Status**: SUPERSEDED. Live as a course companion chapter at the SAME slug, with `aliases: ["/blog/agency-uses-ai-follow-up-questions/"]` - `/blog/agency-uses-ai-follow-up-questions/` already redirects to the course page. A short-title variant (`agency-ai-five-questions`) also shipped with its own alias. 20.07 marks this "⏸ Deferred," which is also stale now that the content exists.
+
+## Course lesson URL(s) (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/agency-uses-ai-follow-up-questions/` - "'We Use AI' - 5 Follow-Up Questions for Your Agency" (live)
+- `/course/tech-for-non-technical-founders-2026/agency-ai-five-questions/` - "The 'We Use AI' 5-Question Script" (live, shorter companion)
+
+## Angle
+No new post - the chapter is the deliverable. Remaining work is 20.07 housekeeping (mark "✅ Absorbed into course").
+
+## Internal-link plan (for OTHER posts, not this one)
+1. `#3 vibe-coding-crisis-ai-code-debt` and `#11 ai-code-ownership-accountability` (published AI-stream posts) are the natural siblings for a link on next revision - both discuss AI-code evaluation without yet pointing at this concrete question script.

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/ai-token-bill-dev-shop-pass-through-cost.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/ai-token-bill-dev-shop-pass-through-cost.md
@@ -1,0 +1,18 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: The AI Token Bill Your Dev Shop Forgot to Mention (ABSORBED - no new post needed)
+
+**Source**: 20.07 content plan, entry NEW-D2 (status: Deferred pending validation, 44/50)
+**Stream**: Founders / AI
+**Planned slug**: `ai-token-bill-dev-shop-pass-through-cost`
+**Status**: SUPERSEDED. Live as a course companion chapter at the SAME slug, with `aliases: ["/blog/ai-token-bill-dev-shop-pass-through-cost/"]` - `/blog/ai-token-bill-dev-shop-pass-through-cost/` already redirects to the course page. 20.07 marks this "⏸ Deferred," which is also stale now that the content exists.
+
+## Course lesson URL (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/ai-token-bill-dev-shop-pass-through-cost/` - "The AI Token Bill Your Agency Forgot" (live)
+
+## Angle
+No new post - the chapter is the deliverable. Remaining work is 20.07 housekeeping (mark "✅ Absorbed into course").
+
+## Internal-link plan (for OTHER posts, not this one)
+1. `dev-shop-sla-requirements-checklist` brief (this same batch) already links here as one of the "3 SOW clauses to redline now."
+2. `#8 quality-tax-ai-mvp-cost` (published) is the natural sibling for a link on next revision - both are hidden-AI-cost posts.

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/asked-simple-admin-panel-built-spaceship.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/asked-simple-admin-panel-built-spaceship.md
@@ -1,0 +1,31 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: You Asked for a Simple Admin Panel. They Built a Spaceship.
+
+**Source**: 20.07 content plan, entry NEW-I (status: Planned, 46/50) - also "Next 5 LinkedIn sprint" #3
+**Stream**: Founders / Control
+**Planned slug**: `asked-simple-admin-panel-built-spaceship`
+**Status**: New post - not yet absorbed into the course as a standalone blog piece (the LinkedIn hook of the same name is in the validation-plan backlog, see linkedin-course-briefs.md). Genuine draft candidate once the gate opens.
+
+## Working title
+"You Asked for a Simple Admin Panel. They Built a Spaceship."
+
+## Target keyword
+Primary: `over engineered mvp founder`
+Secondary: `job stories vs user stories`, `dev shop scope creep`
+
+## Course lesson URL(s) to deep-link (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/one-page-product-brief-vibe-prd/` - "3.1 - The One-Page Product Brief (Vibe PRD)" (the requirements-translation lesson this post's pain maps directly to)
+- `/course/tech-for-non-technical-founders-2026/stop-specifying-features-start-outcomes/` - "3.2 - Quality-check your brief: features to outcomes" (the exact fix for "over-engineered MVP" - rewriting feature nouns as outcome-shaped job stories)
+- `/course/tech-for-non-technical-founders-2026/vibe-prd-template/` - "Vibe PRD Template" (the copy-paste artifact)
+
+## Angle
+This is the client-research "over-engineered MVP" pain (20.07 line 66: "I asked for a report and got a custom BI platform"). The course already ships the fix as Lessons 3.1-3.2. Frame the post as: here's the failure mode with your CURRENT dev shop, here's the free 90-minute fix you can run yourself before your NEXT spec.
+
+## Internal-link plan
+1. Mid-post, right after naming the pain (spaceship vs. admin panel): link `one-page-product-brief-vibe-prd` as "the one-page brief format that prevents this."
+2. Closing section: link `stop-specifying-features-start-outcomes` as the specific quality-gate check ("features to outcomes" rewrite).
+3. This is the strongest course-fit brief in this batch - lesson 3.1/3.2 IS the antidote the post is describing, not an adjacent tool. Prioritize this post first in the funnel-post backlog once the pilot gate opens.
+
+## Hook (unchanged from 20.07, dash-checked)
+"You Asked for a Simple Admin Panel. They Built a Spaceship."

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/cheap-developers-expensive-without-cto-review.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/cheap-developers-expensive-without-cto-review.md
@@ -1,0 +1,31 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: Cheap Developers Are Expensive When Nobody Senior Reviews the Code
+
+**Source**: 20.07 content plan, entry NEW-L (status: Planned, 44/50) - also "Next 5 LinkedIn sprint" #4
+**Stream**: Founders / Control
+**Planned slug**: `cheap-developers-expensive-without-cto-review`
+**Status**: New post - not yet absorbed into the course. Genuine draft candidate once the gate opens.
+
+## Working title
+"Cheap Developers Are Expensive When Nobody Senior Reviews the Code"
+
+## Target keyword
+Primary: `cheap developer expensive mistakes`
+Secondary: `student freelancer developer risk`, `fractional cto code review`
+
+## Course lesson URL(s) to deep-link (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/should-you-hire-2026-decision-tree/` - "4.1 - Should You Hire? The 2026 Decision Tree" (routes the reader to fractional-CTO vs. full hire vs. self-serve BEFORE they repeat the cheap-talent mistake)
+- `/course/tech-for-non-technical-founders-2026/hiring-interview-script/` - "Hiring Interview Script: 7 Questions in 30 Minutes" (the senior-judgment screen this post argues for)
+- `/course/tech-for-non-technical-founders-2026/hire-track-supplementary-reference/` - "Hire Track Supplementary Reference" (fractional CTO bridge - the "senior review" role this post is describing)
+
+## Angle
+Client-research pain: "the student/freelancer was cheap until the product needed senior judgment" (20.07 line 67). Keep the post's existing framing (cheap talent trap, fractional CTO guardrails). Bridge to the course as the pre-hire prevention: run the decision tree first, screen with the interview script if you do hire.
+
+## Internal-link plan
+1. Opening ("the cheap talent trap"): link `should-you-hire-2026-decision-tree` as "this decision tree exists so you don't find out the hard way."
+2. Section on senior review: link `hiring-interview-script` as the screen that catches "cheap but unreviewed" before signing.
+3. Closing: link `hire-track-supplementary-reference` for readers who need the fractional-CTO bridge specifically.
+
+## Hook (unchanged from 20.07, dash-checked)
+"Cheap Developers Are Expensive When Nobody Senior Reviews the Code" / validation-plan variant: "Cheap developers become expensive when nobody senior reviews the code."

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/dev-shop-contract-code-ownership.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/dev-shop-contract-code-ownership.md
@@ -1,0 +1,32 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: Dev Shop Contract - Who Owns the Code?
+
+**Source**: 20.07 content plan, entry NEW-B (status: Planned, 43/50)
+**Stream**: Founders / Control
+**Planned slug**: `dev-shop-contract-code-ownership`
+**Status**: New post - not yet absorbed into the course. Genuine draft candidate once the gate opens.
+
+## Working title
+"Dev Shop Contract: Who Owns the Code?"
+
+## Target keyword
+Primary: `dev shop contract code ownership`
+Secondary: `software development contract IP`, `work for hire developer agreement`
+
+## Course lesson URL(s) to deep-link (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/ownership-checklist/` - "GitHub, AWS, Database Ownership Checklist" (companion artifact, closest topical match - contract clauses feed the same audit)
+- `/course/tech-for-non-technical-founders-2026/sow-reading-guide/` - "SOW Reading Guide: The 8 Clauses Agencies Hope You Skim" (contract-clause overlap - IP assignment is one of the 8)
+- `/course/tech-for-non-technical-founders-2026/github-aws-database-ownership-checklist/` - "4.2 - Who Owns Your GitHub, AWS, and Database?" (numbered lesson version of the same checklist)
+
+## Angle
+The post stays 20.07's existing angle (5 contract clauses, milestone ownership transfer, AI-code ownership complications) but closes with a bridge: "the checklist below is the audit version of Lesson 4.2 in the free course - if you're pre-hire, do the checklist before you sign anything."
+
+## Internal-link plan
+1. Mid-post, after the "IP assignment" section: link `sow-reading-guide` as "read the annotated SOW before you sign."
+2. Closing section ("Red flags in agency contracts"): link `ownership-checklist` as the pre-signature audit readers can run themselves.
+3. No landing-page link - deep-link the two specific chapters only, per Wave G2.1 rule (match module/lesson, not the landing page).
+4. Existing blog internal links stay as-is (`fire-dev-shop-guide`, `dev-shop-red-flags-checklist`, `outsourcing-trap-why-your-product-deserves-better-startup-tutorial`).
+
+## Hook (unchanged from 20.07, dash-checked)
+"You paid $80K for an app you don't own. It happens more than you think."

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/dev-shop-sla-requirements-checklist.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/dev-shop-sla-requirements-checklist.md
@@ -1,0 +1,30 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: What SLAs to Require From Your Dev Shop
+
+**Source**: 20.07 content plan, entry NEW-D (status: Planned, 41/50)
+**Stream**: Founders
+**Planned slug**: `dev-shop-sla-requirements-checklist`
+**Status**: New post - not yet absorbed into the course. Genuine draft candidate once the gate opens.
+
+## Working title
+"What SLAs to Require From Your Dev Shop"
+
+## Target keyword
+Primary: `software development SLA requirements`
+Secondary: `dev shop service level agreement`, `software vendor SLA checklist`
+
+## Course lesson URL(s) to deep-link (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/sow-reading-guide/` - "SOW Reading Guide: The 8 Clauses Agencies Hope You Skim" (the SOW is where SLA language actually lives - closest 1:1 match)
+- `/course/tech-for-non-technical-founders-2026/ai-token-bill-dev-shop-pass-through-cost/` - "The AI Token Bill Your Agency Forgot" (a cost-pass-through clause is itself a mini-SLA gap the post should flag)
+
+## Angle
+Keep 20.07's angle (5 SLAs, response-time commitments, uptime, "done" definition, enforcement). Position the course's SOW guide as the pre-signature version of the same discipline: "an SLA is a contract clause - the course chapter below walks the whole SOW, not just this one clause."
+
+## Internal-link plan
+1. Section 4 ("What 'done' means in a dev contract"): link `sow-reading-guide` as the annotated full-contract read.
+2. Section on response-time commitments: link `ai-token-bill-dev-shop-pass-through-cost` as one specific clause readers should redline (per the course's "3 SOW clauses to redline now").
+3. Existing blog links stay: `dev-shop-red-flags-checklist`, `hiring-dev-shop-questions`, `code-quality-evaluation-non-technical-founders` (verify this last slug exists before publish - not confirmed in this pass, flag for the writer).
+
+## Hook (unchanged from 20.07, dash-checked)
+"Your dev shop has no SLA. That means they have no obligation to fix anything, ever."

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/friday-demo-rule-founder-progress.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/friday-demo-rule-founder-progress.md
@@ -1,0 +1,19 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: The Friday Demo Rule (ABSORBED - no new post needed)
+
+**Source**: 20.07 content plan, entry NEW-J (status: Planned, 45/50) - also "Next 5 LinkedIn sprint" #1
+**Stream**: Founders / Control
+**Planned slug**: `friday-demo-rule-founder-progress`
+**Status**: SUPERSEDED. Live as a course companion chapter at the SAME slug, with `aliases: ["/blog/friday-demo-rule-founder-progress/"]` - `/blog/friday-demo-rule-founder-progress/` already redirects to the course page. A second companion artifact (`friday-demo-template`) also shipped. 20.07's table still marks this "🔲 Planned," which is stale.
+
+## Course lesson URL(s) (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/friday-demo-rule-founder-progress/` - "The Friday Demo Rule: 15 Min Truth Test" (live)
+- `/course/tech-for-non-technical-founders-2026/friday-demo-template/` - "Friday Demo Template" (live companion artifact)
+
+## Angle
+No new post - the chapter is the deliverable. Remaining work is 20.07 housekeeping (mark "✅ Absorbed into course"). This also resolves the matching LinkedIn "Next 5 sprint #1" and Week-1 Friday post hook (see linkedin-course-briefs.md) - the `Comment DEMO` CTA can point straight at this URL once campaigns unlock.
+
+## Internal-link plan (for OTHER posts, not this one)
+1. `retros-founder-transparency-tool` brief (this same batch) already links here as the companion weekly ritual.
+2. `dev-shop-red-flags-checklist` (published, Red Flag #2 "We'll show you when it's done") is the natural sibling to add a link on next revision.

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/github-aws-database-ownership-checklist.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/github-aws-database-ownership-checklist.md
@@ -1,0 +1,19 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: Who Owns Your GitHub, AWS, and Database? (ABSORBED - no new post needed)
+
+**Source**: 20.07 content plan, entry NEW-K (status: Planned, 47/50) - also "Next 5 LinkedIn sprint" #2
+**Stream**: Founders / Control
+**Planned slug**: `github-aws-database-ownership-checklist`
+**Status**: SUPERSEDED. Live as the numbered course chapter (Lesson 4.2) at the SAME slug, with `aliases: ["/blog/github-aws-database-ownership-checklist/"]` - `/blog/github-aws-database-ownership-checklist/` already redirects to the course page. A general (non-numbered) companion `ownership-checklist` also shipped. 20.07's table still marks this "🔲 Planned," which is stale - and it was the highest-scored (47/50) item in the whole "Next 5" sprint.
+
+## Course lesson URL(s) (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/github-aws-database-ownership-checklist/` - "4.2 - Who Owns Your GitHub, AWS, and Database?" (live, numbered lesson)
+- `/course/tech-for-non-technical-founders-2026/ownership-checklist/` - "GitHub, AWS, Database Ownership Checklist" (live, general companion)
+
+## Angle
+No new post - the chapter is the deliverable. Remaining work is 20.07 housekeeping (mark "✅ Absorbed into course"). This also resolves the matching LinkedIn "Next 5 sprint #2" and Week-2 Monday/Tuesday hooks (see linkedin-course-briefs.md) - the `DM me ACCESS` / `Comment ACCOUNTS` CTAs can point straight at this URL once campaigns unlock.
+
+## Internal-link plan (for OTHER posts, not this one)
+1. `dev-shop-contract-code-ownership` and `dev-shop-sla-requirements-checklist` briefs (this same batch) already link here.
+2. `dev-shop-red-flags-checklist` (published, Red Flag #1 "No git access for you") is the natural sibling to add a link on next revision.

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/paas-bill-trap-rescue-migrations.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/paas-bill-trap-rescue-migrations.md
@@ -1,0 +1,28 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: PaaS Bill Trap - 3 Migrations That Cut Costs 10x
+
+**Source**: 20.07 content plan, entry NEW-H (status: Planned, 41/50)
+**Stream**: AI (Rails/DevOps crossover)
+**Planned slug**: `paas-bill-trap-rescue-migrations`
+**Status**: New post - not yet absorbed into the course. Weak course fit - light/optional link only.
+
+## Working title
+"PaaS Bill Trap: 3 Migrations That Cut Costs 10x"
+
+## Target keyword
+Primary: `paas migration cost reduction`
+Secondary: `heroku vs aws cost`, `kamal hetzner rails migration`
+
+## Course lesson URL(s) to deep-link (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-lovable-supabase-stripe-2026/` - "4.3 - The Self-Serve MVP Stack: Tools & Setup" (weak fit: the course's stack is pre-revenue Lovable/Supabase/Stripe, not the post's post-revenue Heroku/AWS/Kamal migration - only link if the post explicitly contrasts "before you scale, here's the stack that got you here")
+
+## Angle
+This post is post-revenue infrastructure-cost content for readers who already scaled past a PaaS. The course's ICP is pre-revenue, evenings-and-weekends, self-serve-first. Do not force a course CTA - the audiences only overlap at the very edge (a course grad who later scales). Keep the post's existing bridge to the Rails-technical Thruster+Kamal post (#15) as the primary internal link.
+
+## Internal-link plan
+1. Optional, single mention only: in the intro or "cost drivers" section, one line acknowledging the course as the earlier-stage prerequisite: "if you haven't built the MVP yet, the free course's self-serve stack lesson covers the stage before this one."
+2. Primary internal links stay Rails-technical: bridge to `thruster-kamal-2-zero-config-rails-8` (queued Rails post) for the engineering audience, per the existing 20.07 brief.
+
+## Hook (unchanged from 20.07, dash-checked)
+"Heroku promised you wouldn't deal with infrastructure. You're now spending $4K/month not dealing with it."

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/retros-founder-transparency-tool.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/retros-founder-transparency-tool.md
@@ -1,0 +1,31 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: Retros Are Your Transparency Tool (Founder Edition)
+
+**Source**: 20.07 content plan, entry NEW-G (status: Planned, 41/50)
+**Stream**: AI / Founders crossover
+**Planned slug**: `retros-founder-transparency-tool`
+**Status**: New post - not yet absorbed into the course. Genuine draft candidate once the gate opens.
+
+## Working title
+"Retros Are Your Transparency Tool (Founder Edition)"
+
+## Target keyword
+Primary: `retros for non-technical founders`
+Secondary: `sprint retrospective founder`, `dev team transparency tool`
+
+## Course lesson URL(s) to deep-link (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/three-questions-turn-standup-into-proof/` - "Three Questions That Turn Standup Into Proof" (same transparency-ritual family, standup instead of retro - closest match)
+- `/course/tech-for-non-technical-founders-2026/friday-demo-rule-founder-progress/` - "The Friday Demo Rule: 15 Min Truth Test" (the companion ritual - retro answers "what happened," the demo answers "does it work")
+- `/course/tech-for-non-technical-founders-2026/friday-demo-template/` - "Friday Demo Template" (the copy-paste artifact readers can request alongside a retro cadence)
+
+## Angle
+Keep 20.07's angle (what a retro is, redacted example, what a founder should see, how to ask for one) as the counter to thoughtbot's engineer-targeted retro post. Bridge to the course by framing retros as the third leg of the same transparency stool: standup (proof), Friday demo (working software), retro (process health).
+
+## Internal-link plan
+1. Opening section ("what a retro is"): link `three-questions-turn-standup-into-proof` as "the daily version of this same idea."
+2. Closing section ("how to ask for them"): link `friday-demo-rule-founder-progress` as the weekly companion ritual.
+3. Existing blog link stays: `async-remote-xp-practices` (JetThoughts' own 15-year retro practice, already in the 20.07 brief).
+
+## Hook (unchanged from 20.07, dash-checked)
+"Your dev shop doesn't run retros. That's the third-most-common red flag, and the one nobody warns you about."

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/salvage-vs-rebuild-software-project.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/salvage-vs-rebuild-software-project.md
@@ -1,0 +1,18 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: Should You Salvage the Codebase or Rebuild? (ABSORBED under a different slug - no new post needed)
+
+**Source**: 20.07 content plan, entry NEW-M (status: Planned, 45/50) - also "Next 5 LinkedIn sprint" #5
+**Stream**: Founders / Rescue
+**Planned slug**: `salvage-vs-rebuild-software-project`
+**Status**: SUPERSEDED under a DIFFERENT slug. The same topic shipped as a course companion chapter at `salvage-vs-rebuild-decision-tree` (not the exact planned slug), with `aliases: ["/blog/salvage-vs-rebuild-decision-tree/"]`. Note the alias covers the COURSE's own slug, not 20.07's planned `salvage-vs-rebuild-software-project` - so a bare link to `/blog/salvage-vs-rebuild-software-project/` would 404. Use the course URL directly, and correct the slug reference in 20.07 rather than relying on an alias.
+
+## Course lesson URL (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/salvage-vs-rebuild-decision-tree/` - "Salvage vs Rebuild: 6-Question Decision Tree" (live)
+
+## Angle
+No new post - the chapter is the deliverable. Remaining work is 20.07 housekeeping: mark NEW-M "✅ Absorbed into course (slug changed to salvage-vs-rebuild-decision-tree)" and fix the slug reference so nobody links the dead `salvage-vs-rebuild-software-project` path. This also resolves the matching LinkedIn "Next 5 sprint #5" and backlog `Comment AUDIT` hook (see linkedin-course-briefs.md).
+
+## Internal-link plan (for OTHER posts, not this one)
+1. `#7 rescue-failed-project-playbook` (deferred in 20.07, replaced by this decision tree per its own status note) - if ever revived, point directly at this course URL instead of drafting new salvage content.
+2. `fire-dev-shop-guide` (published) is a natural sibling for a "what to do with the code you inherit" link on next revision.

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/slopsquatting-ai-supply-chain-attack.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/slopsquatting-ai-supply-chain-attack.md
@@ -1,0 +1,18 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: Slopsquatting (ABSORBED - no new post needed)
+
+**Source**: 20.07 content plan, entry #20 (status: Planned, 38/50)
+**Stream**: AI
+**Planned slug**: `slopsquatting-ai-supply-chain-attack`
+**Status**: SUPERSEDED. This topic already shipped as a course companion chapter at the SAME slug, with `aliases: ["/blog/slopsquatting-ai-supply-chain-attack/"]` in its frontmatter - meaning `/blog/slopsquatting-ai-supply-chain-attack/` already redirects to the course page. 20.07's table still marks this "🔲 Planned," which is stale.
+
+## Course lesson URL (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/slopsquatting-ai-supply-chain-attack/` - "Slopsquatting: The 2025 Supply-Chain Attack" (companion to Lesson 4.5, live)
+
+## Angle
+No brief needed for a new post - the chapter IS the post (the alias means the URL already resolves for anyone who finds the old planned slug). The remaining work is 20.07 housekeeping, not content prep: mark #20 "✅ Absorbed into course" instead of "🔲 Planned" so future funnel-planning passes don't re-queue it.
+
+## Internal-link plan (for OTHER posts, not this one)
+1. Any AI-stream post discussing AI-generated code risk (`#3 vibe-coding-crisis-ai-code-debt`, `#11 ai-code-ownership-accountability`) should add one link to this course chapter when next revised, since it is the most concrete/recent incident write-up in the funnel.
+2. No action on this file beyond the 20.07 status correction (tracked separately, not part of this prep-only brief).

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/switch-dev-shops-safely-transition-guide.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/switch-dev-shops-safely-transition-guide.md
@@ -1,0 +1,32 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: How to Switch Dev Shops Without Losing Progress
+
+**Source**: 20.07 content plan, entry NEW-C (status: Planned, 42/50)
+**Stream**: Founders
+**Planned slug**: `switch-dev-shops-safely-transition-guide`
+**Status**: New post - not yet absorbed into the course. Genuine draft candidate once the gate opens.
+
+## Working title
+"How to Switch Dev Shops Without Losing Progress"
+
+## Target keyword
+Primary: `how to switch development agencies`
+Secondary: `change dev shop transition`, `switching software development companies`
+
+## Course lesson URL(s) to deep-link (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/should-you-hire-2026-decision-tree/` - "4.1 - Should You Hire? The 2026 Decision Tree" (the reader switching shops is re-running the build-path decision)
+- `/course/tech-for-non-technical-founders-2026/where-to-hire-developer-2026-map/` - "Where to Hire Developer 2026 Map" (onshore/nearshore/offshore comparison for the NEW shop)
+- `/course/tech-for-non-technical-founders-2026/hire-track-supplementary-reference/` - "Hire Track Supplementary Reference" (fractional CTO bridge, interview screen, SOW reading - the full toolkit for re-hiring)
+
+## Angle
+Keep 20.07's angle (30-day transition checklist, securing access before firing, knowledge transfer). Frame the course links as "if you're not sure the NEXT shop is the right build path, run the 2026 decision tree before you sign."
+
+## Internal-link plan
+1. Section 4 ("What the new team needs on day one"): link `hire-track-supplementary-reference` as the pre-hire toolkit.
+2. Section 1 ("30-day transition checklist") opening: link `should-you-hire-2026-decision-tree` as "before you replace one shop with another, confirm hiring is still the right path."
+3. Optional (space permitting): `where-to-hire-developer-2026-map` in the "finding the next partner" section.
+4. Existing blog links stay: `fire-dev-shop-guide`, `dev-shop-red-flags-checklist`, `how-does-onboarding-look-like-in-jetthoughts-productivity-startup`.
+
+## Hook (unchanged from 20.07, dash-checked)
+"The hardest part of firing your dev shop isn't finding a new one. It's making sure the old one doesn't take your code with them."

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/technical-dd-series-a-2026.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/technical-dd-series-a-2026.md
@@ -1,0 +1,28 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: Technical Due Diligence in 2026
+
+**Source**: 20.07 content plan, entry #17 (status: Planned, 39/50)
+**Stream**: AI (investor-facing crossover)
+**Planned slug**: `technical-dd-series-a-2026`
+**Status**: New post - not yet absorbed into the course. Weak course fit - light/optional link only.
+
+## Working title
+"Technical Due Diligence in 2026"
+
+## Target keyword
+Primary: `technical due diligence ai code 2026`
+Secondary: `technical assessment series a`, `code quality investor checklist`
+
+## Course lesson URL(s) to deep-link (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/should-you-hire-2026-decision-tree/` - "4.1 - Should You Hire? The 2026 Decision Tree" (weak but real: an investor's "bus factor" question maps to the same build-path decision, one link max)
+
+## Angle
+This post targets founders raising Series A with an existing (often AI-heavy) codebase - a later-stage audience than the course's pre-revenue idea-validation ICP. Do not force a course CTA. The course is not the right artifact for a reader already past first revenue and into a fundraise. Skip the deep-link entirely unless the "how to prepare in 30 days" section needs a founder-education citation, in which case use the one link above as a footnote, not a body CTA.
+
+## Internal-link plan
+1. Optional, single mention only: in the "how to prepare in 30 days" section, one line: "if you're earlier than this - still validating before you've hired a team - the free five-module course covers the same ownership and hiring questions from day one."
+2. No further course integration. Keep existing internal links to `test-driven-development-tdd-in-ruby-step-by-guide-tutor`, `delivery-flow-for-distributed-remote-teams-agile-kanban`, `how-does-onboarding-look-like-in-jetthoughts-productivity-startup` as primary.
+
+## Hook (unchanged from 20.07, dash-checked)
+"Your investor's technical advisor will find what your AI-coding dev shop hid."

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/weekly-dev-report-template-founders.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/briefs/course-funnel/weekly-dev-report-template-founders.md
@@ -1,0 +1,18 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# Brief: Weekly Dev Report Template (ABSORBED - no new post needed)
+
+**Source**: 20.07 content plan, entry NEW-A (status: Planned, 44/50)
+**Stream**: Founders
+**Planned slug**: `weekly-dev-report-template-founders`
+**Status**: SUPERSEDED. Live as a course companion chapter at the SAME slug, with `aliases: ["/blog/weekly-dev-report-template-founders/"]` - `/blog/weekly-dev-report-template-founders/` already redirects to the course page. 20.07's table still marks this "🔲 Planned," which is stale.
+
+## Course lesson URL (verified under content/course/tech-for-non-technical-founders-2026/)
+- `/course/tech-for-non-technical-founders-2026/weekly-dev-report-template-founders/` - "The Plain-English Weekly Dev Report" (live)
+
+## Angle
+No new post - the chapter is the deliverable. Remaining work is 20.07 housekeeping (mark "✅ Absorbed into course").
+
+## Internal-link plan (for OTHER posts, not this one)
+1. `dev-shop-contract-code-ownership` brief (this same batch) already links to the sibling `sow-reading-guide`/`ownership-checklist` chapters - add this report-template chapter too on next brief revision, since transparency and ownership are adjacent pains.
+2. Any published post discussing dev-shop transparency (`how-make-small-valuable-async-standups-productivity-dev`, `how-know-what-your-team-doing-remote-startup`) should add one link to this chapter when next revised.

--- a/docs/projects/2605-tech-for-non-technical-founders/50-59-execution/linkedin-course-briefs.md
+++ b/docs/projects/2605-tech-for-non-technical-founders/50-59-execution/linkedin-course-briefs.md
@@ -1,0 +1,51 @@
+GATE: EXECUTE ONLY after the pilot confirms the course converts readers (GOAL-AT-A-GLANCE next-actions #4). Prep only.
+
+# LinkedIn Course-Funnel Brief Refresh (Wave G3.2)
+
+**Source**: `docs/workflows/linkedin-icp-validation-plan.md` (2-week ICP-E validation plan, 10 posts + 5 backlog)
+**Purpose**: refresh each post hook with the course lesson URL it should deep-link once the LinkedIn campaign is unpaused. This is a URL/link-plan refresh only - the plan's hooks, CTAs, and hypotheses (H1-H5) are unchanged.
+**Standing decision reminder**: no public/social share mechanics ship INSIDE the course (Standing Decision 4) - that rule governs the course's own UI, not this external LinkedIn content. LinkedIn posting itself is a distribution CAMPAIGN and is pilot-gated (Standing Decision 5).
+
+All course lesson slugs below verified to exist under `content/course/tech-for-non-technical-founders-2026/` as of 2026-07-30.
+
+---
+
+## Week 1 - Progress Visibility
+
+| Day | Post Hook | Original CTA | Course URL to link |
+|---|---|---|---|
+| Mon | "Jira is not progress. A founder needs one clickable thing every Friday." | Comment `DEMO` for the Friday demo script | `/course/tech-for-non-technical-founders-2026/friday-demo-rule-founder-progress/` - "The Friday Demo Rule: 15 Min Truth Test" |
+| Tue | "If your dev team can't show staging this week, ask this exact question." | Comment `QUESTION` for the exact wording | `/course/tech-for-non-technical-founders-2026/three-questions-turn-standup-into-proof/` - "Three Questions That Turn Standup Into Proof" |
+| Wed | Poll: "What makes you trust a dev team is actually working?" | Vote + explain what your team sends now | No direct link (poll post - keep link-free per LinkedIn poll best practice; save the URL for the follow-up comment reply instead) |
+| Thu | "A status report with 12 completed tickets can still mean zero product progress." | Comment `REPORT` for the report sanity check | `/course/tech-for-non-technical-founders-2026/weekly-dev-report-template-founders/` - "The Plain-English Weekly Dev Report" |
+| Fri | "The Friday Demo Rule: 5 things non-technical founders should see." | Comment `DEMO` | `/course/tech-for-non-technical-founders-2026/friday-demo-template/` - "Friday Demo Template" (the copy-paste artifact - use this over the rule chapter since the CTA promises a template) |
+
+## Week 2 - Ownership & Access
+
+| Day | Post Hook | Original CTA | Course URL to link |
+|---|---|---|---|
+| Mon | "You don't own your product if your vendor owns GitHub, AWS, and the database." | Comment `ACCESS` for the ownership checklist | `/course/tech-for-non-technical-founders-2026/github-aws-database-ownership-checklist/` - "4.2 - Who Owns Your GitHub, AWS, and Database?" |
+| Tue | "Ask your dev shop who owns these 7 accounts before you pay the next invoice." | Comment `ACCOUNTS` for the list | `/course/tech-for-non-technical-founders-2026/ownership-checklist/` - "GitHub, AWS, Database Ownership Checklist" (general companion, 12-item audit) |
+| Wed | Poll: "Which account would hurt most to lose?" | Vote + comment with the one you do not control | No direct link (poll post, same rule as Week 1 Wed) |
+| Thu | "Read access to GitHub is not ownership." | Comment `REPO` for the repo access test | `/course/tech-for-non-technical-founders-2026/ownership-checklist/` - same checklist, repo-ownership section |
+| Fri | "The vendor transition checklist I wish every founder had before signing." | Comment `TRANSFER` | `/course/tech-for-non-technical-founders-2026/hire-track-supplementary-reference/` - "Hire Track Supplementary Reference" (closest existing artifact; no dedicated "vendor transition checklist" chapter exists yet - flag as a content gap if this post outperforms in the pilot) |
+
+## Backlog (if Weeks 1-2 validate ICP)
+
+| Pillar | Post Hook | Original CTA | Course URL to link |
+|---|---|---|---|
+| Requirements Translation | "You asked for a simple admin report. They built a BI platform." | Comment `SIMPLE` | `/course/tech-for-non-technical-founders-2026/stop-specifying-features-start-outcomes/` - "3.2 - Quality-check your brief: features to outcomes" |
+| Requirements Translation | "Job story template for non-technical founders." | Comment `JOB` | `/course/tech-for-non-technical-founders-2026/vibe-prd-template/` - "Vibe PRD Template - One-Page Product Brief" |
+| Cheap Talent Trap | "Cheap developers become expensive when nobody senior reviews the code." | Comment `REVIEW` | `/course/tech-for-non-technical-founders-2026/hiring-interview-script/` - "Hiring Interview Script: 7 Questions in 30 Minutes" |
+| Salvage vs Rebuild | "Three signs your codebase is salvageable. Three signs it is not." | Comment `AUDIT` | `/course/tech-for-non-technical-founders-2026/salvage-vs-rebuild-decision-tree/` - "Salvage vs Rebuild: 6-Question Decision Tree" |
+| Runway Urgency | "If you have 6 months of runway, don't spend 3 months guessing." | Comment `RUNWAY` | `/course/tech-for-non-technical-founders-2026/form-your-founding-hypothesis-90-minute-sprint/` - "1.1 - Form Your Founding Hypothesis" (the fastest on-ramp lesson - matches the urgency framing) |
+
+---
+
+## Notes for whoever executes this after the gate opens
+
+1. **UTM discipline unchanged**: keep `utm_source=linkedin&utm_medium=social&utm_campaign=icp_validation_<pillar>` plus a per-post `utm_content` on every course URL, per the validation plan's existing UTM Rules section.
+2. **Poll posts (Wed, both weeks) stay link-free in the post body** - LinkedIn's algorithm penalizes outbound links on poll posts; put the course URL in the top comment instead once someone engages.
+3. **Artifact-first CTA rule is unchanged**: "Comment DEMO" / "DM me ACCESS" etc. still comes before any link - the course URL is what gets sent AFTER the comment, not embedded in the post as a public link (Standing Decision 4's private-sharing spirit extends to how these DMs are handled, even though the standing decision itself is scoped to the course's own UI).
+4. **Fri Week 2 gap**: no course chapter matches "vendor transition checklist" 1:1 yet. If this post wins in the pilot, that is a real content gap for Wave G3.1's follow-up work, not just a link-plan miss.
+5. Voice check: all hooks above are copied verbatim from `linkedin-icp-validation-plan.md` - no new hook copy was drafted in this brief, so no additional voice-guide pass was needed beyond confirming existing dashes stay "-" not em/en dash (checked - the source plan already uses "-").


### PR DESCRIPTION
15 blog-funnel briefs + 1 LinkedIn brief, every one stamped 'EXECUTE ONLY after the pilot confirms conversion'. Bonus finding recorded in briefs: 7 topics in the 20.07 plan are already live as course chapters with /blog/ aliases - plan status column is stale. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and updated course-funnel content briefs covering software ownership, developer contracts, SLAs, AI costs, technical due diligence, progress visibility, and vendor transitions.
  * Documented SEO targets, editorial angles, internal-link plans, and course lesson references for new content.
  * Clarified which planned posts have been superseded and absorbed into existing course chapters, including redirect and housekeeping guidance.
  * Added a LinkedIn course-funnel refresh with lesson mappings, campaign linking guidance, and pilot validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->