### PR TITLE
fix(ci): make the visual harness truthful - build drafts, allow first baselines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,8 @@ jobs:
       # BUILD_DRAFTS: the codeblock-styles fixture the screenshot tests visit
       # is a draft post; local runs build with --buildDrafts but bin/hugo-build
       # only passes it when this env is set (2026-07-31: every CI visual run
-      # 404'd the fixture - "File not found: /blog/codeblock-styles-fixture/").
+      # 404'd the fixture - "File not found: /blog/codeblock-styles-fixture/";
+      # evidence: actions/runs/30629929407).
       - uses: ./.github/actions/setup-hugo
         env:
           BUILD_DRAFTS: '1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,13 @@ jobs:
           ruby-version: '4.0'
           cache-apt-packages: true
 
+      # BUILD_DRAFTS: the codeblock-styles fixture the screenshot tests visit
+      # is a draft post; local runs build with --buildDrafts but bin/hugo-build
+      # only passes it when this env is set (2026-07-31: every CI visual run
+      # 404'd the fixture - "File not found: /blog/codeblock-styles-fixture/").
       - uses: ./.github/actions/setup-hugo
+        env:
+          BUILD_DRAFTS: '1'
 
       - name: Cache Chrome for Testing
         uses: actions/cache@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,11 @@ on:
       - 'postcss.config.js'
       - 'test/fixtures/screenshots/**'
       - 'test/system/**'
+      - 'test/support/**'
       - '.dev/cft-version'
       - '.dev/fonts.conf'
+      # the gate must test its own harness changes
+      - '.github/workflows/test.yml'
 
 permissions:
   contents: write

--- a/.okf/build/ci-gates.md
+++ b/.okf/build/ci-gates.md
@@ -49,7 +49,7 @@ A CI screenshot job (`quick_test` + `bin/qtest`) was built and removed in PR #38
 
 **Re-introduced (DevX R2 Phase B, 2026-07-31):** `test.yml` now runs the critical screenshot suite on `pull_request` (paths-filtered to visual surfaces), provisioned via `bin/setup-test-env` so runner pixels match `linux/` baselines. Currently REPORT-ONLY (`continue-on-error: true` - failures upload the snap_diff report and comment the PR); flip that flag off after a clean soak week to make it blocking. Record mode (`workflow_dispatch` + update-baselines) records on the same pinned stack. Local gates in [test-gates.md](test-gates.md) (`bin/test` macOS, `bin/dtest` docker-linux) remain the pre-PR discipline.
 
