### PR TITLE
fix(ci): R3-2 - correctness + cost pass on the CI pipeline

### DIFF
--- a/.github/actions/setup-hugo/action.yml
+++ b/.github/actions/setup-hugo/action.yml
@@ -52,19 +52,32 @@ runs:
       with:
         node-version: '22'
 
-    # hugo_stats.json is cached deliberately: it is gitignored, and without it
-    # every run pays bin/hugo-build's ~52s PurgeCSS warm-up double-build. The
-    # key hashes config/** (the real config location - the old key hashed
-    # nonexistent root hugo.toml/hugo.dev.toml, so config-only changes reused
-    # a stale resources/_gen).
+    # Two separate caches on purpose:
+    #
+    # 1. hugo_stats.json - EXACT key only, NO restore-keys. The warm-up skip
+    #    in _hugo.yml/bin/hugo-build trusts a non-empty stats file; a
+    #    restore-keys partial hit would restore a STALE stats file from an
+    #    older tree and PurgeCSS would purge classes that are live in THIS
+    #    tree (the 2026-07-19 .sr-only incident class). An exact hit means
+    #    the source tree is identical, so the stats are valid; any change
+    #    misses and pays the ~52s warm-up instead of risking a broken deploy.
+    - name: Cache hugo_stats.json (exact tree match only)
+      uses: actions/cache@v5
+      with:
+        path: hugo_stats.json
+        key: ${{ runner.os }}-hugo-stats-${{ inputs.environment }}-${{ hashFiles('config/**', 'postcss.config.js', 'package.json', '**/bun.lockb', 'themes/**', 'layouts/**', 'content/**') }}
+
+    # 2. Hugo's own caches - restore-keys are safe here (Hugo content-hashes
+    #    resources/_gen entries internally), and partial hits still save real
+    #    time. _dest is deliberately NOT cached: it uploaded ~1-2 GB per job,
+    #    evicting every other cache from the 10 GB repo quota, and the build
+    #    step regenerates it anyway.
     - name: Cache Hugo build
       uses: actions/cache@v5
       with:
         path: |
           /tmp/hugo_cache
           resources/_gen
-          _dest
-          hugo_stats.json
         key: ${{ runner.os }}-hugo-${{ inputs.environment }}-${{ hashFiles('config/**', 'postcss.config.js', 'package.json', '**/bun.lockb', 'themes/**', 'layouts/**', 'content/**') }}
         restore-keys: |
           ${{ runner.os }}-hugo-${{ inputs.environment }}-

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - 'content/**'
       - 'themes/**/layouts/**'
+      # root-level template overrides move links just like theme layouts
+      - 'layouts/**'
       - 'config/**'
       - 'data/**'
       - 'lychee.toml'
@@ -43,6 +45,11 @@ defaults:
 jobs:
   link_check:
     name: Broken Internal Links
+    # Sync fan-out gate: "Sync articles" completes every 10 min during the
+    # day, but most runs commit nothing. For workflow_run events, only crawl
+    # when the sync actually pushed (master head moved past the sha the sync
+    # ran on). github.sha for workflow_run = current default-branch head.
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_sha != github.sha) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -55,7 +62,12 @@ jobs:
           ruby-version: '4.0'
           bundler-cache: true
 
+      # setup only - rake test:links runs its own production build via
+      # bin/hugo-build; the composite's default build made this job build
+      # the whole site TWICE and blow its 10-minute timeout on cold caches.
       - uses: ./.github/actions/setup-hugo
+        with:
+          build: 'false'
 
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,12 +26,19 @@ defaults:
   run:
     shell: bash
 
+# Sync fan-out gate (both jobs): "Sync articles" completes every 10 min
+# during the day, but most runs commit nothing - deploying + testing an
+# unchanged tree ~84x/day is pure waste. For workflow_run events, run only
+# when the sync actually pushed (master head moved past the sha the sync ran
+# on). github.sha for workflow_run = current default-branch head.
 jobs:
   build_and_deploy:
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_sha != github.sha) }}
     uses: ./.github/workflows/_hugo.yml
 
   unit_tests:
     name: Unit Tests
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_sha != github.sha) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,10 @@ on:
   pull_request:
     paths:
       - 'themes/**'
+      # root-level template/asset overrides change rendering just like
+      # their themes/ counterparts
+      - 'layouts/**'
+      - 'assets/**'
       - 'config/**'
       - 'postcss.config.js'
       - 'test/fixtures/screenshots/**'
@@ -55,9 +59,13 @@ jobs:
     continue-on-error: ${{ github.event_name == 'pull_request' }}
 
     steps:
+      # PR events use the default checkout (the PR *merge* commit): testing
+      # the head branch alone misses conflicts with the base and breaks on
+      # fork PRs (head_ref doesn't exist in this repo). Record dispatches
+      # check out the real branch ref so the baseline commit can be pushed.
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.head_ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || '' }}
 
       - uses: snap-diff/snap_diff-capybara/.github/actions/setup-ruby-and-dependencies@5ee298fbc3c1e070c78e3d83862ffd3228204214
         with:
