### PR TITLE
Wave M5c: informational SVGs for the 5 zero-visual reference chapters

### DIFF
--- a/content/course/tech-for-non-technical-founders-2026/reference/channel-selection-full/channel-fit-decision.svg
+++ b/content/course/tech-for-non-technical-founders-2026/reference/channel-selection-full/channel-fit-decision.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 680" font-family='"Caveat", "Patrick Hand", "Comic Sans MS", cursive'>
+  <defs>
+    <filter id="rough" x="-2%" y="-2%" width="104%" height="104%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.025" numOctaves="2" seed="17"/>
+      <feDisplacementMap in="SourceGraphic" scale="2"/>
+    </filter>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1a1a1a"/>
+    </marker>
+  </defs>
+  <rect width="980" height="680" fill="#fafaf7"/>
+
+  <!-- Title -->
+  <text x="490" y="40" font-size="30" text-anchor="middle" fill="#1a1a1a" font-weight="bold">Score the channel before you send message one</text>
+  <text x="490" y="66" font-size="19" text-anchor="middle" fill="#555">Interview evidence in, one committed channel out</text>
+
+  <!-- Interview evidence -->
+  <g filter="url(#rough)">
+    <rect x="240" y="90" width="500" height="90" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="490" y="122" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">Interview evidence</text>
+  <text x="490" y="150" font-size="17" text-anchor="middle" fill="#1a1a1a">Pull the channel signals from your 10 transcripts</text>
+
+  <!-- Arrow -->
+  <line x1="490" y1="183" x2="490" y2="222" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="505" y="210" font-size="16" fill="#1a1a1a" font-style="italic">score each channel 1-3 per dimension</text>
+
+  <!-- Channel-fit score -->
+  <g filter="url(#rough)">
+    <rect x="240" y="227" width="500" height="100" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="490" y="260" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">Channel-fit score - total out of 12</text>
+  <text x="490" y="288" font-size="17" text-anchor="middle" fill="#1a1a1a">Price point - buyer type - time budget - interview signal</text>
+  <text x="490" y="310" font-size="15" text-anchor="middle" fill="#555" font-style="italic">LinkedIn DM - cold email - community - social organic</text>
+
+  <!-- Branch arrows -->
+  <path d="M 380 330 L 180 385" fill="none" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="490" y1="330" x2="490" y2="385" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+  <path d="M 600 330 L 800 385" fill="none" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- 9+ commit -->
+  <g filter="url(#rough)">
+    <rect x="40" y="390" width="280" height="110" rx="10" fill="#f0f9f0" stroke="#2e7d32" stroke-width="2.5"/>
+  </g>
+  <text x="180" y="425" font-size="21" text-anchor="middle" fill="#2e7d32" font-weight="bold">9 or more / 12</text>
+  <text x="180" y="453" font-size="16" text-anchor="middle" fill="#1a1a1a">Clear pick -</text>
+  <text x="180" y="475" font-size="16" text-anchor="middle" fill="#1a1a1a">commit to that channel</text>
+
+  <!-- 7-8 pilot -->
+  <g filter="url(#rough)">
+    <rect x="350" y="390" width="280" height="110" rx="10" fill="#fbe9ff" stroke="#8e24aa" stroke-width="2.5"/>
+  </g>
+  <text x="490" y="425" font-size="21" text-anchor="middle" fill="#8e24aa" font-weight="bold">7-8 / 12</text>
+  <text x="490" y="453" font-size="16" text-anchor="middle" fill="#1a1a1a">1-week pilot on your top 2 -</text>
+  <text x="490" y="475" font-size="16" text-anchor="middle" fill="#1a1a1a">higher reply rate wins</text>
+
+  <!-- 6 or less -->
+  <g filter="url(#rough)">
+    <rect x="660" y="390" width="280" height="110" rx="10" fill="#faf7f2" stroke="#a3621e" stroke-width="2.5"/>
+  </g>
+  <text x="800" y="425" font-size="21" text-anchor="middle" fill="#a3621e" font-weight="bold">6 or less / 12</text>
+  <text x="800" y="453" font-size="16" text-anchor="middle" fill="#1a1a1a">No strong fit - go back to</text>
+  <text x="800" y="475" font-size="16" text-anchor="middle" fill="#1a1a1a">the transcripts for missing signal</text>
+
+  <!-- Arrows into commitment -->
+  <line x1="180" y1="503" x2="180" y2="535" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="490" y1="503" x2="490" y2="535" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Commitment -->
+  <g filter="url(#rough)">
+    <rect x="140" y="540" width="700" height="95" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="490" y="572" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">The commitment</text>
+  <text x="490" y="598" font-size="17" text-anchor="middle" fill="#1a1a1a">Run a full send / reply / follow-up arc before any switch</text>
+  <text x="490" y="620" font-size="15" text-anchor="middle" fill="#555" font-style="italic">Check: reply rate over 5% - demos turn into paid conversations - right buyer</text>
+
+  <!-- Footnote -->
+  <text x="490" y="665" font-size="19" text-anchor="middle" fill="#a3621e" font-style="italic">Call the channel dead after 2 quick replies and you just threw away the signal.</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/reference/channel-selection-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/channel-selection-full/index.md
@@ -10,6 +10,8 @@ slug: channel-selection-full
 
 ---
 
