### PR TITLE
Wave M5 (un-gated): P2 SVGs + module-end checklists + interaction audits

### DIFF
--- a/content/course/tech-for-non-technical-founders-2026/clickable-prototype-validation-2-hour-lovable/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/clickable-prototype-validation-2-hour-lovable/index.md
@@ -155,6 +155,8 @@ Catching a shape mismatch here costs one throwaway prototype. Catching it in Mod
 >
 > **Deeper reference:** [Full prototype build, session script, and Module 2 decision matrix](/course/tech-for-non-technical-founders-2026/reference/prototype-build-full/) - the screen-by-screen build, the worked example, the verbatim session script, the combined interview + prototype decision matrix, and the artifacts map.
 
+> **Module 2 closes here.** Before opening Module 3, you should have: (1) a Mom Test question list that reads past-tense and specific (Lesson 2.1), (2) a 30-name list of people you can name because you read what they posted (Lesson 2.3), (3) 10 scored Mom Test interview transcripts (Lesson 2.4), (4) a build / pivot / kill verdict - 7+ strong signals to build (Lesson 2.5), and (5) 5 scored prototype sessions with 4-5 passes and verbatim "describe in one sentence" vocabulary (this lesson). All five in your `Founder OS` folder. Missing one? Go back - Lesson 3.1 reads your validated problem statement into Section 1 and your prototype vocabulary into Section 3; a missing artifact means writing the brief from a guess.
+
 ---
 
 *See it in action: [Module 2 walkthrough: Mia interviews ten parents](/course/tech-for-non-technical-founders-2026/module-2-walkthrough-mia/)*