@@ -95,18 +103,30 @@ jobs:
           PRECOMPILED_ASSETS: '1'
           HUGO_DEFAULT_PATH: _dest/public-test
 
+      # test:system, not the full `rake test`: recording only rewrites
+      # screenshot baselines, and a failing unit test used to abort the run
+      # AFTER 15+ min of recording, discarding every recorded PNG.
       - name: Record baselines
+        id: record
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.update-baselines }}
-        run: FORCE_SCREENSHOT_UPDATE=true bundle exec rake test
+        run: FORCE_SCREENSHOT_UPDATE=true bundle exec rake test:system
         env:
           PRECOMPILED_ASSETS: '1'
           HUGO_DEFAULT_PATH: _dest/public-test
           # Record mode intentionally dirties the fixtures as it runs.
           ALLOW_DIRTY_SCREENSHOTS: '1'
 
+      # always(): freshly recorded baselines must be committed even when a
+      # test failed mid-run (a red test does not invalidate the OTHER pages'
+      # recordings). Gated on the record step actually having run, and the
+      # commit is a no-op when nothing changed.
       - name: Commit updated baselines
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.update-baselines }}
+        if: ${{ always() && steps.record.outcome != 'skipped' && github.event_name == 'workflow_dispatch' && inputs.update-baselines }}
         run: |
+          if [ -z "$(git status --porcelain test/fixtures/screenshots)" ]; then
+            echo "no baseline changes recorded - nothing to commit"
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add test/fixtures/screenshots/

--- a/.okf/build/ci-gates.md
+++ b/.okf/build/ci-gates.md
@@ -1,10 +1,10 @@
 ---
 type: Playbook
 title: CI gates (GitHub Actions)
-description: PR CI runs Hugo build, unit tests, and a path-scoped broken-internal-link crawl (lychee). Visual regression is not in CI yet - the old cross-OS blocker is gone (pinned glibc stack); re-introduction planned as DevX R2 Phase B.
+description: PR CI runs Hugo build, unit tests, a path-scoped broken-internal-link crawl (lychee), and a report-only visual gate on the pinned rendering stack. Sync fan-out is gated - no-op sync runs deploy nothing.
 tags: [ci, github-actions, testing, link-check]
 resource: .github/workflows/link-check.yml
-timestamp: 2026-07-31T00:00:00Z
+timestamp: 2026-07-31T16:30:00Z
 ---
 
 # What CI enforces on a PR