+![A hand-drawn decision flow: a red interview evidence card feeds a red channel-fit score card totalling out of 12 across price point, buyer type, time budget and interview signal, then branches three ways - a green 9 or more card meaning clear pick and commit, a purple 7-8 card meaning 1-week pilot on your top 2 where the higher reply rate wins, and an amber 6 or less card meaning no strong fit, go back to the transcripts. The commit and pilot branches drop into a red commitment card: run a full send / reply / follow-up arc before any switch, checking reply rate over 5%, demos turning into paid conversations, and the right buyer.](channel-fit-decision.svg)
+
 ## The commitment rule, phase by phase
 
 Stick with one channel long enough to read the signal, not chase the algorithm. A cold-email sequence needs time to deliver, more time for replies to accumulate, and more time still before the "not now" replies reveal whether the non-replies are disinterest or bad timing.

--- a/content/course/tech-for-non-technical-founders-2026/reference/find-10-people-full/channels-to-10-calls-funnel.svg
+++ b/content/course/tech-for-non-technical-founders-2026/reference/find-10-people-full/channels-to-10-calls-funnel.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 640" font-family='"Caveat", "Patrick Hand", "Comic Sans MS", cursive'>
+  <defs>
+    <filter id="rough" x="-2%" y="-2%" width="104%" height="104%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.025" numOctaves="2" seed="5"/>
+      <feDisplacementMap in="SourceGraphic" scale="2"/>
+    </filter>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1a1a1a"/>
+    </marker>
+  </defs>
+  <rect width="980" height="640" fill="#fafaf7"/>
+
+  <!-- Title -->
+  <text x="490" y="40" font-size="30" text-anchor="middle" fill="#1a1a1a" font-weight="bold">From channels to 10 booked calls</text>
+  <text x="490" y="66" font-size="19" text-anchor="middle" fill="#555">The list narrows at every step - you want signal, not volume</text>
+
+  <!-- Stage 1: channels -->
+  <g filter="url(#rough)">
+    <rect x="50" y="90" width="600" height="90" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="350" y="122" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">Search the channels</text>
+  <text x="350" y="150" font-size="17" text-anchor="middle" fill="#1a1a1a">Reddit - LinkedIn - Slack / Discord - G2 / Capterra - X - referrals</text>
+
+  <!-- Arrow 1 -->
+  <line x1="350" y1="183" x2="350" y2="222" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="365" y="210" font-size="16" fill="#1a1a1a" font-style="italic">copy complaints verbatim</text>
+
+  <!-- Stage 2: 30 names -->
+  <g filter="url(#rough)">
+    <rect x="100" y="227" width="500" height="80" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="350" y="259" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">30 real sentences + 30 named people</text>
+  <text x="350" y="285" font-size="16" text-anchor="middle" fill="#555" font-style="italic">The exact wording becomes your subject lines</text>
+
+  <!-- Arrow 2 -->
+  <line x1="350" y1="310" x2="350" y2="349" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Stage 3: filter -->
+  <g filter="url(#rough)">
+    <rect x="150" y="354" width="400" height="90" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="350" y="386" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">Filter on six dimensions</text>
+  <text x="350" y="412" font-size="16" text-anchor="middle" fill="#1a1a1a">Buyer OR user - one industry - one timezone</text>
+  <text x="350" y="432" font-size="15" text-anchor="middle" fill="#555" font-style="italic">Drop anyone outside the band</text>
+
+  <!-- Arrow 3 -->
+  <line x1="350" y1="447" x2="350" y2="486" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="365" y="474" font-size="16" fill="#1a1a1a" font-style="italic">3-message sequence (Lesson 2.4)</text>
+
+  <!-- Stage 4: booked calls -->
+  <g filter="url(#rough)">
+    <rect x="200" y="491" width="300" height="70" rx="10" fill="#f0f9f0" stroke="#2e7d32" stroke-width="2.5"/>
+  </g>
+  <text x="350" y="522" font-size="21" text-anchor="middle" fill="#2e7d32" font-weight="bold">10 booked interviewees</text>
+  <text x="350" y="547" font-size="16" text-anchor="middle" fill="#555" font-style="italic">Score each call within 5 minutes</text>
+
+  <!-- Side track: smoke test -->
+  <g filter="url(#rough)">
+    <rect x="690" y="227" width="250" height="105" rx="10" fill="#fbe9ff" stroke="#8e24aa" stroke-width="2.5"/>
+  </g>
+  <text x="815" y="257" font-size="19" text-anchor="middle" fill="#8e24aa" font-weight="bold">Parallel track</text>
+  <text x="815" y="282" font-size="15" text-anchor="middle" fill="#1a1a1a">Smoke-test page - waitlist</text>
+  <text x="815" y="302" font-size="15" text-anchor="middle" fill="#1a1a1a">signups are the warmest opener</text>
+  <path d="M 815 336 L 815 525 L 505 525" fill="none" stroke="#8e24aa" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arr)"/>
+
+  <!-- Side track: research panel -->
+  <g filter="url(#rough)">
+    <rect x="690" y="380" width="250" height="115" rx="10" fill="#fbe9ff" stroke="#8e24aa" stroke-width="2.5"/>
+  </g>
+  <text x="815" y="410" font-size="19" text-anchor="middle" fill="#8e24aa" font-weight="bold">Paid fallback</text>
+  <text x="815" y="435" font-size="15" text-anchor="middle" fill="#1a1a1a">Research panel - only when</text>
+  <text x="815" y="455" font-size="15" text-anchor="middle" fill="#1a1a1a">your ICP can't be reached cold</text>
+  <text x="815" y="478" font-size="14" text-anchor="middle" fill="#555" font-style="italic">User Interviews / Respondent</text>
+
+  <!-- Footnote -->
+  <text x="490" y="600" font-size="19" text-anchor="middle" fill="#a3621e" font-style="italic">Gate: fewer than 7 of 10 calls scoring 7+ means the problem is too weak for this ICP -</text>
+  <text x="490" y="623" font-size="19" text-anchor="middle" fill="#a3621e" font-style="italic">re-evaluate the ICP or the framing before booking another 10.</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/reference/find-10-people-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/find-10-people-full/index.md
@@ -10,6 +10,8 @@ slug: find-10-people-full
 
 ---
 
