### PR TITLE
fix(devx): make bin/dtest run and match CI screenshot rendering

### DIFF
--- a/.dev/Dockerfile
+++ b/.dev/Dockerfile
@@ -56,6 +56,7 @@ ENV \
     TEST_SERVER_PORT=1314
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash \
         build-essential git pkg-config curl ca-certificates unzip \
         libjpeg62-turbo libvips42 \
         xvfb \

--- a/.dev/compose.yml
+++ b/.dev/compose.yml
@@ -24,6 +24,11 @@ services:
   # Interactive shell (optimized)
   sh:
     image: jetthoughts.com-test:1.0.0
+    # amd64, not the host arch: this image pins Chrome for Testing linux64
+    # (.dev/cft-version) and records the linux/ screenshot baselines that CI
+    # (ubuntu-latest = amd64) renders. Building/running arm64 downloads an
+    # amd64 chrome it can only exec under emulation and drifts pixels from CI.
+    platform: linux/amd64
     build:
       context: ../
       dockerfile: ./.dev/Dockerfile
@@ -42,6 +47,8 @@ services:
   # Test runner with optimized dependency management
   t:
     image: jetthoughts.com-test:1.0.0
+    # amd64 to match CI's rendering (see `sh` service note above).
+    platform: linux/amd64
     build:
       context: ../
       dockerfile: ./.dev/Dockerfile

--- a/bin/test
+++ b/bin/test
@@ -13,7 +13,6 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-DEST="_dest/public-test"
 BASE_URL="http://localhost:${TEST_SERVER_PORT:-1314}"
 
 force_build=""
@@ -22,22 +21,30 @@ if [ "${1:-}" = "--build" ]; then
   shift
 fi
 
-stale() {
-  [ -f "$DEST/index.html" ] || return 0
-  newest_src=$(find content themes layouts config data postcss.config.js \
-    -type f -newer "$DEST/index.html" -print -quit 2>/dev/null || true)
-  [ -n "$newest_src" ]
-}
-
-if [ -n "$force_build" ] || stale; then
-  echo "bin/test: building site to $DEST (bin/hugo-build)..."
-  ENVIRONMENT=production OUTPUT_DIR="$DEST" BASE_URL="$BASE_URL" BUILD_DRAFTS=1 bin/hugo-build
+if [ -n "${PRECOMPILED_ASSETS:-}" ] && [ -n "${HUGO_DEFAULT_PATH:-}" ]; then
+  # Caller (bin/dtest) already built the site on the host and mounted it in;
+  # the test container has no hugo to (re)build with, so trust what we're given.
+  echo "bin/test: using caller-precompiled site at $HUGO_DEFAULT_PATH"
 else
-  echo "bin/test: reusing warm build at $DEST (force with --build)"
-fi
+  DEST="_dest/public-test"
 
-export PRECOMPILED_ASSETS=1
-export HUGO_DEFAULT_PATH="$DEST"
+  stale() {
+    [ -f "$DEST/index.html" ] || return 0
+    newest_src=$(find content themes layouts config data postcss.config.js \
+      -type f -newer "$DEST/index.html" -print -quit 2>/dev/null || true)
+    [ -n "$newest_src" ]
+  }
+
+  if [ -n "$force_build" ] || stale; then
+    echo "bin/test: building site to $DEST (bin/hugo-build)..."
+    ENVIRONMENT=production OUTPUT_DIR="$DEST" BASE_URL="$BASE_URL" BUILD_DRAFTS=1 bin/hugo-build
+  else
+    echo "bin/test: reusing warm build at $DEST (force with --build)"
+  fi
+
+  export PRECOMPILED_ASSETS=1
+  export HUGO_DEFAULT_PATH="$DEST"
+fi
 
 if [ $# -eq 0 ]; then
   bin/rake test:critical


### PR DESCRIPTION
## Summary

`bin/dtest` was broken after the R2 refactor and its Linux renders drifted from CI's amd64. Three coupled fixes so local Docker dtest runs **and renders the same pixels CI does**.

| Symptom | Root cause | Fix |
|---------|-----------|-----|
| `env: can't execute 'bash'` | R2 made `bin/test` a bash script (`set -o pipefail`); `ruby:4.0-slim` never installed bash | `+ bash` in `.dev/Dockerfile` |
| `hugo: command not found` | refactored `bin/test` hardcoded its dest + force-built, ignoring the site `bin/dtest` pre-builds and mounts in (container has no hugo) | `bin/test` honors caller-set `PRECOMPILED_ASSETS`+`HUGO_DEFAULT_PATH` |
| screenshots drift from CI | image was arm64 → emulated chrome → different pixels | `platform: linux/amd64` on `sh`/`t` services |

The amd64 image requires colima `rosetta: true` locally (qemu segfaults compiling native gems); Rosetta renders identically to CI. `bin/dtest-all` was unaffected (runs rake directly, bypasses `bin/test`).

## Verification
- **Local dtest (amd64 via Rosetta):** 34 runs, 0 failures, 53 screenshots matched committed `linux/` baselines within tolerance.
- **Local macOS critical:** 34 runs, 0 failures, 53 screenshots.
- **Unit:** 275 runs, 0 failures.
- **CI screenshot suite:** dispatched on this branch to confirm amd64 parity.

Note: `test.yml` is path-gated to rendering inputs (themes/config/test), so it does not auto-run for these harness-infra paths — dispatched manually instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)