-Two gotchas the first record run hit (both fixed, keep in mind for any new CI test job):
+Two gotchas the first record run hit (both fixed; evidence: [run 30629929407](https://github.com/jetthoughts/jetthoughts.github.io/actions/runs/30629929407) - 104 screenshots compared clean, 4 test failures, commit step never ran). Keep in mind for any new CI test job:
 - **Draft fixtures**: screenshot tests visit the draft post `/blog/codeblock-styles-fixture/`; local builds pass `--buildDrafts` but `bin/hugo-build` only does so when `BUILD_DRAFTS` is set - test.yml sets `BUILD_DRAFTS: '1'` on its setup-hugo step. A CI test build without it 404s the fixture and fails the codeblock tests on every run.
 - **fail_if_new in CI**: snap_diff hard-errors on missing baselines when `ENV["CI"]` is set. Record mode (`FORCE_SCREENSHOT_UPDATE=true`) disables `fail_on_difference` AND `fail_if_new` (setup_snap_diff.rb) so pages added since the last recording can get their FIRST baseline.
 

--- a/.okf/build/ci-gates.md
+++ b/.okf/build/ci-gates.md
@@ -49,6 +49,10 @@ A CI screenshot job (`quick_test` + `bin/qtest`) was built and removed in PR #38
 
 **Re-introduced (DevX R2 Phase B, 2026-07-31):** `test.yml` now runs the critical screenshot suite on `pull_request` (paths-filtered to visual surfaces), provisioned via `bin/setup-test-env` so runner pixels match `linux/` baselines. Currently REPORT-ONLY (`continue-on-error: true` - failures upload the snap_diff report and comment the PR); flip that flag off after a clean soak week to make it blocking. Record mode (`workflow_dispatch` + update-baselines) records on the same pinned stack. Local gates in [test-gates.md](test-gates.md) (`bin/test` macOS, `bin/dtest` docker-linux) remain the pre-PR discipline.
 
+Two gotchas the first record run hit (both fixed, keep in mind for any new CI test job):
+- **Draft fixtures**: screenshot tests visit the draft post `/blog/codeblock-styles-fixture/`; local builds pass `--buildDrafts` but `bin/hugo-build` only does so when `BUILD_DRAFTS` is set - test.yml sets `BUILD_DRAFTS: '1'` on its setup-hugo step. A CI test build without it 404s the fixture and fails the codeblock tests on every run.
+- **fail_if_new in CI**: snap_diff hard-errors on missing baselines when `ENV["CI"]` is set. Record mode (`FORCE_SCREENSHOT_UPDATE=true`) disables `fail_on_difference` AND `fail_if_new` (setup_snap_diff.rb) so pages added since the last recording can get their FIRST baseline.
+
 # libvips gotcha (if a CI job ever needs ruby-vips again)
 
 ruby-vips' `:vips` driver `dlopen`s `libvips.so.42` at runtime, which ships in the **libvips42** runtime package - NOT `libvips-dev` (headers only). Install `libvips42` + run `ldconfig`. snap_diff swallows the real `LoadError` behind generic per-screenshot errors, so verify the load explicitly (`ruby -e 'require "vips"'`).

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1,5 +1,16 @@
 # Bundle Update Log
 
+## 2026-07-31 (visual gate truth fix)
+
+* **Update**: [ci-gates](/build/ci-gates.md) - first CI baseline-record run failed with 2 root
+  causes, both now fixed: (1) CI test builds lacked `--buildDrafts`, so the draft
+  codeblock-styles fixture 404'd and the codeblock tests failed on EVERY visual run (incl. the
+  new PR gate - noisy-by-construction); test.yml now sets `BUILD_DRAFTS: '1'` on its setup-hugo
+  step. (2) snap_diff `fail_if_new` hard-errors on missing baselines under ENV["CI"], so record
+  mode could never create a FIRST baseline for pages added since the last recording
+  (vibe_code_rescue); record mode now disables fail_if_new too. Re-record dispatch after merge
+  closes the pending linux/ re-baseline.
+
 ## 2026-07-31 (R2 Phase C)
 
 * **Update**: [test-gates](/build/test-gates.md) + [ci-gates](/build/ci-gates.md) - DevX R2

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -2,8 +2,9 @@
 
 ## 2026-07-31 (visual gate truth fix)
 
-* **Update**: [ci-gates](/build/ci-gates.md) - first CI baseline-record run failed with 2 root
-  causes, both now fixed: (1) CI test builds lacked `--buildDrafts`, so the draft
+* **Update**: [ci-gates](/build/ci-gates.md) - first CI baseline-record run
+  ([run 30629929407](https://github.com/jetthoughts/jetthoughts.github.io/actions/runs/30629929407))
+  failed with 2 root causes, both now fixed: (1) CI test builds lacked `--buildDrafts`, so the draft
   codeblock-styles fixture 404'd and the codeblock tests failed on EVERY visual run (incl. the
   new PR gate - noisy-by-construction); test.yml now sets `BUILD_DRAFTS: '1'` on its setup-hugo
   step. (2) snap_diff `fail_if_new` hard-errors on missing baselines under ENV["CI"], so record

--- a/test/support/setup_snap_diff.rb
+++ b/test/support/setup_snap_diff.rb
@@ -21,4 +21,9 @@ Capybara::Screenshot::Diff.delayed = true
 
 if ENV["FORCE_SCREENSHOT_UPDATE"] == "true"
   Capybara::Screenshot::Diff.fail_on_difference = false
+  # Record mode must be able to create FIRST baselines for new pages: with
+  # ENV["CI"] set, snap_diff's fail_if_new defaults to hard-error, which made
+  # the CI re-record run fail on pages added since the last recording
+  # (2026-07-31: vibe_code_rescue had no linux/ baseline yet).
+  Capybara::Screenshot::Diff.fail_if_new = false
 end


### PR DESCRIPTION
## Summary

The next DevX improvement per the approved plan (YAGNI-scoped: 3 files): make the new CI visual harness tell the truth. The first baseline-record dispatch (run 30629929407) failed — 104 screenshots compared clean, but 4 test failures blocked the commit step. Both root causes diagnosed from the job log and fixed:

### 1. CI test builds had no draft fixtures

`test_codeblock_language_styles` (desktop+mobile) failed with `found 1 match: "File not found: /blog/codeblock-styles-fixture/"` — the fixture is a **draft** post. Local runs build with `--buildDrafts`; `bin/hugo-build` only passes it when `BUILD_DRAFTS` is set, and nothing in CI set it. This made the new PR report-only gate **noisy-by-construction** (would fail on every PR). `test.yml`'s setup-hugo step now sets `BUILD_DRAFTS: '1'`.

### 2. Record mode couldn't create first baselines

`test_vibe_code_rescue` (desktop+mobile) failed with `No existing screenshot found for .../linux/desktop/vibe_code_rescue.base.png` — snap_diff's `fail_if_new` hard-errors under `ENV["CI"]`, and record mode only disabled `fail_on_difference`. Pages added after the last recording could never get a first CI-recorded baseline. `setup_snap_diff.rb`'s record-mode block now disables `fail_if_new` too.

Both gotchas are recorded in `.okf/build/ci-gates.md` so nobody re-diagnoses them.

## Verification

- This PR touches `test.yml` → the paths filter fires the **visual PR job on this very PR**; it coming back green proves fix 1 end-to-end (fixture found, codeblock tests pass) with compare-mode semantics unchanged.
- `ruby -c` + YAML parse clean.
- **After merge**: dispatch `Screenshot Tests` with `update-baselines: true` — expected: green run + a `chore: update screenshot baselines [ci skip]` commit with the pinned-stack `linux/` PNGs including NEW `vibe_code_rescue` baselines. That closes the last open re-baseline item.

Deferred (YAGNI, per plan): CI artifact-sharing, parallelization, blocking-mode flip (stays report-only until a clean soak week on real PRs).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXHeUErqoiyH9xN1mjC8cH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXHeUErqoiyH9xN1mjC8cH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved screenshot testing by including draft content in automated builds.
  - New screenshots can now be recorded as initial visual baselines without causing test failures.

- **Documentation**
  - Added guidance for configuring screenshot tests when validating draft pages and recording new visual baselines.
  - Documented the related CI corrections for improved troubleshooting and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->