@@ -52,6 +52,35 @@ A CI screenshot job (`quick_test` + `bin/qtest`) was built and removed in PR #38
 Two gotchas the first record run hit (both fixed; evidence: [run 30629929407](https://github.com/jetthoughts/jetthoughts.github.io/actions/runs/30629929407) - 104 screenshots compared clean, 4 test failures, commit step never ran). Keep in mind for any new CI test job:
 - **Draft fixtures**: screenshot tests visit the draft post `/blog/codeblock-styles-fixture/`; local builds pass `--buildDrafts` but `bin/hugo-build` only does so when `BUILD_DRAFTS` is set - test.yml sets `BUILD_DRAFTS: '1'` on its setup-hugo step. A CI test build without it 404s the fixture and fails the codeblock tests on every run.
 - **fail_if_new in CI**: snap_diff hard-errors on missing baselines when `ENV["CI"]` is set. Record mode (`FORCE_SCREENSHOT_UPDATE=true`) disables `fail_on_difference` AND `fail_if_new` (setup_snap_diff.rb) so pages added since the last recording can get their FIRST baseline.
+
+# R3-2 correctness + cost fixes (2026-07-31)
+
+- **hugo_stats.json cache is EXACT-key-only** (own cache entry in
+  setup-hugo, no restore-keys). The warm-up skip trusts any non-empty stats
+  file; a restore-keys partial hit could restore a STALE stats file from an
+  older tree and PurgeCSS would purge live classes (the .sr-only incident
+  class re-opened via cache). Exact hit = identical source tree = valid
+  stats; any change pays the ~52s warm-up instead. Never add restore-keys
+  back to that entry.
+- **`_dest` is not cached** - it uploaded ~1-2 GB/job and evicted every
+  other cache from the 10 GB repo quota; the build regenerates it anyway.
+- **Sync fan-out gate**: publish.yml + link-check.yml `workflow_run` jobs
+  run only when `github.event.workflow_run.head_sha != github.sha`
+  (for workflow_run events github.sha = current default-branch head; the
+  sync pushing a commit is exactly what moves them apart). "Sync articles"
+  fires every 10 min 8-21 UTC but usually commits nothing - that was ~84
+  no-op deploy+test cascades/day.
+- **link-check builds ONCE**: setup-hugo runs with `build: 'false'`;
+  `rake test:links` does its own production build. The double build blew
+  the job's 10-min timeout on cold caches (seen on PR #422).
+- **test.yml checks out the PR MERGE commit** (default checkout) for
+  pull_request events; only record dispatches check out the branch ref
+  (needed to push the baseline commit). head_ref checkout tested the tip
+  without the base merged and breaks fork PRs.
+- **Record commits survive red tests**: record runs `rake test:system`
+  only (a unit failure used to discard 15+ min of recording), and the
+  commit step is `always()`-gated + porcelain-guarded, so recorded PNGs
+  land even when one page's test fails.
 
 # libvips gotcha (if a CI job ever needs ruby-vips again)
 

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1,5 +1,22 @@
 # Bundle Update Log
 
+## 2026-07-31 (R3-2 CI correctness + cost)
+
+* **Update**: [ci-gates](/build/ci-gates.md) - DevX R3-2: hugo_stats.json
+  moved to its own EXACT-key-only cache (restore-keys could restore stale
+  stats and re-open the PurgeCSS purge-live-classes incident class via
+  cache); `_dest` dropped from cache paths (~1-2 GB/job, evicted everything
+  else); sync fan-out gated (workflow_run jobs skip when the sync pushed
+  nothing - was ~84 no-op deploy+test cascades/day); link-check builds once
+  (composite `build: 'false'` - the double build blew its 10-min timeout on
+  cold caches, seen live on PR #422); test.yml checks out the PR merge
+  commit (head_ref tested the tip unmerged + broke fork PRs) and records
+  via `rake test:system` with an always()-gated porcelain-guarded commit
+  step (a red unit test used to discard 15+ min of recorded baselines).
+  Also: baseline re-record landed (2edb94d9) on the pinned stack - third
+  attempt, after #417 (drafts/fail_if_new) and #418 (push race + swallowed
+  retry failure).
+
 ## 2026-07-31 (R3-1 harness truth)
 
 * **Update**: [test-gates](/build/test-gates.md) - all four test runners now


### PR DESCRIPTION
## What

Round-3 DevX, part 2 (follows #422): fixes the CI pipeline's correctness hazards and its biggest cost leaks. All findings verified against the live workflows; two were observed failing in real runs this session.

### Correctness

- **`hugo_stats.json` cache is now exact-key-only** (own cache entry in `setup-hugo`, no `restore-keys`). The PurgeCSS warm-up skip trusts any non-empty stats file, but a `restore-keys` partial hit could restore a *stale* stats file from an older tree — re-opening the purge-live-classes incident class (2026-07-19 `.sr-only`) through the cache. An exact hit means the source tree is identical, so the stats are valid; any change misses and pays the ~52s warm-up instead of risking a broken deploy.
- **`test.yml` PR runs check out the merge commit** (default checkout) instead of `head_ref` — the head-only checkout tested the tip without the base merged in and breaks on fork PRs. Record dispatches still check out the branch ref, which the baseline push needs.
- **Record-mode resilience**: recording runs `rake test:system` only (the full `rake test` meant a unit failure aborted the run *after* 15+ minutes of recording, discarding every PNG), and the commit step is `always()`-gated + porcelain-guarded, so recorded baselines land even when one page's test is red.
- **Paths filters gain root `layouts/**` and `assets/**`** (visual gate) and root `layouts/**` (link check) — root-level template/asset overrides previously skipped both gates.

### Cost

- **Sync fan-out gated**: `publish.yml` and `link-check.yml` `workflow_run` jobs now skip when "Sync articles" pushed nothing, via `github.event.workflow_run.head_sha != github.sha` (for `workflow_run` events `github.sha` is the current default-branch head — a sync push is exactly what moves them apart). The sync fires every 10 minutes 8-21 UTC and usually commits nothing; that was ~84 no-op deploy + test + link-crawl cascades per day.
- **`_dest` dropped from the setup-hugo cache** — it uploaded ~1-2 GB per job and evicted every other cache from the 10 GB repo quota; the build step regenerates it anyway.
- **Link check builds once**: the composite runs with `build: 'false'` and `rake test:links` does its own production build. The double build blew the job's 10-minute timeout on cold caches — observed live on #422 (job 91200611137, killed mid-build at 10m; the warm re-run passed in 3m19s).

### Deliberately not done

- Narrowing `test.yml` permissions per-step: GitHub has no step-level permissions and the single job serves both PR (needs `pull-requests: write` for the report comment) and record (needs `contents: write`) events; splitting the job would duplicate the whole step list. Fork PRs already receive a read-only token automatically.

## Verification

- All four YAML files parse clean; the fan-out gate expression only affects `workflow_run` events (schedule/push/PR/dispatch behavior unchanged).
- The stats-cache split keeps the same key expression as before, so the first run after merge records a fresh exact-key entry; `bin/hugo-build`'s own cold-start guard covers the miss path (verified in R3-1).
- Link-check single build: `rake test:links` already builds via `bin/hugo-build` into its own `OUTPUT_DIR` (`Rakefile` `build_for_linkcheck`); the composite build it replaces produced a tree nothing in this job read.
- Observing one no-op sync cycle post-merge confirms the fan-out gate (zero downstream runs when the sync commits nothing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXHeUErqoiyH9xN1mjC8cH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated link checks, builds, and deployment workflows.
  * Prevented duplicate production builds and ensured pull-request checks use the correct merged content.
  * Improved screenshot test baseline recording and commit handling.

* **Documentation**
  * Updated the CI guidance and maintenance log with visual testing, caching, synchronization, and build-process details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->