### PR TITLE
Wave G2.1: blog-to-course internal links (10 evergreen posts)

### DIFF
--- a/content/blog/ai-agent-deleted-production-database-pocketos/index.md
+++ b/content/blog/ai-agent-deleted-production-database-pocketos/index.md
@@ -73,6 +73,8 @@ These four guardrails don't prevent every failure. They turn "company death in 9
 
 This is the same operational discipline that powers [our remote XP practices post](/blog/async-remote-xp-practices/) - the boring infrastructure that makes small mistakes cheap to fix.
 
+> **The four config defaults above are exactly what a Friday audit is built to catch.** Our free founder course includes a 45-minute walkthrough for locking down who owns your code, cloud, and database before anyone else - human or agent - touches them. [Who Owns Your GitHub, AWS, and Database?](/course/tech-for-non-technical-founders-2026/github-aws-database-ownership-checklist/).
+
 ## The 7 questions to ask your dev shop this week
 
 Crane's incident thread ran past 1,000 comments because every founder reading it recognized something. You don't need to know what a "scoped token" is to ask the right question. Read these out loud on your next agency call:

--- a/content/blog/ai-code-ownership-accountability/index.md
+++ b/content/blog/ai-code-ownership-accountability/index.md
@@ -76,6 +76,8 @@ Last clause, the one that closes the back door: source-handover obligation on te
 
 Expect a 30-minute call about the amendment. Expect the agency to ask for a 5-10% rate bump on the SBOM and handover clauses; they require operational changes on their side, and that's a fair ask. If they push back on all five, you've already learned what was missing from the original deal.
 
+> **The weekend audit below has a printable version.** Our free course includes a 12-item ownership checklist you can run alone, no engineer required, covering the same code, cloud, and database questions this post walks through. [GitHub, AWS, Database Ownership Checklist](/course/tech-for-non-technical-founders-2026/ownership-checklist/).
+
 ## But Wait - You Trust Your Agency
 
 Sure. So did Jer Crane at [PocketOS](/blog/ai-agent-deleted-production-database-pocketos/), a live car-rental SaaS whose AI agent dropped the production database and the backups in nine seconds. His agency wasn't malicious. They just didn't gate the model the way the kernel gates a contributor. The diligence partner asks for a signature, not for trust. The kernel maintainers trust their contributors and still demand one. Without a paper trail, trust is just hope, and hope doesn't survive due diligence.

--- a/content/blog/dev-shop-red-flags-checklist/index.md
+++ b/content/blog/dev-shop-red-flags-checklist/index.md
@@ -131,6 +131,8 @@ Count your red flags. Be honest.
 | 3-4 | Orange zone | Start your exit plan. Secure code access, export your data, get a second opinion. Don't fire them yet - but be ready. Read our [guide to firing your dev shop safely](/blog/fire-dev-shop-guide/) |
 | 5+ | Red zone | You're paying for damage, not progress. Begin the transition now. The longer you wait, the more expensive the cleanup |
 
+> **If your scorecard landed in the orange or red zone, the next call isn't "fire or stay" - it's "salvage or rebuild."** A free lesson from our non-technical founder course turns that call into a structured thirty-minute decision with a 30/60/90 day plan attached. [Salvage vs Rebuild: 6-Question Decision Tree](/course/tech-for-non-technical-founders-2026/salvage-vs-rebuild-decision-tree/).
+
 ## What to Do If You See 3+ Red Flags
 
 Don't panic, and don't send an angry email at midnight. Here's the sequence.

--- a/content/blog/fire-dev-shop-guide/index.md
+++ b/content/blog/fire-dev-shop-guide/index.md
@@ -141,6 +141,8 @@ Request a reference from a founder they've rescued - not their happiest client, 
 
 The first week tells you everything about the next six months. Did they send an [onboarding checklist](/blog/effective-project-onboarding-checklist-management-productivity/)? Set up a project board? Explain their [delivery flow](/blog/delivery-flow-for-distributed-remote-teams-agile-kanban/)?
 
+> **Before you sign with the next team, revisit whether "hire an agency" is even the right path.** JetThoughts' free course maps the fork between hiring, going self-serve, and bringing on a fractional CTO. [Should You Hire? The 2026 Decision Tree](/course/tech-for-non-technical-founders-2026/should-you-hire-2026-decision-tree/).
+
 ## When NOT to fire
 
 A new team takes 4-8 weeks of ramp-up before they ship anything, during which your burn continues with zero output. Firing also stacks $5K-$15K of overhead before the next feature ships: code escrow, audit, transition oversight, contract negotiation. If your runway is under four months, your MVP launch is inside thirty days, or the only complaint you can articulate is founder frustration without a missed deliverable, the exit is usually the wrong move. Fix the spec or the communication first; if the next sprint with clear written goals still slips, then you have your answer in writing.

