### PR TITLE
Wave G2 theme: copy-link referral button + GA4 beacon + analytics consent granted

### DIFF
--- a/themes/beaver/layouts/partials/blog/course-analytics.html
+++ b/themes/beaver/layouts/partials/blog/course-analytics.html
@@ -17,7 +17,8 @@
     if (!el || typeof window.gtag !== 'function') return;
     window.gtag('event', 'course_' + el.getAttribute('data-course-event').replace(/-/g, '_'), {
       course_label: el.getAttribute('data-course-label') || '',
-      link_url: el.getAttribute('href') || ''
+      link_url: el.getAttribute('href') || '',
+      transport_type: 'beacon'
     });
   }, { passive: true });
 </script>

--- a/themes/beaver/layouts/partials/blog/course-prev-next.html
+++ b/themes/beaver/layouts/partials/blog/course-prev-next.html
@@ -97,5 +97,12 @@
     {{- end }}
   </div>
   <p class="course-prev-next__glossary">Tripping on a term? <a href="{{ $base }}five-tech-words-stop-nodding-at/" data-course-event="glossary-click" data-course-label="{{ $slug }}">Five Tech Words to Stop Nodding At</a> - the course glossary.</p>
+  {{- $moduleEnds := slice "price-hypothesis-on-smoke-test-page" "clickable-prototype-validation-2-hour-lovable" "stop-specifying-features-start-outcomes" "vibe-coding-ceiling-signals" "outbound-without-sales-team" }}
+  {{- if in $moduleEnds $slug }}
+  <p class="course-prev-next__glossary">Know a founder sitting on an idea? <button type="button"
+      style="background:none;border:none;padding:0;color:inherit;text-decoration:underline;cursor:pointer;font:inherit"
+      data-course-event="copy-share-link" data-course-label="{{ $slug }}"
+      onclick="var b=this; navigator.clipboard.writeText('{{ site.BaseURL }}course/tech-for-non-technical-founders-2026/').then(function(){ b.textContent='Copied - paste it in a DM'; })">Copy the course link</button> to send them privately.</p>
+  {{- end }}
 </nav>
 {{- end -}}

--- a/themes/beaver/layouts/partials/page/analytics.html
+++ b/themes/beaver/layouts/partials/page/analytics.html
@@ -17,8 +17,14 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     {{ if site.Params.privacyCompliant }}
+      {{/* 2026-07-30 (Paul): analytics consent granted by default - the old
+           denied-by-default had no banner to ever grant it, so GA4 ran
+           permanently in cookieless-ping mode and the course funnel recorded
+           nothing. Ads storage stays denied (we run no ads). If a consent
+           banner ships later (e.g. Google Privacy & Messaging CMP), flip
+           analytics_storage back to 'denied' as the pre-consent default. */}}
       gtag('consent', 'default', {
-        'analytics_storage': 'denied',
+        'analytics_storage': 'granted',
         'ad_storage': 'denied'
       });
     {{ end }}


### PR DESCRIPTION
## Summary

Three measurement/referral fixes from growth runbook 20.12:

- **Copy-link referral button** on the 5 module-end lessons (1.5/2.6/3.2/4.5/5.7): clipboard-only, no social icons (stealth-ICP standing rule), styled as an inline link, fires `course_copy_share_link` through the existing data-course-event handler. Click feedback swaps the label to "Copied - paste it in a DM".
- **GA4 beacon transport** in course-analytics: click events (incl. `course_pdf_download`) previously never landed - the click navigated away before gtag flushed. Verified missing in the G1.2 production check.
- **Analytics consent default -> granted** (Paul, 2026-07-30): the old denied-by-default had no consent banner to ever grant it, so GA4 ran permanently in cookieless-ping mode and the course funnel recorded nothing. `ad_storage` stays denied (no ads). If a CMP banner ships later, the pre-consent default flips back to denied (comment in the partial documents this).

## Verification
- bin/hugo-build + 8 validators green; bin/rake test:critical 34 runs 0 failures
- BOTH visual suites: bin/test (macOS) green; bin/dtest (Linux/Docker) green after rebuilding the stale test image (gems from #391 - image rebuild documented)
- Button verified rendering on 5.7 in dev server; GA4 consent + event delivery re-verify on production post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)