### PR TITLE
fix(homepage): breathing room between hero CTA and hero image on mobile

### DIFF
--- a/themes/beaver/assets/css/critical/homepage-critical.css
+++ b/themes/beaver/assets/css/critical/homepage-critical.css
@@ -609,6 +609,13 @@
   .fl-photo-img {
     max-width: 100%;
   }
+  /* Stacked hero columns: on desktop the CTA and the hero photo sit
+     side-by-side; below 860px they stack and nothing supplies a gap -
+     the photo starts at the button's bottom pixel (0px, measured at a
+     390px viewport). Breathing room for the stacked layout only. */
+  .home-hero-media {
+    margin-top: 28px;
+  }
   .home-hero-photo .fl-photo {
     text-align: left;
   }


### PR DESCRIPTION
## Summary

Fixes the button layout issue from the production phone screenshot: on mobile, the hero "Get a Free Code Audit" CTA sat **glued to the hero image** — a measured **0px gap** at a 390×844 viewport. On desktop the CTA and photo are side-by-side columns; below 860px they stack, and nothing supplied a stacking margin.

One rule, scoped to the existing stacked-layout breakpoint in `themes/beaver/assets/css/critical/homepage-critical.css`:

```css
@media (max-width: 860px) {
  .home-hero-media { margin-top: 28px; }
}
```

## Diagnosis notes

- Production is **not down** — the deploy pipeline's latest master runs are all green and the site serves (the phone screenshot itself renders the page). Direct curl checks from the agent container are blocked by its proxy, not by the site.
- The button's Ruby-red 8px-radius styling itself is **intentional** (the site-wide CTA branding in `navigation.css` deliberately overrides the legacy blue 25px pill — verified via a full cascade probe). The actual defect was the missing stacking gap.

## Verification

- Browser probe at 390×844 emulation (pinned Chrome for Testing 141): gap `0px → 28px`, no horizontal overflow (`scrollWidth == innerWidth == 390`).
- Desktop 1280×800 screenshot unchanged — the rule lives inside the ≤860px block only.
- Production `bin/hugo-build` green.

## Baseline note

Mobile homepage baselines (`macos/` and `linux/`) will show this intentional 28px shift on the next blessed-stack run — re-record via `bin/test` (macOS) / `bin/dtest` and commit alongside, per the visual-gate rule. (This container can't produce valid baselines for either stack; the Phase 3 dirty-baseline guard now protects against accidental commits meanwhile.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXHeUErqoiyH9xN1mjC8cH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXHeUErqoiyH9xN1mjC8cH)_