### PR TITLE
fix(devx): R3-1 - one truthful build path for every test runner

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Pre-push guard: fast local mirror of the CI gates (<10s warm), so a push
+# that would fail publish.yml dies here instead of 3 minutes later in CI.
+# Installed by bin/setup via `git config core.hooksPath .githooks`.
+#
+#   SKIP_CHECKS=1 git push     # bypass once, intentionally
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+if [ "${SKIP_CHECKS:-}" = "1" ]; then
+  echo "pre-push: SKIP_CHECKS=1 - skipping checks"
+  exit 0
+fi
+
+fail() { echo "pre-push: $1 failed - fix it or bypass once with SKIP_CHECKS=1 git push" >&2; exit 1; }
+
+echo "pre-push: CSS lint ratchet"
+bin/lint-css >/dev/null 2>&1 || fail "bin/lint-css (rerun it directly for the report)"
+
+echo "pre-push: course validators"
+bin/validate-course >/dev/null || fail "bin/validate-course"
+
+# Each file gets its own ruby invocation: `ruby file1.rb file2.rb` executes
+# ONLY file1 (file2 becomes ARGV) - that silently skipped bin_scripts_test
+# for a while. bin_scripts_test now guards this hook against the pattern.
+echo "pre-push: toolchain pins guard"
+bundle exec ruby -Itest test/unit/toolchain_pins_test.rb >/dev/null 2>&1 \
+  || fail "toolchain_pins_test (run: bundle exec ruby -Itest test/unit/toolchain_pins_test.rb)"
+
+echo "pre-push: bin script guards"
+bundle exec ruby -Itest test/unit/bin_scripts_test.rb >/dev/null 2>&1 \
+  || fail "bin_scripts_test (run: bundle exec ruby -Itest test/unit/bin_scripts_test.rb)"
+
+echo "pre-push: all checks green"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -20,15 +20,11 @@ bin/lint-css >/dev/null 2>&1 || fail "bin/lint-css (rerun it directly for the re
 echo "pre-push: course validators"
 bin/validate-course >/dev/null || fail "bin/validate-course"
 
-# Each file gets its own ruby invocation: `ruby file1.rb file2.rb` executes
-# ONLY file1 (file2 becomes ARGV) - that silently skipped bin_scripts_test
-# for a while. bin_scripts_test now guards this hook against the pattern.
-echo "pre-push: toolchain pins guard"
-bundle exec ruby -Itest test/unit/toolchain_pins_test.rb >/dev/null 2>&1 \
-  || fail "toolchain_pins_test (run: bundle exec ruby -Itest test/unit/toolchain_pins_test.rb)"
-
-echo "pre-push: bin script guards"
-bundle exec ruby -Itest test/unit/bin_scripts_test.rb >/dev/null 2>&1 \
-  || fail "bin_scripts_test (run: bundle exec ruby -Itest test/unit/bin_scripts_test.rb)"
+# One rake task, not `ruby file1.rb file2.rb` - the latter executes ONLY
+# file1 (file2 becomes ARGV) and silently skipped bin_scripts_test for a
+# while. bin_scripts_test guards this hook against regressing.
+echo "pre-push: guard tests (toolchain pins + bin scripts)"
+bin/rake test:guards >/dev/null 2>&1 \
+  || fail "guard tests (run: bin/rake test:guards)"
 
 echo "pre-push: all checks green"

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ hugo.linux
 !.stitch
 !.junie
 !.dev
+# project git hooks (bin/setup wires core.hooksPath here) - without this
+# negation the .* rule silently kept the pre-push guard out of the repo
+!.githooks
 !.gitignore
 !.mise.toml
 !.ruby-version

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -3,7 +3,7 @@ type: Playbook
 title: Test gates and when they block commits
 description: bin/qtest --changed is the routine gate; bin/rake test:critical at milestones; bin/test AND bin/dtest once at PR prep (or on explicit confirmation) for themes/, layouts/, or CSS changes.
 tags: [testing, visual-regression, gates]