+![A hand-drawn funnel from channels to booked calls: a wide red card listing Reddit, LinkedIn, Slack / Discord, G2 / Capterra, X and referrals narrows through copy complaints verbatim into 30 real sentences plus 30 named people, then through a filter on six dimensions card, then via the 3-message sequence into a green 10 booked interviewees card. Two purple side boxes show the parallel smoke-test page track and the paid research-panel fallback, and an amber footnote carries the gate: fewer than 7 of 10 calls scoring 7+ means the problem is too weak.](channels-to-10-calls-funnel.svg)
+
 ## Where to Search: The Full Channel Walk
 
 The AI ICP map (from Lesson 2.3) names your specific communities. Here is how to work each channel type once you have the list. Read before you write a single message - you are collecting the exact words people use when their problem flares up, because those words become your subject lines in Lesson 2.4.
@@ -170,5 +172,3 @@ If fewer than 7 of 10 calls score >= 7, the problem is too weak for this ICP. Re
 ---
 
 *Built by [JetThoughts](https://jetthoughts.com) as a companion reference to the [From Idea to First Paying Customer](/course/tech-for-non-technical-founders-2026/) free curriculum.*
-</content>
-</invoke>

--- a/content/course/tech-for-non-technical-founders-2026/reference/mvp-build-phases-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/mvp-build-phases-full/index.md
@@ -14,6 +14,8 @@ This guide assumes you already ran Modules 1-3 (hypothesis, smoke test, 10 inter
 
 > **Calendar reality for the MVP build.** A full-time founder with daytime availability can hit the Phase 4 5-lights in 4-6 weeks. An evening-only founder (the 2-4 hr/week pattern this course is built for) typically needs 10-12 weeks for the same outputs. Phase 2 (Supabase wiring + RLS - Row-Level Security, the database rule that walls one customer's data off from another's) and Phase 3 (Stripe webhook - an automatic message Stripe sends your app when a payment lands - plus idempotency, the rule that says "if the same webhook fires twice, only act once") are where part-time founders lose the most calendar. Plan the 10-week version, not the 4-week version.
 
+![A hand-drawn map of the MVP build: four red phase cards - Phase 1 Lovable UI with prompts from the one-page brief, Phase 2 Supabase with tables plus RLS and real signup, Phase 3 Stripe with checkout, webhook and $1 test transactions, Phase 4 deploy plus 5 ICP users exiting on all five green lights - flowing into a green Onramp card that invites your 10 interviewees by name, with an amber footnote on the 4-6 week full-time vs 10-12 week evening-only calendar.](mvp-build-phases-map.svg)
+
 ## Phase 1 - write your prompts, set up Lovable, ship the UI
 
 Start by opening the one-page brief. The "what you're building" section becomes your first three Lovable prompts.

--- a/content/course/tech-for-non-technical-founders-2026/reference/mvp-build-phases-full/mvp-build-phases-map.svg
+++ b/content/course/tech-for-non-technical-founders-2026/reference/mvp-build-phases-full/mvp-build-phases-map.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 560" font-family='"Caveat", "Patrick Hand", "Comic Sans MS", cursive'>
+  <defs>
+    <filter id="rough" x="-2%" y="-2%" width="104%" height="104%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.025" numOctaves="2" seed="7"/>
+      <feDisplacementMap in="SourceGraphic" scale="2"/>
+    </filter>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1a1a1a"/>
+    </marker>
+  </defs>
+  <rect width="980" height="560" fill="#fafaf7"/>
+
+  <!-- Title -->
+  <text x="490" y="40" font-size="30" text-anchor="middle" fill="#1a1a1a" font-weight="bold">The MVP build, phase by phase</text>
+  <text x="490" y="66" font-size="19" text-anchor="middle" fill="#555">Four phases, one demo each - then the onramp hands you to Module 5</text>
+
+  <!-- Phase 1 -->
+  <g filter="url(#rough)">
+    <rect x="30" y="95" width="270" height="140" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="165" y="130" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">Phase 1 - Lovable UI</text>
+  <text x="165" y="160" font-size="17" text-anchor="middle" fill="#1a1a1a">Prompts from the</text>
+  <text x="165" y="180" font-size="17" text-anchor="middle" fill="#1a1a1a">one-page brief</text>
+  <text x="165" y="212" font-size="16" text-anchor="middle" fill="#555" font-style="italic">Demo: screens need zero tour</text>
+
+  <!-- Phase 2 -->
+  <g filter="url(#rough)">
+    <rect x="355" y="95" width="270" height="140" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="490" y="130" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">Phase 2 - Supabase</text>
+  <text x="490" y="160" font-size="17" text-anchor="middle" fill="#1a1a1a">Tables + RLS from the start,</text>
+  <text x="490" y="180" font-size="17" text-anchor="middle" fill="#1a1a1a">real signup works</text>
+  <text x="490" y="212" font-size="16" text-anchor="middle" fill="#555" font-style="italic">Demo: signup row appears live</text>
+
+  <!-- Phase 3 -->
+  <g filter="url(#rough)">
+    <rect x="680" y="95" width="270" height="140" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="815" y="130" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">Phase 3 - Stripe</text>
+  <text x="815" y="160" font-size="17" text-anchor="middle" fill="#1a1a1a">Checkout + webhook,</text>
+  <text x="815" y="180" font-size="17" text-anchor="middle" fill="#1a1a1a">$1 test transactions</text>
+  <text x="815" y="212" font-size="16" text-anchor="middle" fill="#555" font-style="italic">Demo: pay $1, row says paid</text>
+
+  <!-- Arrows row 1 -->
+  <line x1="303" y1="165" x2="350" y2="165" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="628" y1="165" x2="675" y2="165" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Elbow arrow Phase 3 -> Phase 4 -->
+  <path d="M 815 238 L 815 268 L 275 268 L 275 295" fill="none" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Phase 4 -->
+  <g filter="url(#rough)">
+    <rect x="110" y="300" width="330" height="140" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="275" y="335" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">Phase 4 - deploy + 5 ICP users</text>
+  <text x="275" y="365" font-size="17" text-anchor="middle" fill="#1a1a1a">Stripe live mode, custom domain,</text>
+  <text x="275" y="385" font-size="17" text-anchor="middle" fill="#1a1a1a">3-line cold sends</text>
+  <text x="275" y="417" font-size="16" text-anchor="middle" fill="#2e7d32" font-style="italic">Exit: all five green lights</text>
+
+  <!-- Arrow Phase 4 -> Onramp -->
+  <line x1="443" y1="370" x2="550" y2="370" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Onramp -->
+  <g filter="url(#rough)">
+    <rect x="555" y="300" width="360" height="140" rx="10" fill="#f0f9f0" stroke="#2e7d32" stroke-width="2.5"/>
+  </g>
+  <text x="735" y="335" font-size="21" text-anchor="middle" fill="#2e7d32" font-weight="bold">Onramp - Module 5 handoff</text>
+  <text x="735" y="365" font-size="17" text-anchor="middle" fill="#1a1a1a">Invite your 10 interviewees by name</text>
+  <text x="735" y="385" font-size="17" text-anchor="middle" fill="#1a1a1a">Expect 4-6 accounts, 1-2 survey-ready</text>
+  <text x="735" y="417" font-size="16" text-anchor="middle" fill="#555" font-style="italic">Then book up to 10 user sessions</text>
+
+  <!-- Calendar footnote -->
+  <text x="490" y="490" font-size="19" text-anchor="middle" fill="#a3621e" font-style="italic">Calendar reality: full-time founder 4-6 weeks;</text>
+  <text x="490" y="515" font-size="19" text-anchor="middle" fill="#a3621e" font-style="italic">evening-only (2-4 hr/week) - plan the 10-12 week version.</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/reference/persona-rehearsal-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/persona-rehearsal-full/index.md
@@ -21,6 +21,8 @@ slug: persona-rehearsal-full
 
 Think of it as a trial attorney prepping cross-examination with a paralegal standing in as the witness. The paralegal can't give testimony, but the rehearsal finds the question that falls apart under any pressure at all.
 
+![A hand-drawn loop of four prompt cards: red Prompt 2 opening question test in character, purple Prompt 3 question diagnosis with break character for 30 seconds, red Prompt 4 objection surface back in character, and red Prompt 5 sharpening to past-anchored under 20 words. A dashed arrow loops back to repeat for each question across all 3 personas, then a keep / revise / cut arrow drops to two green deliverable cards - 5-7 solid questions and the top 3 objections for the Objection Tracker - with an amber footnote that the real gate stays 10 Mom Test interviews at 7+/10 strong signal.](persona-rehearsal-loop.svg)
+
 ## Run the rehearsal session
 
 Once the persona is set (Prompt 1 lives in [Lesson 2.2](/course/tech-for-non-technical-founders-2026/ai-persona-pre-validation-mom-test-prep/)), run your draft questions. Here's the sequence.

--- a/content/course/tech-for-non-technical-founders-2026/reference/persona-rehearsal-full/persona-rehearsal-loop.svg
+++ b/content/course/tech-for-non-technical-founders-2026/reference/persona-rehearsal-full/persona-rehearsal-loop.svg
@@ -45,7 +45,7 @@
   </g>
   <text x="866" y="128" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">Prompt 5</text>
   <text x="866" y="156" font-size="17" text-anchor="middle" fill="#1a1a1a">Sharpening</text>
-  <text x="866" y="184" font-size="15" text-anchor="middle" fill="#555" font-style="italic">past-anchored, under 20 words</text>
+  <text x="866" y="184" font-size="13" text-anchor="middle" fill="#555" font-style="italic">past-anchored, under 20 words</text>
 
   <!-- Arrows between prompts -->
   <line x1="248" y1="160" x2="268" y2="160" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>

--- a/content/course/tech-for-non-technical-founders-2026/reference/persona-rehearsal-full/persona-rehearsal-loop.svg
+++ b/content/course/tech-for-non-technical-founders-2026/reference/persona-rehearsal-full/persona-rehearsal-loop.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 620" font-family='"Caveat", "Patrick Hand", "Comic Sans MS", cursive'>
+  <defs>
+    <filter id="rough" x="-2%" y="-2%" width="104%" height="104%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.025" numOctaves="2" seed="13"/>
+      <feDisplacementMap in="SourceGraphic" scale="2"/>
+    </filter>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1a1a1a"/>
+    </marker>
+  </defs>
+  <rect width="980" height="620" fill="#fafaf7"/>
+
+  <!-- Title -->
+  <text x="490" y="40" font-size="30" text-anchor="middle" fill="#1a1a1a" font-weight="bold">The persona rehearsal loop</text>
+  <text x="490" y="66" font-size="19" text-anchor="middle" fill="#555">Four prompts per question, three personas, two deliverables</text>
+
+  <!-- Prompt 2 -->
+  <g filter="url(#rough)">
+    <rect x="30" y="95" width="215" height="130" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="137" y="128" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">Prompt 2</text>
+  <text x="137" y="156" font-size="17" text-anchor="middle" fill="#1a1a1a">Opening question test</text>
+  <text x="137" y="184" font-size="15" text-anchor="middle" fill="#555" font-style="italic">in character</text>
+
+  <!-- Prompt 3 -->
+  <g filter="url(#rough)">
+    <rect x="273" y="95" width="215" height="130" rx="10" fill="#fbe9ff" stroke="#8e24aa" stroke-width="2.5"/>
+  </g>
+  <text x="380" y="128" font-size="21" text-anchor="middle" fill="#8e24aa" font-weight="bold">Prompt 3</text>
+  <text x="380" y="156" font-size="17" text-anchor="middle" fill="#1a1a1a">Question diagnosis</text>
+  <text x="380" y="184" font-size="15" text-anchor="middle" fill="#555" font-style="italic">break character for 30 sec</text>
+
+  <!-- Prompt 4 -->
+  <g filter="url(#rough)">
+    <rect x="516" y="95" width="215" height="130" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="623" y="128" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">Prompt 4</text>
+  <text x="623" y="156" font-size="17" text-anchor="middle" fill="#1a1a1a">Objection surface</text>
+  <text x="623" y="184" font-size="15" text-anchor="middle" fill="#555" font-style="italic">back in character</text>
+
+  <!-- Prompt 5 -->
+  <g filter="url(#rough)">
+    <rect x="759" y="95" width="215" height="130" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="866" y="128" font-size="21" text-anchor="middle" fill="#cc342d" font-weight="bold">Prompt 5</text>
+  <text x="866" y="156" font-size="17" text-anchor="middle" fill="#1a1a1a">Sharpening</text>
+  <text x="866" y="184" font-size="15" text-anchor="middle" fill="#555" font-style="italic">past-anchored, under 20 words</text>
+
+  <!-- Arrows between prompts -->
+  <line x1="248" y1="160" x2="268" y2="160" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="491" y1="160" x2="511" y2="160" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="734" y1="160" x2="754" y2="160" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Loop back -->
+  <path d="M 866 228 L 866 268 L 137 268 L 137 233" fill="none" stroke="#1a1a1a" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arr)"/>
+  <text x="500" y="292" font-size="18" text-anchor="middle" fill="#1a1a1a" font-style="italic">repeat for each question - then run the same list past all 3 personas</text>
+
+  <!-- Arrow to deliverables -->
+  <line x1="490" y1="305" x2="490" y2="345" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="505" y="335" font-size="16" fill="#1a1a1a" font-style="italic">keep / revise / cut</text>
+
+  <!-- Deliverable 1 -->
+  <g filter="url(#rough)">
+    <rect x="110" y="350" width="350" height="100" rx="10" fill="#f0f9f0" stroke="#2e7d32" stroke-width="2.5"/>
+  </g>
+  <text x="285" y="385" font-size="20" text-anchor="middle" fill="#2e7d32" font-weight="bold">5-7 solid questions</text>
+  <text x="285" y="412" font-size="16" text-anchor="middle" fill="#1a1a1a">from the 5-8 loose ones</text>
+  <text x="285" y="432" font-size="16" text-anchor="middle" fill="#1a1a1a">you started with</text>
+
+  <!-- Deliverable 2 -->
+  <g filter="url(#rough)">
+    <rect x="520" y="350" width="350" height="100" rx="10" fill="#f0f9f0" stroke="#2e7d32" stroke-width="2.5"/>
+  </g>
+  <text x="695" y="385" font-size="20" text-anchor="middle" fill="#2e7d32" font-weight="bold">Top 3 objections</text>
+  <text x="695" y="412" font-size="16" text-anchor="middle" fill="#1a1a1a">raised by 2+ of 3 personas -</text>
+  <text x="695" y="432" font-size="16" text-anchor="middle" fill="#1a1a1a">into the Objection Tracker</text>
+
+  <!-- Footnote -->
+  <text x="490" y="530" font-size="19" text-anchor="middle" fill="#a3621e" font-style="italic">The persona is only as right as your ICP description.</text>
+  <text x="490" y="555" font-size="19" text-anchor="middle" fill="#a3621e" font-style="italic">The real gate stays: 10 Mom Test interviews, 7+/10 strong signal.</text>
+</svg>

--- a/content/course/tech-for-non-technical-founders-2026/reference/stack-tools-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/stack-tools-full/index.md
@@ -16,6 +16,8 @@ slug: stack-tools-full
 
 Boring is what you want for an MVP. The boring path lets one non-technical founder ship the full loop (signup, paid onboarding, the one feature that solves the validated problem) without ever opening a terminal.
 
+![A hand-drawn layer diagram of the self-serve stack: a red Lovable card labeled the UI layer, an arrow reading reads / writes rows down to a blue Supabase card labeled the data layer with Postgres, auth, storage and row-level security, then user hits the paywall down to a green Stripe card labeled the money layer, with a dashed green webhook arrow looping from Stripe back into Supabase to flip subscription status to active, a gray GitHub backup box synced from Lovable on day 1, and an amber footnote warning not to let one tool do another tool's job.](stack-layer-boundaries.svg)
+
 How much demand evidence you already have decides the path. With enough of it, you open Lovable and build. Without it, a $0 Concierge MVP - a no-code "Wizard of Oz" where you fake the automation by hand behind the curtain - gets you more evidence before you commit to Lovable code. Wire up Tally (free form) → Zapier or Make.com (free routing) → Airtable or Notion (free storage): the customer fills the Tally form, Zapier drops the row in Airtable, and you process it by hand. To the customer it looks automated, so you validate willingness-to-pay before writing code. The trade-off is that you run it by hand, which makes it a stepping stone, not a replacement. Either way, the Lovable + Supabase + Stripe stack is what ships in [Lesson 4.4](/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-build-phases/).
 
 ## M2 prototype vs M4 MVP - different artifacts, different rigor

--- a/content/course/tech-for-non-technical-founders-2026/reference/stack-tools-full/stack-layer-boundaries.svg
+++ b/content/course/tech-for-non-technical-founders-2026/reference/stack-tools-full/stack-layer-boundaries.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 600" font-family='"Caveat", "Patrick Hand", "Comic Sans MS", cursive'>
+  <defs>
+    <filter id="rough" x="-2%" y="-2%" width="104%" height="104%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.025" numOctaves="2" seed="11"/>
+      <feDisplacementMap in="SourceGraphic" scale="2"/>
+    </filter>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1a1a1a"/>
+    </marker>
+  </defs>
+  <rect width="980" height="600" fill="#fafaf7"/>
+
+  <!-- Title -->
+  <text x="490" y="40" font-size="30" text-anchor="middle" fill="#1a1a1a" font-weight="bold">Three tools, three jobs</text>
+  <text x="490" y="66" font-size="19" text-anchor="middle" fill="#555">The layer boundaries are the only architecture you need on day one</text>
+
+  <!-- Lovable - UI layer -->
+  <g filter="url(#rough)">
+    <rect x="60" y="95" width="560" height="110" rx="10" fill="#fff5f5" stroke="#cc342d" stroke-width="2.5"/>
+  </g>
+  <text x="340" y="128" font-size="22" text-anchor="middle" fill="#cc342d" font-weight="bold">Lovable - the UI layer</text>
+  <text x="340" y="156" font-size="17" text-anchor="middle" fill="#1a1a1a">Describe screens in English - every save deploys to a staging URL</text>
+  <text x="340" y="182" font-size="16" text-anchor="middle" fill="#555" font-style="italic">Not for: backend logic, auth flows, the database</text>
+
+  <!-- GitHub backup -->
+  <g filter="url(#rough)">
+    <rect x="700" y="95" width="240" height="110" rx="10" fill="#faf7f2" stroke="#555" stroke-width="2.5"/>
+  </g>
+  <text x="820" y="128" font-size="21" text-anchor="middle" fill="#555" font-weight="bold">GitHub - the backup</text>
+  <text x="820" y="156" font-size="16" text-anchor="middle" fill="#1a1a1a">Sync in Lovable Settings,</text>
+  <text x="820" y="176" font-size="16" text-anchor="middle" fill="#1a1a1a">day 1 - code survives Lovable</text>
+  <line x1="623" y1="150" x2="695" y2="150" stroke="#555" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arr)"/>
+
+  <!-- Arrow Lovable -> Supabase -->
+  <line x1="340" y1="208" x2="340" y2="250" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="355" y="237" font-size="17" fill="#1a1a1a" font-style="italic">reads / writes rows</text>
+
+  <!-- Supabase - data layer -->
+  <g filter="url(#rough)">
+    <rect x="60" y="255" width="560" height="110" rx="10" fill="#e8f4f8" stroke="#0277bd" stroke-width="2.5"/>
+  </g>
+  <text x="340" y="288" font-size="22" text-anchor="middle" fill="#0277bd" font-weight="bold">Supabase - the data layer</text>
+  <text x="340" y="316" font-size="17" text-anchor="middle" fill="#1a1a1a">Postgres + auth + file storage + row-level security</text>
+  <text x="340" y="342" font-size="16" text-anchor="middle" fill="#555" font-style="italic">RLS keeps each user's rows private to them</text>
+
+  <!-- Arrow Supabase -> Stripe (paywall) -->
+  <line x1="340" y1="368" x2="340" y2="410" stroke="#1a1a1a" stroke-width="2" marker-end="url(#arr)"/>
+  <text x="355" y="397" font-size="17" fill="#1a1a1a" font-style="italic">user hits the paywall</text>
+
+  <!-- Stripe - money layer -->
+  <g filter="url(#rough)">
+    <rect x="60" y="415" width="560" height="110" rx="10" fill="#f0f9f0" stroke="#2e7d32" stroke-width="2.5"/>
+  </g>
+  <text x="340" y="448" font-size="22" text-anchor="middle" fill="#2e7d32" font-weight="bold">Stripe - the money layer</text>
+  <text x="340" y="476" font-size="17" text-anchor="middle" fill="#1a1a1a">Stripe Checkout: one hosted page Lovable links to</text>
+  <text x="340" y="502" font-size="16" text-anchor="middle" fill="#555" font-style="italic">Not the source of truth for user state</text>
+
+  <!-- Webhook elbow: Stripe -> Supabase -->
+  <path d="M 623 470 L 720 470 L 720 310 L 628 310" fill="none" stroke="#2e7d32" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arr)"/>
+  <text x="740" y="400" font-size="17" fill="#2e7d32" font-style="italic">webhook: charge</text>
+  <text x="740" y="422" font-size="17" fill="#2e7d32" font-style="italic">clears, subscription</text>
+  <text x="740" y="444" font-size="17" fill="#2e7d32" font-style="italic">status flips to active</text>
+
+  <!-- Footnote -->
+  <text x="490" y="565" font-size="19" text-anchor="middle" fill="#a3621e" font-style="italic">Strict boundaries: Lovable renders screens, Supabase stores data, Stripe collects payment.</text>
+  <text x="490" y="588" font-size="19" text-anchor="middle" fill="#a3621e" font-style="italic">Do not let one tool do another tool's job.</text>
+</svg>