--- a/content/course/tech-for-non-technical-founders-2026/fake-stripe-pre-sale-pieter-levels/dollar-presale-flow.svg
+++ b/content/course/tech-for-non-technical-founders-2026/fake-stripe-pre-sale-pieter-levels/dollar-presale-flow.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 600" role="img" aria-labelledby="presale-title">
+  <title id="presale-title">The $1 pre-sale flow, from button to proof</title>
+  <defs>
+    <style>
+      .heading      { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 28px; fill: #1a1a1a; font-weight: 700; }
+      .step-label   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 21px; fill: #1a1a1a; font-weight: 700; }
+      .step-rule    { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #333; }
+      .step-note    { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 14px; fill: #444; font-style: italic; }
+      .money-line   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #15803d; font-weight: 700; }
+      .subtitle     { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #444; font-style: italic; }
+      .step-button  { fill: #faf7f2; stroke: #1a1a1a; stroke-width: 2.5; }
+      .step-charge  { fill: #fff5f5; stroke: #cc342d; stroke-width: 2.5; }
+      .step-promise { fill: #fff8e0; stroke: #b8860b; stroke-width: 2.5; }
+      .step-proof   { fill: #faf7f2; stroke: #1a1a1a; stroke-width: 2.5; }
+      .callout      { fill: #fbe9ff; stroke: #a855f7; stroke-width: 2.5; }
+    </style>
+  </defs>
+
+  <text x="500" y="40" class="heading" text-anchor="middle">The $1 pre-sale flow</text>
+  <text x="500" y="68" class="subtitle" text-anchor="middle">A real $1 charge beats a free email signup - same visitors, sharper signal.</text>
+
+  <!-- Step 1: The button -->
+  <rect x="60" y="100" width="430" height="180" rx="14" class="step-button" transform="rotate(-0.3 275 190)"/>
+  <text x="275" y="134" class="step-label" text-anchor="middle">1. THE BUTTON</text>
+  <text x="275" y="168" class="step-rule" text-anchor="middle">"Reserve your spot - $1 today,</text>
+  <text x="275" y="192" class="step-rule" text-anchor="middle">refundable if we don't ship by [DATE]."</text>
+  <text x="275" y="222" class="step-note" text-anchor="middle">Same Stripe Payment Link setup as Lesson 1.5.</text>
+
+  <!-- Step 2: The charge -->
+  <rect x="510" y="100" width="430" height="180" rx="14" class="step-charge" transform="rotate(0.4 725 190)"/>
+  <text x="725" y="134" class="step-label" text-anchor="middle">2. THE CHARGE</text>
+  <text x="725" y="168" class="step-rule" text-anchor="middle">A real $1 Stripe charge - a wallet</text>
+  <text x="725" y="192" class="step-rule" text-anchor="middle">decision, not a free email click.</text>
+  <text x="725" y="222" class="step-note" text-anchor="middle">Conversion drops 3-5x - fewer clicks, truer signal.</text>
+
+  <!-- Step 3: The promise -->
+  <rect x="60" y="310" width="430" height="180" rx="14" class="step-promise" transform="rotate(0.3 275 400)"/>
+  <text x="275" y="344" class="step-label" text-anchor="middle">3. THE PROMISE</text>
+  <text x="275" y="378" class="step-rule" text-anchor="middle">Thank-you page promises a full refund</text>
+  <text x="275" y="402" class="step-rule" text-anchor="middle">within 7 days if we don't ship by [DATE].</text>
+  <text x="275" y="432" class="step-note" text-anchor="middle">Non-negotiable: refund every charge within 30 days.</text>
+
+  <!-- Step 4: What the click proved -->
+  <rect x="510" y="310" width="430" height="180" rx="14" class="step-proof" transform="rotate(-0.4 725 400)"/>
+  <text x="725" y="344" class="step-label" text-anchor="middle">4. WHAT THE CLICK PROVED</text>
+  <text x="725" y="378" class="step-rule" text-anchor="middle">0 sales: hypothesis or price is wrong.</text>
+  <text x="725" y="402" class="step-rule" text-anchor="middle">1-10 sales: iterate headline + targeting.</text>
+  <text x="725" y="432" class="money-line" text-anchor="middle">50+ sales: PMF signal - start building.</text>
+
+  <!-- Bottom callout -->
+  <rect x="80" y="520" width="840" height="65" rx="12" class="callout"/>
+  <text x="500" y="546" class="step-label" text-anchor="middle">The click proves demand. Not a business.</text>
+  <text x="500" y="572" class="step-note" text-anchor="middle">Retention (5.1) and unit economics are separate, later tests.</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/fake-stripe-pre-sale-pieter-levels/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/fake-stripe-pre-sale-pieter-levels/index.md
@@ -32,6 +32,8 @@ The default [smoke test](/course/tech-for-non-technical-founders-2026/smoke-test
 
 This page is the companion writeup for that variant. Use it when an email-only signal isn't strong enough to commit to a build.
 
+![The $1 pre-sale flow - button, charge, refund promise, and what the click proved](dollar-presale-flow.svg)
+
 ## Email signup vs $1 refundable charge
 
 A waitlist captures curiosity (a free email costs the visitor nothing). A $1 charge captures a wallet decision. The same 100 visitors who would cheerfully give you an email might generate zero payment clicks - and that zero is the validated demand signal you actually need.

--- a/content/course/tech-for-non-technical-founders-2026/friday-demo-template/friday-demo-timeline.svg
+++ b/content/course/tech-for-non-technical-founders-2026/friday-demo-template/friday-demo-timeline.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 400" role="img" aria-labelledby="demo-timeline-title">
+  <title id="demo-timeline-title">The 15-minute Friday demo: 7 questions in order, then the hard stop</title>
+  <defs>
+    <style>
+      .heading   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 27px; fill: #1a1a1a; font-weight: 700; }
+      .subtitle  { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #444; font-style: italic; }
+      .qnum      { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 20px; fill: #cc342d; font-weight: 700; }
+      .stopnum   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 20px; fill: #b8860b; font-weight: 700; }
+      .qlabel    { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 13px; fill: #1a1a1a; font-weight: 700; }
+      .chevron   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 16px; fill: #999; }
+      .step      { fill: #faf7f2; stroke: #1a1a1a; stroke-width: 2; }
+      .stop      { fill: #fff8e0; stroke: #b8860b; stroke-width: 2.5; }
+      .rule-label{ font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 18px; fill: #1a1a1a; font-weight: 700; }
+      .rule-note { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 14px; fill: #444; font-style: italic; }
+    </style>
+  </defs>
+
+  <text x="500" y="34" class="heading" text-anchor="middle">The 15-minute Friday demo</text>
+  <text x="500" y="58" class="subtitle" text-anchor="middle">Same 7 questions, same order, every week - 4pm, hard stop.</text>
+
+  <!-- 7 questions -->
+  <rect x="40" y="90" width="99" height="110" rx="10" class="step" transform="rotate(-0.3 89.5 145)"/>
+  <text x="89.5" y="120" class="qnum" text-anchor="middle">Q1</text>
+  <text x="89.5" y="150" class="qlabel" text-anchor="middle">SHIPPED?</text>
+
+  <text x="148" y="150" class="chevron" text-anchor="middle">&#8250;</text>
+
+  <rect x="157" y="90" width="99" height="110" rx="10" class="step" transform="rotate(0.3 206.5 145)"/>
+  <text x="206.5" y="120" class="qnum" text-anchor="middle">Q2</text>
+  <text x="206.5" y="150" class="qlabel" text-anchor="middle">USER DID?</text>
+
+  <text x="265" y="150" class="chevron" text-anchor="middle">&#8250;</text>
+
+  <rect x="274" y="90" width="99" height="110" rx="10" class="step" transform="rotate(-0.3 323.5 145)"/>
+  <text x="323.5" y="120" class="qnum" text-anchor="middle">Q3</text>
+  <text x="323.5" y="150" class="qlabel" text-anchor="middle">LIVE HERE?</text>
+
+  <text x="382" y="150" class="chevron" text-anchor="middle">&#8250;</text>
+
+  <rect x="391" y="90" width="99" height="110" rx="10" class="step" transform="rotate(0.3 440.5 145)"/>
+  <text x="440.5" y="120" class="qnum" text-anchor="middle">Q4</text>
+  <text x="440.5" y="150" class="qlabel" text-anchor="middle">WHAT CUT?</text>
+
+  <text x="499" y="150" class="chevron" text-anchor="middle">&#8250;</text>
+
+  <rect x="508" y="90" width="99" height="110" rx="10" class="step" transform="rotate(-0.3 557.5 145)"/>
+  <text x="557.5" y="120" class="qnum" text-anchor="middle">Q5</text>
+  <text x="557.5" y="150" class="qlabel" text-anchor="middle">IN REVIEW?</text>
+
+  <text x="616" y="150" class="chevron" text-anchor="middle">&#8250;</text>
+
+  <rect x="625" y="90" width="99" height="110" rx="10" class="step" transform="rotate(0.3 674.5 145)"/>
+  <text x="674.5" y="120" class="qnum" text-anchor="middle">Q6</text>
+  <text x="674.5" y="150" class="qlabel" text-anchor="middle">BLOCKED?</text>
+
+  <text x="733" y="150" class="chevron" text-anchor="middle">&#8250;</text>
+
+  <rect x="742" y="90" width="99" height="110" rx="10" class="step" transform="rotate(-0.3 791.5 145)"/>
+  <text x="791.5" y="120" class="qnum" text-anchor="middle">Q7</text>
+  <text x="791.5" y="150" class="qlabel" text-anchor="middle">WORRY NEXT?</text>
+
+  <text x="850" y="150" class="chevron" text-anchor="middle">&#8250;</text>
+
+  <!-- hard stop -->
+  <rect x="859" y="90" width="99" height="110" rx="10" class="stop" transform="rotate(0.4 908.5 145)"/>
+  <text x="908.5" y="120" class="stopnum" text-anchor="middle">STOP</text>
+  <text x="908.5" y="150" class="qlabel" text-anchor="middle">15 MIN</text>
+  <text x="908.5" y="170" class="qlabel" text-anchor="middle">HARD</text>
+
+  <!-- hard rules footer -->
+  <rect x="50" y="240" width="900" height="90" rx="12" class="stop"/>
+  <text x="500" y="272" class="rule-label" text-anchor="middle">Working software only. No slides, no mockups.</text>
+  <text x="500" y="296" class="rule-note" text-anchor="middle">No Figma, no Jira screenshots. If a demo isn't ready, say so Wednesday.</text>
+  <text x="500" y="318" class="rule-note" text-anchor="middle">You click the staging URL yourself, live, while they talk.</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/friday-demo-template/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/friday-demo-template/index.md
@@ -32,6 +32,8 @@ By Friday of week 4 you will know whether your dev team is shipping or stalling.
 
 > **7 questions, asked in order:** (1) What shipped? (2) What did the user do? (3) Where is it live for me? (4) What did we cut? (5) What's in review? (6) What's blocked? (7) What should I worry about next week?
 
+![The 15-minute Friday demo timeline - 7 questions in order, then the hard stop](friday-demo-timeline.svg)
+
 ## Why this exists
 
 Jira closing nine tickets in a week tells you cards moved, not that anything works. A feature can sit "behind a feature flag" for three weeks, throw a 500 on every click, and still show up as closed tickets and a confident status update - four months and $54K into a six-week MVP - because no one on the call has to open it in front of you. The seven questions above force that open. Asked in order, they turn a status call into four demos and four staging URLs you click yourself: what shipped, what the user can now do, where it is live for you, and what got cut to make room.

--- a/content/course/tech-for-non-technical-founders-2026/outbound-without-sales-team/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/outbound-without-sales-team/index.md
@@ -119,6 +119,8 @@ The 30-message batch is not a one-time event. Run fresh batches until you have 2
 >
 > **Deeper reference:** [Product Hunt data, the full tooling stack, domain warmup, the funnel math, all three script variants, the stage cadence, and the no-reply diagnostic](/course/tech-for-non-technical-founders-2026/reference/outbound-full/)
 
+> **Module 5 closes here.** Before calling the course complete, you should have: (1) a passed Sean Ellis 40% must-have test against your early users (Lesson 5.1), (2) a 50-name network list sorted into 4 outreach buckets (Lesson 5.3), (3) 4 outreach message variants plus a 90-second Loom (Lesson 5.4), (4) at least one signed Design Partner Agreement with a refundable Stripe deposit (Lesson 5.6), and (5) a 30-message filtered cold-outbound batch sent with replies tracked once the network list ran dry (this lesson). All five in your `Founder OS` folder. Missing one? Go back - customer 11-20 depend on the same motion, and a broken step upstream (an untested must-have signal, an unsent batch, an unsigned DPA) breaks every batch that follows it.
+
 ---
 
 *See it in action: [Module 5 walkthrough: Mia gets paid](/course/tech-for-non-technical-founders-2026/module-5-walkthrough-mia/)*

--- a/content/course/tech-for-non-technical-founders-2026/price-hypothesis-on-smoke-test-page/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/price-hypothesis-on-smoke-test-page/index.md
@@ -101,6 +101,8 @@ Open your Stripe dashboard. Write down the number of clicks vs. completed paymen
 >
 > **Variant:** [Fake-Stripe Pre-Sale (Pieter Levels style)](/course/tech-for-non-technical-founders-2026/fake-stripe-pre-sale-pieter-levels/) - a $1 refundable charge instead of a waitlist button, when you want the strongest pre-product demand signal. Includes refund and FTC compliance notes.
 
+> **Module 1 closes here.** Before opening Module 2, you should have: (1) a founding hypothesis scored 14+/20 across the four lenses (Lesson 1.1), (2) a live smoke-test page that passed the one-stranger clarity test (Lesson 1.2), (3) Clarity + GA4 tracking installed and verified (Lesson 1.3), (4) a go / iterate / kill read from 300 cold visitors (Lesson 1.4), and (5) a Stripe Payment Link live with a measured click-to-payment rate (this lesson). All five in your `Founder OS` folder. Missing one? Go back - Module 2 interviews ask real people about the hypothesis and price you just tested; walking in without a finished artifact means asking about a guess instead of a measured signal.
+
 ---
 
 *See it in action: [Module 1 walkthrough: Mia builds TutorMatch](/course/tech-for-non-technical-founders-2026/module-1-walkthrough-mia/)*

--- a/content/course/tech-for-non-technical-founders-2026/sow-reading-guide/eight-clause-risk-map.svg
+++ b/content/course/tech-for-non-technical-founders-2026/sow-reading-guide/eight-clause-risk-map.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 520" role="img" aria-labelledby="clause-map-title">
+  <title id="clause-map-title">The 8-clause SOW risk map: each clause and what it quietly costs</title>
+  <defs>
+    <style>
+      .heading    { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 27px; fill: #1a1a1a; font-weight: 700; }
+      .subtitle   { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #444; font-style: italic; }
+      .clabel     { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 15px; fill: #1a1a1a; font-weight: 700; }
+      .ccost      { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 14px; fill: #cc342d; }
+      .card       { fill: #fff5f5; stroke: #cc342d; stroke-width: 2; }
+      .callout    { fill: #fff8e0; stroke: #b8860b; stroke-width: 2.5; }
+      .call-label { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 19px; fill: #1a1a1a; font-weight: 700; }
+      .call-note  { font-family: "Caveat", "Patrick Hand", "Comic Sans MS", cursive; font-size: 14px; fill: #444; font-style: italic; }
+    </style>
+  </defs>
+
+  <text x="500" y="34" class="heading" text-anchor="middle">The 8-clause SOW risk map</text>
+  <text x="500" y="58" class="subtitle" text-anchor="middle">Each clause, and what it quietly costs you if you skim it.</text>
+
+  <!-- Row 1 -->
+  <rect x="40" y="90" width="218" height="150" rx="12" class="card" transform="rotate(-0.3 149 165)"/>
+  <text x="149" y="120" class="clabel" text-anchor="middle">1. SCOPE</text>
+  <text x="149" y="150" class="ccost" text-anchor="middle">Vague scope = blank</text>
+  <text x="149" y="168" class="ccost" text-anchor="middle">check.</text>
+
+  <rect x="274" y="90" width="218" height="150" rx="12" class="card" transform="rotate(0.3 383 165)"/>
+  <text x="383" y="120" class="clabel" text-anchor="middle">2. MILESTONE</text>
+  <text x="383" y="140" class="clabel" text-anchor="middle">ACCEPTANCE</text>
+  <text x="383" y="168" class="ccost" text-anchor="middle">Paid for staging no</text>
+  <text x="383" y="186" class="ccost" text-anchor="middle">one uses.</text>
+
+  <rect x="508" y="90" width="218" height="150" rx="12" class="card" transform="rotate(-0.3 617 165)"/>
+  <text x="617" y="120" class="clabel" text-anchor="middle">3. CHANGE</text>
+  <text x="617" y="140" class="clabel" text-anchor="middle">REQUESTS</text>
+  <text x="617" y="168" class="ccost" text-anchor="middle">$185/hr, no cap,</text>
+  <text x="617" y="186" class="ccost" text-anchor="middle">no compare.</text>
+
+  <rect x="742" y="90" width="218" height="150" rx="12" class="card" transform="rotate(0.3 851 165)"/>
+  <text x="851" y="120" class="clabel" text-anchor="middle">4. IP</text>
+  <text x="851" y="140" class="clabel" text-anchor="middle">OWNERSHIP</text>
+  <text x="851" y="168" class="ccost" text-anchor="middle">Agency holds repo</text>
+  <text x="851" y="186" class="ccost" text-anchor="middle">hostage.</text>
+
+  <!-- Row 2 -->
+  <rect x="40" y="260" width="218" height="150" rx="12" class="card" transform="rotate(0.3 149 335)"/>
+  <text x="149" y="290" class="clabel" text-anchor="middle">5. 3RD-PARTY</text>
+  <text x="149" y="310" class="clabel" text-anchor="middle">ACCOUNTS</text>
+  <text x="149" y="338" class="ccost" text-anchor="middle">Rented accounts</text>
+  <text x="149" y="356" class="ccost" text-anchor="middle">+ 15% fee.</text>
+
+  <rect x="274" y="260" width="218" height="150" rx="12" class="card" transform="rotate(-0.3 383 335)"/>
+  <text x="383" y="290" class="clabel" text-anchor="middle">6. TERMINATION</text>
+  <text x="383" y="330" class="ccost" text-anchor="middle">Can't exit for</text>
+  <text x="383" y="348" class="ccost" text-anchor="middle">bad work.</text>
+
+  <rect x="508" y="260" width="218" height="150" rx="12" class="card" transform="rotate(0.3 617 335)"/>
+  <text x="617" y="290" class="clabel" text-anchor="middle">7. WARRANTY</text>
+  <text x="617" y="330" class="ccost" text-anchor="middle">Clock runs out</text>
+  <text x="617" y="348" class="ccost" text-anchor="middle">before launch.</text>
+
+  <rect x="742" y="260" width="218" height="150" rx="12" class="card" transform="rotate(-0.3 851 335)"/>
+  <text x="851" y="290" class="clabel" text-anchor="middle">8. DISPUTES</text>
+  <text x="851" y="330" class="ccost" text-anchor="middle">Their city,</text>
+  <text x="851" y="348" class="ccost" text-anchor="middle">their lawyer.</text>
+
+  <!-- Bottom callout -->
+  <rect x="50" y="440" width="900" height="65" rx="12" class="callout"/>
+  <text x="500" y="466" class="call-label" text-anchor="middle">$78K invoiced. 4 of 5 milestones. Runway 12mo to 7mo.</text>
+  <text x="500" y="490" class="call-note" text-anchor="middle">One email with all 8 questions, before you sign, catches this.</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/sow-reading-guide/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/sow-reading-guide/index.md
@@ -30,6 +30,8 @@ An annotated sample SOW that catches the 8 clauses agencies hope you skim.
 
 By the time you finish your second coffee you will know whether the 47-page Statement of Work in front of you carries 3-5 clauses that will cost you more than the price of the project. You will not have read a line of code or talked to a lawyer. You will have walked one sample SOW clause by clause, marked the flags, and written the questions the agency needs to answer before you sign.
 
+![The 8-clause SOW risk map - each clause and what it quietly costs](eight-clause-risk-map.svg)
+
 ## Why this exists
 
 One clause in a 47-page SOW decides whether you can withhold payment for work that does not run: the **milestone acceptance clause**. When it defines "delivered" as "deployed to staging" rather than "passing the acceptance criteria with production traffic," every milestone clears the moment code reaches a staging URL - even one that 500s on the second click. A general counsel reading the SOW the night before tends to catch the liability cap and the IP assignment and skim right past this line. Miss it, and three months in you can have paid for **four of five milestones** and been invoiced **$78K** for work nobody can use, with runway compressed from twelve months to seven. Most agencies are not malicious about SOW language; they start from a template that survived their last twelve clients, and the template has a few clauses that quietly favor the agency.

--- a/content/course/tech-for-non-technical-founders-2026/stop-specifying-features-start-outcomes/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/stop-specifying-features-start-outcomes/index.md
@@ -95,8 +95,6 @@ After Lessons 3.1-3.2 you have five artifacts. Each feeds a specific downstream 
 | **Audience-of-one fork** (AI agent / junior dev / senior team, from 3.1) | Lesson 4.1 build-path routing - decides whether the brief goes to Lovable or a contractor. |
 | **Quality-check verdict** (3.2 - did the peer answer cleanly?) | Checkpoint before Module 4. If the peer cannot answer cleanly, return here and rewrite Section 3 first. |
 
-> **Module 3 closes here.** Before opening Module 4 you should have: a one-page Product Brief with 5 sections filled in (3.1), Section 3 rewritten as outcome-shaped job stories that pass the peer test (this lesson), and a no-go list of 5-8 items - all in your `Founder OS` folder. If this lesson saved you a build-and-throwaway round, someone you know is about to hand a builder four vague words too - send them this free course page. Missing an artifact? Go back - Module 4 reads the brief into Lovable prompts, and a half-written brief produces a half-working MVP.
-
 ---
 
 > **Done:** every line of Section 3 is rewritten in the *When / I want / So I can* shape, and one quality-check pass (peer, AI, or the manual question) names nothing outside your Section 3 scope and no-go list.
@@ -108,6 +106,8 @@ After Lessons 3.1-3.2 you have five artifacts. Each feeds a specific downstream 
 > **If blocked:** see "If this fails" above.
 >
 > **Deeper reference:** [The second worked pair, the priced-out comparison, the full AI-reviewer protocol, and stack-ranking outcomes with real users](/course/tech-for-non-technical-founders-2026/reference/outcomes-not-features-full/)
+
+> **Module 3 closes here.** Before opening Module 4, you should have: (1) a one-page Product Brief with 5 sections filled in (Lesson 3.1), (2) Section 3 rewritten as outcome-shaped job stories in the *When / I want / So I can* form (this lesson), (3) a no-go list of 5-8 items (Lesson 3.1 Section 5), and (4) a passed quality-check verdict - a peer or AI reviewer names nothing outside your Section 3 scope and no-go list (this lesson). All four in your `Founder OS` folder. Missing one? Go back - Module 4 reads the brief into Lovable prompts, and a half-written brief produces a half-working MVP.
 
 ---
 


### PR DESCRIPTION
## Summary

Wave M5, un-gated by Paul 2026-07-30. Combined M5a (designer agent) + M5b (editor agent), both independently reviewed by team lead with a browser walk of every new artifact.

**M5a - 3 informational SVGs** (house hand-drawn spec, text budgets verified):
- fake-stripe-pre-sale: $1 pre-sale flow (button -> charge -> promise -> what the click proved). Agent caught + corrected a spec error: the page is a REAL refundable charge, not a fake-door pattern.
- friday-demo-template: 8-node Q1-Q7 + hard-stop timeline strip
- sow-reading-guide: 8-clause risk map with the page's own $78K numbers (no green anywhere - page has no money-success outcome)
- 2 pages skipped with reason (agency-AI-questions, churn-triage) - both already carry adequate decision visuals

**M5b - module-end checklists** for M1/M2/M3/M5 matching M4's model form (position, numbered checks, Founder OS reference, go-back consequence); all numbers from existing canon. Plus two audits: Do-This-Now template-link audit (0 violations - a prior wave closed it) and reflection-line duplicate audit (0 exact duplicates; 4-lesson soft pattern noted for future).

## Verification
- Team-lead visual gate at 1280x800: all 3 SVGs + M1 checklist walked in browser - rendering, budgets, semantic colors, placement all clean
- bin/hugo-build 8/8 validators + ratchet green; bin/rake test:critical 34 runs 0 failures, 53 snap_diff clean on the combined branch
- Note: Lesson 1.3 still teaches Sam to install Clarity on SAM'S OWN smoke-test page - unaffected by our site's Clarity waiver (different concern; no change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)