### PR TITLE
fix(ci): rebase before pushing recorded baselines (push race)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,11 +115,19 @@ jobs:
           # and a plain push gets rejected non-fast-forward (run 30632854418
           # recorded everything, then lost it all at push). Baseline PNGs don't
           # conflict with content commits, so rebase-and-retry is safe.
+          pushed=0
           for i in 1 2 3; do
-            git pull --rebase origin "${GITHUB_REF_NAME}" && git push && break
+            if git pull --rebase origin "${GITHUB_REF_NAME}" && git push; then
+              pushed=1
+              break
+            fi
             echo "push attempt $i failed, retrying..."
-            sleep 5
+            [ "$i" -lt 3 ] && sleep 5
           done
+          if [ "$pushed" -ne 1 ]; then
+            echo "::error::failed to push recorded baselines after 3 attempts"
+            exit 1
+          fi
 
       - name: Upload screenshot report
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,15 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add test/fixtures/screenshots/
           git diff --staged --quiet || git commit -m "chore: update screenshot baselines [ci skip]"
-          git push
+          # The record run takes ~17 min - master routinely moves underneath it
+          # and a plain push gets rejected non-fast-forward (run 30632854418
+          # recorded everything, then lost it all at push). Baseline PNGs don't
+          # conflict with content commits, so rebase-and-retry is safe.
+          for i in 1 2 3; do
+            git pull --rebase origin "${GITHUB_REF_NAME}" && git push && break
+            echo "push attempt $i failed, retrying..."
+            sleep 5
+          done
 
       - name: Upload screenshot report
         if: failure()


### PR DESCRIPTION
## Summary

The second baseline-record dispatch ([run 30632854418](https://github.com/jetthoughts/jetthoughts.github.io/actions/runs/30632854418)) got all the way through: pinned stack installed, full suite recorded, baselines committed — then **failed at `git push` with a non-fast-forward rejection** and discarded everything. Root cause: the record run takes ~17 minutes and master routinely moves underneath it (two merges landed mid-run).

Fix: in the commit step, `git pull --rebase origin ${GITHUB_REF_NAME}` before pushing, with 3 retries. Baseline PNGs cannot conflict with content commits, so the rebase is always clean.

One file, +9 lines. After merge, the third `update-baselines` dispatch should finally land the pinned-stack `linux/` baselines.

## Verification

- YAML parses; the retry loop only runs in record mode (`workflow_dispatch` + `update-baselines`), which is the only path with `contents: write` usage.
- End-to-end proof is the post-merge dispatch itself — success = `chore: update screenshot baselines [ci skip]` commit on master.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXHeUErqoiyH9xN1mjC8cH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXHeUErqoiyH9xN1mjC8cH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated baseline updates to handle concurrent changes more reliably.
  * Added automatic retries when publishing updated baselines, reducing failures caused by conflicting remote updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->