### PR DESCRIPTION
## Summary

One hand-drawn informational SVG for each of the 5 reference/*-full chapters that had 1,800-2,600 words and zero visuals (board Wave B / M5c):

| Chapter | Visual |
|---|---|
| mvp-build-phases-full | 4 red phase cards -> green Module-5 handoff, amber calendar-reality footnote |
| stack-tools-full | Lovable/Supabase/Stripe layer diagram with webhook loop + GitHub backup box |
| find-10-people-full | channels -> 10 booked calls narrowing funnel, purple parallel/fallback tracks |
| persona-rehearsal-full | Prompt 2-5 rehearsal loop -> two green deliverables, amber real-gate footnote |
| channel-selection-full | channel-fit score /12 three-way decision branch -> red commitment card |

All labels verbatim from their own pages; house visual spec followed (paper tones, 2-2.5px strokes, semantic colors, labels inside shapes, "-" dashes).

Bonus fix: removed literal stray `</content>`/`</invoke>` corruption that rendered at the end of find-10-people-full (pre-existing).

## Review evidence (4-eyes: designer agent + coordinator review)

- Visual scroll gate run at 1280x800 AND 390x844 on all 5 chapters via chrome-devtools; all pass (compact-diagram mobile norms).
- One review finding fixed: Prompt 5 card text exceeded the 10px text-margin budget (207px text in 195px space) - font 15->13.
- Spelling of tool names grep-verified; blue data-layer accent matches existing precedent (#0277bd, 11 uses in shipped SVGs).
- bin/hugo-build green on every commit (8 course validators + banned-string ratchet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzSs7FupxTPeX4QW1u5anX