-timestamp: 2026-07-31T00:00:00Z
+timestamp: 2026-07-31T15:00:00Z
 ---
 
 # The suites
@@ -73,7 +73,28 @@ extend it when adding components or critical files. The macOS full suite remains
   in the same commit that fixes duplicates - it only goes down.
 - Tests must assert behavior shape (`q=\d+`, has `<picture>`), never tunable
   config values (exact quality/width numbers).
-- Visual regression is a LOCAL gate only. CI does NOT run screenshot diffs -
-  cross-OS pixel comparison is unusable (Alpine/musl baselines vs Ubuntu/glibc
-  CI diverge 3-28%), so `bin/test` + `bin/dtest` are the sole visual coverage.
-  What CI enforces (build, unit, link check) lives in [ci-gates.md](ci-gates.md).
+- CI DOES run screenshot diffs since 2026-07-31 (PRs #413/#417): test.yml
+  installs the pinned rendering stack (bin/setup-test-env: CfT per
+  .dev/cft-version + fonts.conf) so the runner renders the same pixels as
+  the `linux/` baselines - the old Alpine/musl-vs-glibc 3-28% divergence
+  argument no longer applies (image is Debian/glibc since #403). The PR
+  gate is REPORT-ONLY during the soak week; details in
+  [ci-gates.md](ci-gates.md).
+- All four runners (test/qtest/dtest/dtest-all) build through
+  `bin/build-if-stale <dest>` - it routes via bin/hugo-build (PurgeCSS
+  cold-start warm-up guard; a bare `hugo` call can purge live classes on a
+  fresh clone) and skips on a warm tree. qtest and bin/test share
+  `_dest/public-test`, so a qtest right after a bin/test run costs 0s of
+  build. `FORCE_BUILD=1` (or bin/test `--build`) forces. The staleness
+  probe watches content/ themes/ layouts/ config/ data/ assets/ static/
+  postcss.config.js package.json bun.lockb.
+- `bin/qtest --changed` counts UNTRACKED files (git ls-files --others):
+  before 2026-07-31 a brand-new pages/foo.css produced "no visual-affecting
+  changes" and a false green exit 0.
+- The `.gitignore` `.*` rule silently keeps NEW dot-directories out of the
+  repo unless negated (`!.githooks`, `!.mise.toml`, `!.claude/settings.json`
+  all needed this). The R2 pre-push hook shipped bin/setup wiring for
+  `core.hooksPath .githooks` while the hook file itself never made it into
+  the repo - fresh clones had a hooksPath pointing at nothing. Adding any
+  root dotfile/dot-dir? Check `git check-ignore -v <path>` before assuming
+  it's tracked.

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1,5 +1,23 @@
 # Bundle Update Log
 
+## 2026-07-31 (R3-1 harness truth)
+
+* **Update**: [test-gates](/build/test-gates.md) - all four test runners now
+  build through the shared `bin/build-if-stale` helper (routes via
+  bin/hugo-build's PurgeCSS warm-up guard, skips on warm trees); qtest shares
+  bin/test's `_dest/public-test` so micro-commit gates stop paying a ~26s
+  rebuild each run; `qtest --changed` now counts untracked files (was false
+  green exit 0 on a brand-new CSS file); bin/test honors preset
+  HUGO_DEFAULT_PATH + PRECOMPILED_ASSETS (was silently breaking bin/dtest by
+  pointing the container at the wrong tree). Removed the stale "CI does NOT
+  run screenshot diffs" claim (superseded by #413/#417). New gotcha recorded:
+  the `.gitignore` `.*` rule kept `.githooks/pre-push` out of the repo
+  entirely - the R2 pre-push guard existed only on one machine until the
+  `!.githooks` negation landed; check `git check-ignore -v` for any new root
+  dot-path. Guard tests added: bare `hugo --environment production` outside
+  hugo-build/build-if-stale, multi-file `ruby a_test.rb b_test.rb` (only the
+  first file executes), bin/test HUGO_DEFAULT_PATH contract.
+
 ## 2026-07-31 (visual gate truth fix)
 
 * **Update**: [ci-gates](/build/ci-gates.md) - first CI baseline-record run

--- a/Rakefile
+++ b/Rakefile
@@ -49,6 +49,18 @@ namespace :test do
     t.pattern = "test/integration/**/*_test.rb"
   end
 
+  # Fast repo-shape guards (~2s): toolchain pin drift + bin-script portability.
+  # The pre-push hook's test entrypoint - one task, so the hook never falls
+  # into the `ruby file1.rb file2.rb` trap (only file1 executes).
+  Rake::TestTask.new(:guards) do |t|
+    t.libs << "test"
+    t.libs << "lib"
+    t.test_files = FileList[
+      "test/unit/toolchain_pins_test.rb",
+      "test/unit/bin_scripts_test.rb"
+    ]
+  end
+
   namespace :screenshots do
     desc "Restore baseline PNGs rewritten by a test run (candidates live in the working tree; git HEAD is the baseline)"
     task :reset do

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,38 +1,52 @@
 # Bin Directory Scripts
 
-This directory contains utility scripts for the JetThoughts Hugo site.
+Utility scripts for the JetThoughts Hugo site. This list matches the actual
+contents of `bin/` — if you add or remove a script, update it here.
 
 ## Build & Development
 
-- `dev` - Start development server with hot reload (port 1313)
-- `debug` - Start development server with debug logging
-- `build` - Build production site
-- `benchmark-dev` - Benchmark development server performance
+- `dev` - Development server with hot reload (port 1313, development PostCSS chain)
+- `build` - Production build (wraps `hugo-build`)
+- `hugo-build` - Canonical production build: PurgeCSS cold-start warm-up guard, validation. ALL production builds route through this
+- `build-if-stale <dest> [base-url]` - Shared helper: builds via `hugo-build` only when sources are newer than the dest tree (`FORCE_BUILD=1` overrides). Used by `test`/`qtest`/`dtest`/`dtest-all`
+- `hugo-clean` - Remove build artifacts (`_dest`, caches)
 
 ## Testing
 
-- `test` - Run Ruby test suite
-- `dtest` - Run tests in Docker environment
-- `lighthouse` - Run Lighthouse performance benchmarks (90+ score requirement)
-- `lighthouse-compare` - Compare two Lighthouse benchmark runs
+- `qtest [--changed|--all|page-keys]` - Fast scoped visual gate (~25-90s): only the screenshot tests for pages a change touches, plus random extras. The per-micro-commit gate
+- `test [file.rb]` - Full local suite (`rake test:critical`) or a single test file, against a warm prebuilt tree
+- `dtest [file.rb]` - Same as `test` but inside the Docker rendering container (Linux baselines)
+- `dtest-all` - Whole suite (`rake test:all`) in Docker, detached; logs to `tmp/dtest-all.log`
+- `setup-test-env` - Install the pinned rendering stack (Chrome for Testing per `.dev/cft-version`, fonts, fontconfig); prints `CHROME_BIN`/`CHROMEDRIVER_PATH` with `--print-env`
+- `smoke` - Build + lint + dtest in one shot
+- `lighthouse` / `lighthouse-compare` - Performance benchmarks and run comparison
+- `lint-css` - Stylelint ratchet (warning count can only go down)
+- `validate-course` - Course content validators
 
 ## Docker
 
 - `dc` - Docker Compose wrapper
-- `docked` - Run commands in Docker container
+- `docked` - Run a command in the test container
+- `docker-rebuild` - Nuke and rebuild the compose images from scratch
 
-## Utilities
+## Setup
 
-- `setup` - Initial project setup
-- `rake` - Ruby task runner
-- `bunx` - NPM package runner (using bunx)
+- `setup` - Initial project setup (mise, bundle, hooks via `core.hooksPath .githooks`, doctor summary)
+- `agent-bootstrap` - Idempotent agent/remote-session bootstrap (bundle, bun, test env); wired as a SessionStart hook
+
+## Content & Sync
+
 - `sync_with_devto` - Sync blog posts with dev.to
-- `skillshare-sync` - Sync skills to all configured AI CLI targets
+- `skillshare-sync` - Sync skills to configured AI CLI targets
+- `generate-template-pdfs` - Regenerate course template PDFs
 
-## Content
+## CSS Migration Tooling (project 2509)
 
-- `generate-cover-image` - Generate a blog post cover image (1200x630 JPEG) via the Gemini CLI. Takes two positional args: `<slug>` and `"concept sentence"`. Writes to `content/blog/<slug>/cover.jpg`. Uses the `gemini-3.1-flash-image-preview` model (Nano Banana 2); requires `GEMINI_API_KEY` from https://aistudio.google.com/app/apikey. Full design system rationale in `docs/projects/2510-seo-content-strategy/20-29-strategy/20.06-blog-cover-image-design-system.md`.
+- `css-split` - Extract shared-component rules from a page CSS file
+- `css-winners` - Compare two compiled bundles at the per-selector winner level
 
-## Deprecated
+## Misc
 
-- `surge` - Static site deployment (folder)
+- `rake` - Ruby task runner wrapper
+- `hive` - Spawn a claude-flow hive-mind session
+- `surge/` - Static preview deployment (folder: `deploy`, `cleanup`)

--- a/bin/build-if-stale
+++ b/bin/build-if-stale
@@ -18,8 +18,11 @@ BASE_URL="${2:-http://localhost:${TEST_SERVER_PORT:-1314}}"
 
 stale() {
   [ -f "$DEST/index.html" ] || return 0
+  # Directories are probed too (no -type f): deleting a source file leaves
+  # nothing to be -newer, but it DOES bump the parent directory's mtime -
+  # without this, a deleted page could be served from a "warm" tree forever.
   newest_src=$(find content themes layouts config data assets static postcss.config.js package.json bun.lockb \
-    -type f -newer "$DEST/index.html" -print -quit 2>/dev/null || true)
+    -newer "$DEST/index.html" -print -quit 2>/dev/null || true)
   [ -n "$newest_src" ]
 }
 

--- a/bin/build-if-stale
+++ b/bin/build-if-stale
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# bash, not sh: `set -o pipefail` is a bashism - dash (Linux /bin/sh) rejects it
+#
+# Shared build-once helper for the test runners (bin/test, bin/qtest,
+# bin/dtest, bin/dtest-all). Builds through bin/hugo-build - which carries
+# the PurgeCSS cold-start warm-up guard a bare `hugo` call lacks (the
+# 2026-07-19 .sr-only incident class) - and skips entirely when the dest
+# is newer than every source tree (warm rerun).
+#
+#   bin/build-if-stale <dest> [base-url]     # build only if stale
+#   FORCE_BUILD=1 bin/build-if-stale <dest>  # always build
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+DEST="${1:?usage: bin/build-if-stale <dest> [base-url]}"
+BASE_URL="${2:-http://localhost:${TEST_SERVER_PORT:-1314}}"
+
+stale() {
+  [ -f "$DEST/index.html" ] || return 0
+  newest_src=$(find content themes layouts config data assets static postcss.config.js package.json bun.lockb \
+    -type f -newer "$DEST/index.html" -print -quit 2>/dev/null || true)
+  [ -n "$newest_src" ]
+}
+
+if [ -n "${FORCE_BUILD:-}" ] || stale; then
+  echo "build-if-stale: building site to $DEST (bin/hugo-build)..."
+  ENVIRONMENT=production OUTPUT_DIR="$DEST" BASE_URL="$BASE_URL" BUILD_DRAFTS=1 bin/hugo-build
+else
+  echo "build-if-stale: reusing warm build at $DEST (FORCE_BUILD=1 to rebuild)"
+fi

--- a/bin/dtest
+++ b/bin/dtest
@@ -2,16 +2,14 @@
 
 set -euo pipefail
 
-echo "Building Hugo site for Docker tests (public-dtest) with optimizations..."
-hugo --noBuildLock \
-   --buildDrafts \
-   --environment production \
-   --destination=_dest/public-dtest \
-   --logLevel=warn \
-   --baseURL="http://localhost:1314"
+echo "Building Hugo site for Docker tests (public-dtest)..."
+bin/build-if-stale _dest/public-dtest "http://localhost:1314"
 
 # Now run the tests in Docker. Args must go THROUGH bin/test - compose's
 # `run t <args>` replaces the container command entirely, so a bare .rb
 # path would be exec'd as the command itself (mirrors bin/dtest-all).
+# HUGO_DEFAULT_PATH must be passed explicitly: bin/test honors it, and
+# PRECOMPILED_ASSETS stops the container (which has no hugo) from building.
 echo "Running tests in Docker..."
-bin/docked --env PRECOMPILED_ASSETS=true --env TEST_SERVER_PORT=1314 t bin/test "$@"
+bin/docked --env PRECOMPILED_ASSETS=true --env TEST_SERVER_PORT=1314 \
+  --env HUGO_DEFAULT_PATH=_dest/public-dtest t bin/test "$@"

--- a/bin/dtest-all
+++ b/bin/dtest-all
@@ -20,9 +20,8 @@ DEST = "_dest/public-dtest-all"
 LOG = "tmp/dtest-all.log"
 
 puts "dtest-all: building snapshot to #{DEST} ..."
-system("hugo", "--noBuildLock", "--buildDrafts", "--environment", "production",
-  "--destination", DEST, "--logLevel", "warn",
-  "--baseURL", "http://localhost:1314") || abort("dtest-all: hugo build failed")
+# via bin/hugo-build (PurgeCSS cold-start warm-up guard) + staleness skip
+system("bin/build-if-stale", DEST, "http://localhost:1314") || abort("dtest-all: build failed")
 
 require "fileutils"
 FileUtils.mkdir_p("tmp")

--- a/bin/qtest
+++ b/bin/qtest
@@ -21,7 +21,10 @@
 # Site-wide files (skin, style.css, theme-main, 586, navigation, foundations/…)
 # escalate to --all: a scoped run cannot vouch for them.
 
-DEST = "_dest/public-fast"
+# Shared with bin/test so one warm tree serves both gates (bin/build-if-stale
+# skips the rebuild when nothing changed - previously qtest rebuilt ~26s+ on
+# every single invocation into its own private _dest/public-fast).
+DEST = "_dest/public-test"
 
 PAGE_TESTS = {
   "homepage" => "homepage",
@@ -99,9 +102,13 @@ start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 elapsed = -> { (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start).round }
 
 if changed
+  # Untracked files count as changes: a brand-new pages/foo.css previously
+  # produced "no visual-affecting changes" and a false green exit 0.
+  untracked = `git ls-files --others --exclude-standard`.split("\n")
   files = `git diff --name-only #{ref}`.split("\n") if ref
   files = `git diff --name-only HEAD`.split("\n") if files.nil? || files.empty?
-  files = `git diff --name-only HEAD~1..HEAD`.split("\n") if files.empty?
+  files = `git diff --name-only HEAD~1..HEAD`.split("\n") if files.empty? && untracked.empty?
+  files = (files || []) + untracked
   files.each do |f|
     mapped = pages_for(f)
     if mapped == :all
@@ -139,9 +146,10 @@ unless ENV["ALLOW_DIRTY_SCREENSHOTS"]
 end
 
 if build
-  puts "qtest: building to #{DEST} ..."
-  system("hugo", "--baseURL", "/", "--environment", "production", "--buildDrafts",
-    "--noBuildLock", "--quiet", "--destination", DEST) || abort("qtest: hugo build failed")
+  # bin/build-if-stale routes through bin/hugo-build (PurgeCSS cold-start
+  # warm-up guard - a bare `hugo` call can purge live classes on a fresh
+  # clone) and no-ops on a warm tree.
+  system("bin/build-if-stale", DEST) || abort("qtest: build failed")
 end
 
 ENV["PRECOMPILED_ASSETS"] = "true"

--- a/bin/test
+++ b/bin/test
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 # bash, not sh: `set -o pipefail` is a bashism - dash (Linux /bin/sh) rejects it
 #
-# Fast path: build ONCE through bin/hugo-build (which carries the PurgeCSS
-# cold-start warm-up guard the bare `hugo` call in hugo_helpers lacks) to a
-# stable dest, then run tests with PRECOMPILED_ASSETS so nothing rebuilds.
-# A warm rerun skips the build entirely via an mtime staleness check.
+# Build once (via bin/build-if-stale -> bin/hugo-build, which carries the
+# PurgeCSS cold-start warm-up guard), then run tests against the prebuilt
+# tree. Warm reruns skip the build via an mtime staleness check.
 #
 #   bin/test                 # critical suite
 #   bin/test path/to/x.rb    # single file (reuses the same prebuilt site)
 #   bin/test --build [...]   # force a rebuild first
+#
+# Honors a pre-set HUGO_DEFAULT_PATH (bin/dtest points the container at
+# _dest/public-dtest) and skips building entirely when PRECOMPILED_ASSETS
+# is already set by the caller (containers have no hugo binary).
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-BASE_URL="http://localhost:${TEST_SERVER_PORT:-1314}"
+DEST="${HUGO_DEFAULT_PATH:-_dest/public-test}"
 
 force_build=""
 if [ "${1:-}" = "--build" ]; then
@@ -21,30 +24,16 @@ if [ "${1:-}" = "--build" ]; then
   shift
 fi
 
-if [ -n "${PRECOMPILED_ASSETS:-}" ] && [ -n "${HUGO_DEFAULT_PATH:-}" ]; then
-  # Caller (bin/dtest) already built the site on the host and mounted it in;
+if [ -n "${PRECOMPILED_ASSETS:-}" ]; then
+  # Caller (bin/dtest, CI) already built the site and pointed us at it;
   # the test container has no hugo to (re)build with, so trust what we're given.
-  echo "bin/test: using caller-precompiled site at $HUGO_DEFAULT_PATH"
+  echo "bin/test: using caller-precompiled site at $DEST"
 else
-  DEST="_dest/public-test"
-
-  stale() {
-    [ -f "$DEST/index.html" ] || return 0
-    newest_src=$(find content themes layouts config data postcss.config.js \
-      -type f -newer "$DEST/index.html" -print -quit 2>/dev/null || true)
-    [ -n "$newest_src" ]
-  }
-
-  if [ -n "$force_build" ] || stale; then
-    echo "bin/test: building site to $DEST (bin/hugo-build)..."
-    ENVIRONMENT=production OUTPUT_DIR="$DEST" BASE_URL="$BASE_URL" BUILD_DRAFTS=1 bin/hugo-build
-  else
-    echo "bin/test: reusing warm build at $DEST (force with --build)"
-  fi
-
-  export PRECOMPILED_ASSETS=1
-  export HUGO_DEFAULT_PATH="$DEST"
+  FORCE_BUILD="$force_build" bin/build-if-stale "$DEST"
 fi
+
+export PRECOMPILED_ASSETS=1
+export HUGO_DEFAULT_PATH="$DEST"
 
 if [ $# -eq 0 ]; then
   bin/rake test:critical

--- a/test/unit/bin_scripts_test.rb
+++ b/test/unit/bin_scripts_test.rb
@@ -60,10 +60,14 @@ class BinScriptsTest < Minitest::Test
 
   # `ruby file1.rb file2.rb` executes ONLY file1 (file2 becomes ARGV) -
   # this silently disabled these very guards in the pre-push hook once.
-  def test_pre_push_hook_runs_each_test_file_separately
+  # The hook must run them through the rake entrypoint, and must not fall
+  # back to the multi-file ruby pattern.
+  def test_pre_push_hook_runs_guards_via_rake_entrypoint
     hook = File.expand_path("../../.githooks/pre-push", __dir__)
-    skip "no pre-push hook" unless File.file?(hook)
+    assert File.file?(hook), ".githooks/pre-push missing - the .gitignore `.*` rule swallowed it once"
     body = File.read(hook, encoding: "bom|utf-8")
+    assert_match(%r{bin/rake test:guards}, body,
+      "pre-push must run the guard tests via `bin/rake test:guards`")
     refute_match(/ruby\s+(?:-\S+\s+)*\S+_test\.rb\s+\S+_test\.rb/, body,
       "pre-push passes multiple test files to one ruby invocation - only the first runs")
   end

--- a/test/unit/bin_scripts_test.rb
+++ b/test/unit/bin_scripts_test.rb
@@ -39,4 +39,41 @@ class BinScriptsTest < Minitest::Test
     end
     assert_empty missing, "executable bin/ scripts without a shebang"
   end
+
+  # Production builds must route through bin/hugo-build: it carries the
+  # PurgeCSS cold-start warm-up guard (missing hugo_stats.json purges live
+  # classes - the 2026-07-19 .sr-only production incident). A bare
+  # `hugo --environment production` in any other runner silently skips it.
+  def test_no_bare_production_hugo_builds_outside_hugo_build
+    offenders = Dir.children(BIN_DIR).filter_map do |name|
+      next if %w[hugo-build build-if-stale].include?(name)
+      path = File.join(BIN_DIR, name)
+      next unless File.file?(path) && File.executable?(path)
+      body = File.read(path, encoding: "bom|utf-8")
+      invokes_hugo = body.match?(/system\(\s*["']hugo["']/) || body.match?(/^\s*hugo\s/)
+      production_env = body.match?(/--environment[",\s]+["']?production/)
+      path if invokes_hugo && production_env
+    end
+    assert_empty offenders,
+      "bin/ scripts invoking bare `hugo --environment production` - route through bin/hugo-build (or bin/build-if-stale)"
+  end
+
+  # `ruby file1.rb file2.rb` executes ONLY file1 (file2 becomes ARGV) -
+  # this silently disabled these very guards in the pre-push hook once.
+  def test_pre_push_hook_runs_each_test_file_separately
+    hook = File.expand_path("../../.githooks/pre-push", __dir__)
+    skip "no pre-push hook" unless File.file?(hook)
+    body = File.read(hook, encoding: "bom|utf-8")
+    refute_match(/ruby\s+(?:-\S+\s+)*\S+_test\.rb\s+\S+_test\.rb/, body,
+      "pre-push passes multiple test files to one ruby invocation - only the first runs")
+  end
+
+  # bin/test must honor a caller-provided HUGO_DEFAULT_PATH (bin/dtest points
+  # the container at _dest/public-dtest) - a hardcoded DEST silently tests
+  # the wrong tree.
+  def test_bin_test_honors_preset_hugo_default_path
+    body = File.read(File.join(BIN_DIR, "test"), encoding: "bom|utf-8")
+    assert_match(/DEST="\$\{HUGO_DEFAULT_PATH:-/, body,
+      "bin/test must default DEST from HUGO_DEFAULT_PATH")
+  end
 end


### PR DESCRIPTION
## What

Round-3 DevX: make the local test harness truthful and fast. All four test runners (`bin/test`, `bin/qtest`, `bin/dtest`, `bin/dtest-all`) now build through one shared helper, and the lies the multi-agent audit found are fixed:

- **New `bin/build-if-stale <dest> [base-url]`**: routes every test build through `bin/hugo-build` (PurgeCSS cold-start warm-up guard — the 2026-07-19 `.sr-only` incident class) and skips the rebuild when the dest tree is newer than every source tree. Staleness probe now also watches `assets/`, `static/`, `package.json`, `bun.lockb` (previously blind to badge/static-asset edits). `FORCE_BUILD=1` overrides.
- **`bin/test` no longer breaks `bin/dtest`**: `DEST` honors a caller-preset `HUGO_DEFAULT_PATH`, and the build is skipped entirely when `PRECOMPILED_ASSETS` is already set — previously it exported `_dest/public-test` over the container's `_dest/public-dtest` and pointed the Docker suite at the wrong tree (or `hugo: command not found` on a stale one).
- **`bin/qtest` shares `bin/test`'s warm tree** (`_dest/public-test`): the per-micro-commit gate stops paying a ~26s private rebuild on every invocation (measured warm skip: 0.02s).
- **`bin/qtest --changed` counts untracked files**: a brand-new `pages/foo.css` previously produced "no visual-affecting changes" and a false green exit 0.
- **Pre-push hook rescued into the repo**: the R2 hook ran two test files in one `ruby` invocation (only the first executes — the guard suite was silently skipped), now split into two invocations. Bigger find: **the hook file itself had never been committed** — the `.gitignore` `.*` rule swallowed `.githooks/`, so every fresh clone had `core.hooksPath` pointing at nothing. Added the `!.githooks` negation and committed the hook.
- **3 new `bin_scripts_test` guards**: no bare `hugo --environment production` outside `hugo-build`/`build-if-stale`; pre-push must not pass multiple test files to one `ruby`; `bin/test` must default `DEST` from `HUGO_DEFAULT_PATH`.
- **Doc truth**: `bin/README.md` listed four scripts that don't exist and omitted eleven that do — rewritten to match the directory. `.okf` test-gates concept updated (drops the stale "CI does NOT run screenshot diffs" claim, superseded by #413/#417) + log entry.
- Removed 3.7 GB of orphan `_dest/public-test-[0-9]` trees left by the old `rand(5)` bucket fan-out (local cleanup, not in the diff).

## Verification

- `bundle exec rake test:unit`: **278 runs, 0 failures** (275 pre-existing + 3 new guards); new guards verified red against the reverted patterns.
- Warm path: `bin/build-if-stale _dest/public-test` twice — second run skips in 0.02s; touching a content file correctly re-triggers a build.
- Untracked trigger: `touch themes/beaver/assets/css/pages/zzz-fake.css` → qtest sees it and aborts loudly (exit 1) instead of exiting 0 green.
- Scoped `bin/qtest homepage` end-to-end on the pinned rendering stack: reused the warm tree, ran the scoped tests, and the dirty-baseline guard fired as designed. (The screenshot diffs themselves are the known old-baselines-vs-pinned-stack gap that the post-#418 baseline re-record closes — environmental, reproduced identically in CI on master.)
- `bash -n` / `ruby -c` clean on all edited scripts; pre-push hook ran green on the push of this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXHeUErqoiyH9xN1mjC8cH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added smarter site builds that reuse up-to-date output and support custom destinations and base URLs.
  - Improved test workflows with shared build output, configurable paths, and detection of untracked files.
  - Added a pre-push validation hook with progress reporting and actionable failure messages.

- **Documentation**
  - Expanded the script inventory and updated testing guidance to reflect current build and screenshot workflows.

- **Tests**
  - Added safeguards for approved build execution, test-file handling, and configurable site output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->