--- a/content/blog/founders-guide-hiring-dev-shop/index.md
+++ b/content/blog/founders-guide-hiring-dev-shop/index.md
@@ -30,6 +30,8 @@ We tracked the patterns in [47 Startups Failed the Same Way](/blog/47-startups-f
 
 Before you sign any contract, understand what "done" actually means. A working demo is not a shippable product. Ask the agency how they handle testing, code review, and security audits - and get specific answers, not reassurances.
 
+> **The decision you're about to make has a name.** JetThoughts runs a free, ungated course for non-technical founders, and lesson 4.1 walks through this exact fork - validate without code, self-serve, fractional CTO, or hire a team - with the five questions that tell you which path fits. [Should You Hire? The 2026 Decision Tree](/course/tech-for-non-technical-founders-2026/should-you-hire-2026-decision-tree/).
+
 ## How to Evaluate
 
 Once you start working with an agency, most problems reveal themselves within the first few weeks - if you know where to look. We compiled the most common early signals in [8 Red Flags You Hired the Wrong Dev Shop](/blog/dev-shop-red-flags-checklist/). The short version: watch for agencies that avoid showing you the code, resist third-party audits, or cannot explain their architecture decisions in plain language.

--- a/content/blog/hiring-dev-shop-questions/index.md
+++ b/content/blog/hiring-dev-shop-questions/index.md
@@ -122,7 +122,7 @@ The founders who asked "what's your rate?" first and skipped the rest? They hire
 
 If a shop can't give you direct answers to all five questions on the first call, you've already learned everything you need to know about how the engagement will go.
 
-> **Vetting solved, sourcing is next.** Our free founder course lays out onshore, nearshore, and offshore hiring side by side - pricing, time-to-hire, and where each option tends to work. No email, no login: [Where to Hire a Developer, 2026 Map](/course/tech-for-non-technical-founders-2026/where-to-hire-developer-2026-map/).
+> **Once you know what to ask, the next question is where to look.** Our free founder course lays out onshore, nearshore, and offshore hiring side by side - pricing, time-to-hire, and where each option tends to work. No email, no login: [Where to Hire a Developer, 2026 Map](/course/tech-for-non-technical-founders-2026/where-to-hire-developer-2026-map/).
 
 ---
 

--- a/content/blog/hiring-dev-shop-questions/index.md
+++ b/content/blog/hiring-dev-shop-questions/index.md
@@ -122,6 +122,8 @@ The founders who asked "what's your rate?" first and skipped the rest? They hire
 
 If a shop can't give you direct answers to all five questions on the first call, you've already learned everything you need to know about how the engagement will go.
 
+> **Vetting solved, sourcing is next.** Our free founder course lays out onshore, nearshore, and offshore hiring side by side - pricing, time-to-hire, and where each option tends to work. No email, no login: [Where to Hire a Developer, 2026 Map](/course/tech-for-non-technical-founders-2026/where-to-hire-developer-2026-map/).
+
 ---
 
 ## Use the checklist on us first

--- a/content/blog/hiring-developers-contractors-budget-guide-founders/index.md
+++ b/content/blog/hiring-developers-contractors-budget-guide-founders/index.md
@@ -1824,6 +1824,8 @@ In the Maya scenario above, the founder spent $76K total after a $16K false star
 4. ✅ **Hire for communication as much as technical skill** (you'll talk daily)
 5. ✅ **Trust but verify** (code reviews, demos, milestone-based payments)
 
+> **This budget math has a free companion.** A lesson in our non-technical founder course compares onshore, nearshore, and Tier-2 offshore options against pricing and time-to-hire, so you can sanity-check the numbers above against your own runway. [Where to Hire a Developer, 2026 Map](/course/tech-for-non-technical-founders-2026/where-to-hire-developer-2026-map/).
+
 **Take Action Monday Morning**:
 1. Calculate true budget (subtract 15-20% for tools and contingency)
 2. Choose hiring model based on YOUR constraints

--- a/content/blog/quality-tax-ai-mvp-cost/index.md
+++ b/content/blog/quality-tax-ai-mvp-cost/index.md
@@ -90,6 +90,8 @@ That process catches bugs cheaper than the alternatives. A bug caught in TDD cos
 
 A B2B fintech founder, post-Series-A in Q4 2025, had been quoted $42K by an AI-first shop for a 4-week MVP. She engaged us at $58K instead - same scope, 6 weeks, TDD and security pass included. Eight months on, her test coverage sits at 78%, she has added two engineers without a rewrite, and her only post-launch fix was a 6-hour rate-limiting issue in the third-party broker integration that no test could have caught at MVP scope. **Sticker price was 38% higher; her 12-month all-in came in 41% lower.**
 
+> **Disciplined AI usage is teachable, and we wrote the walkthrough down.** Our free course for non-technical founders covers the same tools-then-build sequence - Lovable, Supabase, Stripe - plus the pre-flight rules that keep AI output honest before you write a line of code. [The Self-Serve MVP Stack: Tools & Setup](/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-lovable-supabase-stripe-2026/).
+
 ## 7. When AI actually saves money
 
 AI saves money in two specific conditions, and we'll be direct about both.

--- a/content/blog/vibe-coding-crisis-ai-code-debt/index.md
+++ b/content/blog/vibe-coding-crisis-ai-code-debt/index.md
@@ -64,6 +64,8 @@ A second person should read every pull request before it lands. Two developers [
 
 Your team should send you a [weekly report](/blog/how-know-what-your-team-doing-remote-startup/) showing what shipped and whether test coverage went up or down. Watch that ratio. If features climb while coverage drops, somebody is cutting corners. Ship small features often, not three-week sprints that end in a big reveal - the big reveal is where vibe-coded apps look impressive, because nobody has tested them with real users yet, and where [technical debt compounds fastest](/blog/fixing-slow-engineering-teams-an-extended/).
 
+> **These five signals have a course-lesson twin.** We wrote a companion piece for founders already building on Lovable or a similar tool - five architectural ceiling signals, and what it means when two of them fire for a month straight. Free, no sign-up: [Vibe Coding Done Right: 5 Ceiling Signals](/course/tech-for-non-technical-founders-2026/vibe-coding-ceiling-signals/).
+
 ## You've already got one. What's next?
 
 If three or more of those signals describe your codebase, the next question isn't whether you have a vibe-coded app. Our companion post on [the generate-validate-kill workflow](/blog/vibe-coding-disposable-by-design/) walks through how to use vibe coding for what it's good at, plus the cost math on why founders who try to skip the rebuild end up paying twice.

--- a/content/blog/vibe-coding-disposable-by-design/index.md
+++ b/content/blog/vibe-coding-disposable-by-design/index.md
@@ -129,6 +129,8 @@ The validation work survives the kill. User flows, edge cases the prototype expo
 
 Skipping the rebuild is the trap. The MVP works, the customers pay, the founder thinks: "I'll just keep iterating on this." Six months later the rebuild is happening anyway, only now the founder has runway pressure and ten production users who hit a new bug every time the team ships a fix.
 
+> **Rebuilding fresh needs a plan, not just resolve.** A free lesson in our founder course lays out the four build phases from a bare Lovable UI to a live Stripe checkout, with a demo at the end of each phase. [The Self-Serve MVP Stack: Build Phases](/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-build-phases/).
+
 ## Five questions to ask before you charge a paying customer
 
 Before you take real money for a vibe-coded app - whether you built it yourself or your shop did - run these questions on whoever shipped it.


### PR DESCRIPTION
## Summary

Fixes the biggest acquisition-hygiene bug from the growth audit: 0 of ~580 blog posts linked to the free course. Adds ONE house-style callout to 10 evergreen posts, each deep-linking a topically-matching course lesson (8 distinct lessons - link equity spread across Module 4 pages, not dumped on the landing).

Guardrails honored: rotation rule (10 distinct openers; one copula-avoiding fragment caught in team-lead review and reworded), voice gates, no selling language (free/ungated per Standing Decision 1), dev_to imports skipped, all target slugs verified. Not pilot-gated per runbook 20.12 (internal linking hygiene, not a campaign).

## Verification
- bin/hugo-build 8/8 validators green; bin/rake test:critical 34 runs 0 failures (initial flaky screenshot failures reproduced on a clean tree - pre-existing, not from these text-only edits)
- Content-only markdown; no theme/CSS touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)