### PR TITLE
Wave E: Sprint D content gaps - echo-chamber warnings + Concierge MVP path

### DIFF
--- a/content/course/tech-for-non-technical-founders-2026/find-10-people-where-to-look/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/find-10-people-where-to-look/index.md
@@ -116,6 +116,8 @@ Ran the research prompt back in [Lesson 1.2](/course/tech-for-non-technical-foun
 
 When you're done you should have 30 real sentences and 30 named people. Don't paraphrase - the exact wording is the point, and it becomes your subject lines in Part 2. The per-channel walk (Reddit, LinkedIn, G2, Slack, Twitter, personal network), the Reddit karma rules, and the keyword-variation gallery live in the [full reference](/course/tech-for-non-technical-founders-2026/reference/find-10-people-full/).
 
+> **Watch for the echo chamber.** If your list starts filling with friends and fellow founders from startup communities, stop and go back to the search strings. People who know you will say the idea sounds great, because being nice costs them nothing. A real signal comes from a stranger who describes the problem in their own words and has no reason to spare your feelings.
+
 ## Build a list of 30 specific people
 
 Turn the 30 sentences into 30 names. Open each thread you saved, click each useful username, and copy four things into a spreadsheet: **Name** (theirs, not their company), **role + company** (one cell), **the post you'll reference** (paste the URL), and **one specific line they wrote** (the phrase you'll quote back).

--- a/content/course/tech-for-non-technical-founders-2026/first-ten-customers-network-list/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/first-ten-customers-network-list/index.md
@@ -48,6 +48,8 @@ Lenny Rachitsky asked today's fastest-growing B2B companies (Figma, Stripe, Slac
 
 You are not asking friends to buy. You are asking them to be first to try something that solves a problem they already have, at a steep discount, while you fix the rough edges they catch.
 
+> **A friendly reply is not a validation signal.** People who know you will answer warmly whether or not the problem is real. The problem test already happened in [Module 2](/course/tech-for-non-technical-founders-2026/find-10-people-where-to-look/), with strangers who had no reason to be nice to you. On this list you are selling, so only two replies count as progress: a booked demo and a paid deposit. Log "sounds great, let me know when it launches" as a maybe.
+
 Open a Google Sheet. Six columns: Name, Company, Role, Bucket, Relationship strength, Last contact date. Fill 50 rows in one sitting before you send anything.
 
 | Bucket | How many | Definition |

--- a/content/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-lovable-supabase-stripe-2026/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-lovable-supabase-stripe-2026/index.md
@@ -48,6 +48,8 @@ Three tools do the whole self-serve build, and each one has exactly one job. The
 
 If you completed Modules 1-3, your default Module 4 path is to build it yourself with Lovable (an AI app builder that turns a plain-English prompt into a working web app) + Supabase (managed database + login system) + Stripe (the service that charges the card). Hiring is a ceiling-signal trigger covered in the [supplementary reference](/course/tech-for-non-technical-founders-2026/hire-track-supplementary-reference/), not a parallel choice. You will not write code.
 
+> **Not ready to commit to the build? Run a Concierge MVP first.** Fake the automation by hand: collect customer requests through a [Tally](https://tally.so) form (a form builder), route them into an [Airtable](https://airtable.com) base (a spreadsheet-database hybrid) with [Zapier](https://zapier.com) or [Make](https://www.make.com) (tools that pass data between apps automatically), and do the work behind the scenes yourself. Your customer experiences what looks like a working product while you find out whether anyone wants it, before you spend weeks in Lovable. This is the "Wizard of Oz" pattern from [the course overview](/course/tech-for-non-technical-founders-2026/how-this-course-works/); when requests outgrow your hands, come back and build the real stack below.
+
 ## Three tools, three jobs
 
 | Tool | Job | Cost |

--- a/docs/projects/2605-tech-for-non-technical-founders/10-19-research/10.08-validation-tools-analysis-2026.md
+++ b/docs/projects/2605-tech-for-non-technical-founders/10-19-research/10.08-validation-tools-analysis-2026.md
@@ -146,8 +146,8 @@ The research presents a SIPOC model that maps the startup launch pipeline:
 | # | Gap | Effort | Impact | Status |
 |---|---|---|---|---|
 | 1 | Perplexity/Trend Seeker pre-hypothesis research | Low (sidebar) | High | ✅ Shipped - validation-tools overview chapter |
-| 2 | Wizard of Oz Concierge MVP stack | Medium (new alt path) | Critical | ✅ Shipped - HTCW + 4.3a + glossary |
-| 3 | Echo chamber warning in Ch 5.3 + 2.3 | Low (inline callout) | High | 🟡 Structurally addressed (M2 = strangers, 5.3 = sales-not-validation); inline callout in 2.3 still optional |
+| 2 | Wizard of Oz Concierge MVP stack | Medium (new alt path) | Critical | ✅ Shipped - HTCW + glossary + 4.3 path callout (2026-07-31; the earlier "4.3a" page no longer exists after the M4 renumber) |
+| 3 | Echo chamber warning in Ch 5.3 + 2.3 | Low (inline callout) | High | ✅ Shipped - inline callouts in 2.3 (list-building) and 5.3 (sales-not-validation), 2026-07-31 |
 | 4 | Loom video outreach tactic | Low (tactic option) | Medium | ✅ Shipped - 5.3b outreach message |
 | 5 | Engineering as Marketing micro-tools | Low (tactic option) | Medium | ✅ Shipped - 5.2 channel-selection callout |
 | 6 | IdeaProof/ValidatorAI ensemble validation | Low (sidebar) | Medium | ✅ Shipped - validation-tools overview chapter |


### PR DESCRIPTION
## Summary (board Wave E, un-gated Sprint D batch)

**Shipped (2 of 6 items - the other 4 are already resolved, see below):**
- **Echo-chamber warnings** in 2.3 (find-10-people-where-to-look) and 5.3 (first-ten-customers-network-list): friendly/known-people replies are not validation signal; on the selling list only booked demos + paid deposits count.
- **Concierge MVP (Wizard of Oz) path** in 4.3 (self-serve-mvp-stack): fake-the-automation-by-hand option via Tally + Zapier/Make + Airtable (each glossed), consistent with existing course phrasing; fixes the glossary's dangling 'Lesson 4.3 Concierge MVP' pointer left by the M4 renumber.
- 10.08 gap-status table corrected (gaps 2+3 marked shipped; two spec-vs-page mismatches documented).

**Done-as-stale (no edits forced):**
- Loom outreach: already canonical in 5.4/5.5; adding to 5.2 would front-load mechanics and reopen the 40.19-reconciled 4-channel framing.
- Engineering-as-Marketing in 5.2: deliberately demoted to reference-chapter treatment by the 40.19 review - re-promoting would reverse a reviewed decision.
- Operating Kit '5 remaining templates': no authoritative list exists anywhere; the kit page's reviewed framing says all 6 components are live at their source lessons. Needs a Paul decision if standalone template pages are still wanted.
- Manual-minimum audit 5.3/5.4: free/manual paths already stated for every tool.

## Review evidence (4-eyes)
- Coordinator content review: Sam-voice, glossing, external-link convention verified against existing pages; banned-pattern sweep zero hits; no em-dashes.
- Render check via chrome-devtools on all 3 edited pages: callouts render on the house red-accent style, no adjacent same-form callouts (verified in DOM).
- bin/hugo-build green per commit (8 validators + ratchet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzSs7FupxTPeX4QW1u5anX