### PR TITLE
docs(2607): re-weight demand lanes — warm demoted, LinkedIn primary, posting packet ready

### DIFF
--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1054,3 +1054,36 @@ nowhere); AGENTS.md lines 77-621 (the same rules concatenated verbatim).
 **Deferred (documented, not done):** the six duplicate 60.xx JD numbers in
 60-69-project-management + moving its four testing docs to 20-29 (M effort,
 inbound-link risk); .junie/ + GEMINI.md/QWEN.md mirrors (other tools' files).
+
+## 2026-08-08 — Warm lane demoted: C1 premise partially falsified, lanes re-weighted
+
+Paul: "I would not be able to provide 10 warm names." The A0 C1 pick (warm =
+primary channel) leaned on an enumeration he can't produce - exactly the risk
+the register's devil's-advocate pre-registered ("C1 assumes Paul's network
+actually contains ICP-adjacent founders"). Handled per runbook rule 7: a dated
+ADDENDUM in the register's §C, not a silent rewrite.
+
+**New lane order** (mirrored in OS Rock 1, runbook C0/C1/sprint map, strategy,
+executive summary): LinkedIn PRIMARY (agent drafts, Paul posts 3-4/wk; posting
+packet ready - his total effort is copy/paste/post) → cold #29 load-bearing
+secondary (tooling unblock back on the critical path) → inbound floor LIVE
+(verified: all 6 founder-intent posts link to /services/vibe-code-rescue/,
+shipped in yesterday's 20.09 execution) → referral-ask OPTIONAL side lane
+(2-3 past clients; a referral source need not be the ICP; nothing gates on it).
+
+**Kill-criteria re-based** everywhere it appears (register, OS §1/§3,
+portfolio, executive summary): "2 weeks of warm outreach" → "2 weeks of active
+outreach across live lanes (LinkedIn posts and/or verified sends), 0 booked
+calls → pause, re-open A + C." Clock starts at first post or first send.
+
+**Durable rules:**
+1. **When a human says they can't do the ask, the ask is dead - re-plan the
+   lane, don't shrink the ask.** The F5Bot lesson generalized: a dead ask
+   parked on the CEO's desk displaces the real unblock.
+2. **A pre-registered risk firing is the register working.** The
+   devil's-advocate note made this a 30-minute re-weight instead of a crisis -
+   record premise changes as dated addenda so the vote history stays honest.
+3. **Distinguish the ask from its cheapest satisfiable form**: "10 warm ICP
+   names" was unsatisfiable; "2-3 past-client referral asks" survives because
+   a referral source need not be the ICP. Demote, don't delete, when a weaker
+   form retains value.

--- a/docs/business/operating-system.md
+++ b/docs/business/operating-system.md
@@ -16,7 +16,7 @@ Source of truth: [`rescue-sprint/pipeline.md`](../projects/2607-vibe-code-rescue
 | 2026-08-08 | 0 | 0 | 0 (target 8-12 by Nov 30) | 0 (target 3-5) | 0 (target 1) | 2 (Aug, target ~6/mo) |
 
 **Verdict: 🔴 red.** Not "zero calls" - **zero touches have ever been sent.** Batch-1 has been HOLD since 2026-07-26 (stale rows); the Sprint-3 re-source ran 2026-08-08 and is now BLOCKED-ON-TOOLING (`operation-runbook.md` §Card #29). 18 days since Sprint 3 kicked off (2026-07-26), the bottleneck hasn't moved past sourcing.
-**Kill-check**: the C1 kill-criteria ("2 weeks of warm outreach yields 0 booked calls → pause, re-open A+C") has **not fired** - its precondition is 2 weeks of *actual* outreach, and none has gone out yet. Don't read that as safe: it means we don't even have the data the criteria needs. See Issue 2.
+**Kill-check**: the re-based C1 kill-criteria (register addendum 2026-08-08: "2 weeks of active outreach across live lanes yields 0 booked calls → pause, re-open A + C") has **not fired** - its clock starts at the first LinkedIn post or first send, and neither has happened. Don't read that as safe: it means we don't even have the data the criteria needs. See Issue 2.
 **Where sessions went this week**: mostly 2605 (course wave completion, W1-W5) and 2510 (content re-plan), plus this session's 2607 sourcing-tool diagnosis. That allocation is why a distribution failure sat unflagged for 18 days - nobody was in the pipeline sheet.
 
 ---
@@ -40,16 +40,17 @@ Source of truth: [`rescue-sprint/pipeline.md`](../projects/2607-vibe-code-rescue
 | KR3 - Audits delivered | 3-5 free Rescue Audits | 🔴 0 - blocked behind KR2 |
 | KR4 - Rescue signed | 1 by Nov 30 | 🔴 0 - blocked behind KR3 |
 
-**Kill-criteria (from the assumptions register, evaluated here weekly - this is the "runs automatically via OS-WEEKLY" promise, made real):** C1 warm-channel test - 0 calls after 2 weeks of *actual sent* outreach → pause, re-open ICP/channel. Currently **untestable**, see §1. A0 ICP test - if ≥half of early interest is technical or pre-launch founders, re-open the ICP vote. Not yet evaluable - zero interest of any kind so far.
+**Kill-criteria (from the assumptions register, evaluated here weekly - this is the "runs automatically via OS-WEEKLY" promise, made real):** C1 test (re-based 2026-08-08) - 0 calls after 2 weeks of *active outreach across live lanes* (LinkedIn posts and/or verified sends) → pause, re-open A + C. Currently **untestable** - the clock hasn't started, see §1. A0 ICP test - if ≥half of early interest is technical or pre-launch founders, re-open the ICP vote. Not yet evaluable - zero interest of any kind so far.
 
 ## 4. Rocks (open only — realigned 2026-08-08 so the lanes SUM to KR2)
 
-The arithmetic that forced the realignment: KR2 needs 8-12 calls; the cold lane at full success (10-15 verified rows, generous 20% reply-to-call) yields ~2-3. The cold lane cannot carry the KR alone — the voted-primary warm lane and LinkedIn must carry the rest, and both were idle.
+The arithmetic that forced the realignment: KR2 needs 8-12 calls; the cold lane at full success (10-15 verified rows, generous 20% reply-to-call) yields ~2-3. The cold lane cannot carry the KR alone — LinkedIn (now primary) plus inbound must carry the rest, with cold unblocked as the secondary and referral-asks as optional upside.
 
-1. **Demand flowing from three lanes** (now):
-   - **Warm (PRIMARY, per A0 C1 vote)** - blocked ONLY on Paul: ~10 names from memory into `warm-intro-referral-kit.md` (or Gmail consent for T3). No tooling needed. Fastest path to a sendable touch.
-   - **LinkedIn Stream 0** - agent drafts, Paul posts, 3-4/wk total (20.09 §7); campaign vehicle is `linkedin-icp-validation-plan.md` (paused at 3/10 drafts, revivable on Paul's go).
-   - **Cold #29 (top-up)** - still BLOCKED-ON-TOOLING (`chrome-devtools` + egress to at least one of indiehackers.com / reddit.com). Worth unblocking; not the critical path anymore.
+1. **Demand flowing from the live lanes** (re-weighted 2026-08-08 — Paul cannot enumerate 10 warm names, so the A0 C1 warm-primary premise is partially falsified; recorded as a dated addendum in the assumptions register):
+   - **LinkedIn Stream 0 (PRIMARY)** - agent drafts, Paul posts, 3-4/wk total (20.09 §7). Cheapest unblock on the board: **Paul posts ICP post #1** (`linkedin-posts/icp-validation/POSTING-PACKET.md` - copy, paste, post). Reaches his network passively without naming anyone.
+   - **Cold #29 (load-bearing again)** - BLOCKED-ON-TOOLING (`chrome-devtools` + egress to at least one of indiehackers.com / reddit.com). With warm gone this unblock is back on the critical path.
+   - **Inbound (live floor)** - 6 funnel-linked founder-intent posts → `/services/vibe-code-rescue/` + the booking link; B1 landing is the capacity-blocked amplifier.
+   - **Referral-ask (OPTIONAL side lane, not a gate)** - 2-3 past clients as referral sources via the kit templates, or T3 Gmail consent, or skip. Nothing waits on it.
 2. **Landing page** (Aug) - card B1, blocked on nothing but capacity; booking link already live standalone.
 3. **First send → first call** (Aug-Sep) - batch-1 from whichever lane opens first, then the daily reply-monitor.
 4. **First audit → first signing** (Oct) - gated on Rock 3.
@@ -62,8 +63,8 @@ The arithmetic that forced the realignment: KR2 needs 8-12 calls; the cold lane 
 
 | # | Issue | Owner | Status |
 |---|---|---|---|
-| 1 | Sourcing BLOCKED-ON-TOOLING - #29's sweep can't open any thread to verify a timestamp | Infra/Paul | 🔴 Open since 2026-08-08 - see runbook §Card #29. Demoted from sole-blocker: the warm + LinkedIn lanes don't need it (Rock 1) |
-| 2 | Kill-criteria untestable AND the primary lane never started - 18 days, zero touches sent; the voted-primary warm channel has an empty target list. The cheapest unblock on the whole board is Paul's ~10 warm names | Paul | 🔴 Open - the C1 clock starts at first send |
+| 1 | Sourcing BLOCKED-ON-TOOLING - #29's sweep can't open any thread to verify a timestamp | Infra/Paul | 🔴 Open since 2026-08-08 - see runbook §Card #29. **Load-bearing again** (2026-08-08): with the warm lane demoted, cold is the secondary demand lane and this unblock is back on the critical path |
+| 2 | Kill-criteria untestable - zero posts posted, zero touches sent. Warm lane demoted 2026-08-08 (Paul can't enumerate 10 warm names - register addendum). **The cheapest unblock is now Paul posting LinkedIn ICP post #1** (packet ready: copy, paste, post); the re-based clock starts at first post or first send | Paul | 🔴 Open |
 | 3 | Joy Adamson override - only survivor of batch-1, 5mo old, still publicly unanswered | Paul | 🟡 Open - **decide before first send** (she rides batch-1 or not at all) |
 | 4 | Pricing vs. thesis tension - JT undercuts at $7,500 against $25-55K competitors one week after publishing "cheap developers are expensive," which argues against its own thesis to a twice-shy founder. Related: the category name "vibe code rescue" is now a competitor's page title, page 1 occupied - fight for it or differentiate? | Paul | 🟡 Open - **decide both before first send** (openers and the landing quote the offer) |
 | 5 | vision-mission.md still stamped DRAFT, 18 days on, while other docs cite it as settled | Paul | 🟡 Open - 1-line decision: ship it or say what's wrong |

--- a/docs/business/opportunity-portfolio.md
+++ b/docs/business/opportunity-portfolio.md
@@ -24,7 +24,7 @@ Discipline: **one bet is Validating at a time.** Spreading the company across se
 
 | # | Opportunity | State | Project | Thesis (one line) | Kill-criteria (short) |
 |---|---|---|---|---|---|
-| 1 | **Vibe Code Rescue** | 🔵 **Validating** | [`2607-vibe-code-rescue`](../projects/2607-vibe-code-rescue/) | Funded non-technical founders will pay a fixed price to rescue a broken AI/dev-shop MVP and get ownership back. | If 2 weeks of warm outreach yields 0 booked calls → **pause and re-open A + C** (ICP *and* channel), per the [assumptions register](../projects/2607-vibe-code-rescue/rescue-sprint/assumptions-register.md) C1. **Status: untestable — zero touches have ever been sent** (see [OS §1](operating-system.md)); the clock starts at first send. |
+| 1 | **Vibe Code Rescue** | 🔵 **Validating** | [`2607-vibe-code-rescue`](../projects/2607-vibe-code-rescue/) | Funded non-technical founders will pay a fixed price to rescue a broken AI/dev-shop MVP and get ownership back. | If 2 weeks of **active outreach across live lanes** (LinkedIn posts and/or verified sends) yields 0 booked calls → **pause and re-open A + C** (ICP *and* channel), per the [assumptions register](../projects/2607-vibe-code-rescue/rescue-sprint/assumptions-register.md) C1 addendum (2026-08-08 — re-based after the warm lane was demoted). **Status: untestable — the clock starts at the first post or first send**, neither of which has happened (see [OS §1](operating-system.md)). |
 
 **Parking lot (candidates, not resourced)**: none yet. Add a row here when a new wedge earns a one-page thesis; do NOT start validating it while bet #1 is still open.
 

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
@@ -49,11 +49,14 @@ configuration the bet prohibits.
 
 | Action | Owner | Cost | Why it is P0 |
 |---|---|---|---|
-| Restore **thread-open access** for sourcing (`chrome-devtools` + egress to **at least one** of indiehackers.com / reddit.com) | Paul / infra | - | Card #29's sweep ran 2026-08-08 and returned zero rows purely on tooling: every thread-open hit `EGRESS_BLOCKED`. Qualification needs a timestamp read from the opened thread, so **no sourcing method can produce a lead until this lands.** |
+| **Post LinkedIn ICP post #1** from `linkedin-posts/icp-validation/POSTING-PACKET.md` (copy, paste, post) | Paul | ~2 min | The PRIMARY demand lane since the 2026-08-08 re-weight (warm-names premise fell). Activates the campaign and starts the kill-criteria clock. Cheapest unblock on the whole board. |
+| Restore **thread-open access** for sourcing (`chrome-devtools` + egress to **at least one** of indiehackers.com / reddit.com) | Paul / infra | - | Card #29's sweep ran 2026-08-08 and returned zero rows purely on tooling: every thread-open hit `EGRESS_BLOCKED`. Cold is the load-bearing secondary lane — no sourcing method can produce a lead until this lands. |
 | Run card **#29** - re-source prospects against the fixed v2 rubric | Agent | 1 session | Unblocks #12 and every send after it. **Gated on the row above.** |
 | Decide the **Joy Adamson override** (5mo old, still publicly unanswered) | Paul | 1 min | Only survivor of batch 1 |
 
-If a session has capacity for exactly one thing this week, it is #29 - not a post.
+✅ **DONE (verified 2026-08-08): P1 funnel links** — all six founder-intent posts now link to `/services/vibe-code-rescue/` (§3 below is executed; the inbound floor is live).
+
+If a session has capacity for exactly one thing this week, it is keeping the LinkedIn drafts flowing + #29 the moment tooling lands - not a new post.
 
 ---
 
@@ -80,7 +83,7 @@ overdue rows and the Aug 1-6 silence.
 
 ---
 
-## 3. P1 — Wire existing traffic to the offer (zero new content)
+## 3. P1 — Wire existing traffic to the offer (zero new content) — ✅ EXECUTED (verified 2026-08-08: all six posts link to the offer)
 
 **The single highest-leverage fix in the entire content operation.**
 

--- a/docs/projects/2607-vibe-code-rescue/executive-summary.md
+++ b/docs/projects/2607-vibe-code-rescue/executive-summary.md
@@ -33,7 +33,7 @@ Four independent signals, not one hopeful reading:
 
 This is a fixed-time bet, not an open-ended growth program. We are not building a pipeline machine or ranking in search. We are proving, end to end, that one motion works: a founder in pain finds us, books a free audit, and signs a fixed-price rescue. One signing produces the first case study and the confidence to scale in Q1 2027.
 
-**Circuit breaker**: if two weeks of warm outreach produce zero booked calls, we stop and re-open the ICP bet before spending another hour - the machine is wrong, not under-fed.
+**Circuit breaker** (re-based 2026-08-08, register C1 addendum): if two weeks of active outreach across the live lanes (LinkedIn posts and/or verified sends) produce zero booked calls, we stop and re-open the ICP *and* channel picks before spending another hour - the machine is wrong, not under-fed. The clock starts at the first post or first send.
 
 ## Solution
 
@@ -41,7 +41,7 @@ This is a fixed-time bet, not an open-ended growth program. We are not building 
 
 **The wedge.** Not "we fix broken code" - that lane is crowded. Ours is **ownership and trust**: you own the code and every account at each milestone, and Paul sits on every call as your fractional CTO translating what the developers are doing into decisions you can make. Trust is the product; the rebuild is how we deliver it.
 
-**How we find them.** We listen for the founder's own words of pain (the "Push" - our trigger taxonomy) in the venues where they post it, and lead with their words plus the ownership wedge, never a cold pitch. Warm intros and past-client referrals first (they convert fastest for a burned buyer); agent-sourced cold community threads (IndieHackers, Reddit, HN, X) second; Paul working the high-value manual signals on LinkedIn.
+**How we find them.** We listen for the founder's own words of pain (the "Push" - our trigger taxonomy) in the venues where they post it, and lead with their words plus the ownership wedge, never a cold pitch. LinkedIn first (Paul posting agent-drafted control-loss stories, 3-4/wk - re-weighted 2026-08-08 when the warm-names premise fell); agent-sourced cold community threads (IndieHackers, Reddit, HN, X) second; the funnel-linked blog posts and booking link as the always-on inbound floor; past-client referral asks as optional upside.
 
 **Who does what.** A white-label partner builds the rescue under the JetThoughts brand, to our quality bar. Agents do all the prep - research, sourcing, drafting, the target list, the openers, the scripts. **Paul is reserved for the calls and the close.** A runbook plus an incremental task backlog holds the state so any session can pick up and execute without losing context.
 

--- a/docs/projects/2607-vibe-code-rescue/operation-runbook.md
+++ b/docs/projects/2607-vibe-code-rescue/operation-runbook.md
@@ -31,7 +31,7 @@ critic's verdict pasted VERBATIM), and sets the next card `Ready`.
 | `t4-t5-grooming.md` | T4/T5 groomed design (3-agent brainstorm + votes: discovery, throughput, qualification) | ✓ done |
 | `voice-of-customer.md` | VoC swipe file keyed to Four Forces; stale-dropped leads still feed it (no age limit) | ✓ done — 27 quotes, all four forces PASS |
 | `offer-one-pager.md` | A2 — the Vibe Code Rescue offer (free audit → fixed rescue) | ✓ done — priced $2,500/$7,500/$10,000, live booking link |
-| `warm-intro-referral-kit.md` | C0 — target-list table + 3 outreach templates; **PRIMARY channel per A0 C1 vote** | templates done; **list EMPTY — blocked only on Paul (10 names or Gmail consent)** |
+| `warm-intro-referral-kit.md` | C0 — referral-ask templates; **OPTIONAL side lane since 2026-08-08** (warm-primary premise falsified — register C1 addendum) | templates done; 2-3 past-client referral asks if Paul wants, or T3 Gmail consent, or skip — **nothing gates on this file** |
 | `booking-page-spec.md` | S0 — NeetoCal setup spec (fulfilled; link live 2026-07-24) | ✓ done — historical record |
 | `45-minute-session-playbook.md` | D1 — the call script Paul runs on a booked Rescue Context Call | done; awaiting Paul's read-through |
 | `send-runner-prompt.md` / `reply-monitor-prompt.md` | #12 send runner (pre-research → Paul approves → send → log) / #20 daily reply monitor | ready; dormant until first sends |
@@ -69,7 +69,7 @@ These are the only items that need Paul. Everything else an agent session does a
 |---|---|---|---|
 | P1 | Create the booking page in his own Cal.com/NeetoCal account (~5 min; spec in `booking-page-spec.md`) | Needs his calendar + login | S0 gate; live URL: https://jetthoughts.neetocal.com/free-code-audit-find-out-whats-actually-broken-before-you-spend-another-dollar |
 | P2 | Confirm the price band (audit free; tiered rescue pricing) | Depends on partner margin only he knows | ✅ Done 2026-07-22 — A2 confirmed at $2,500 / $7,500 / $10,000 |
-| P3 | Review the agent-built target list + openers, then **hit send** from his own inbox/LinkedIn | The intros go out under his name/relationship | C0 send |
+| P3 | **Post LinkedIn ICP post #1** (`linkedin-posts/icp-validation/POSTING-PACKET.md` — copy, paste, post; ~2 min), then keep the 3-4/wk cadence from agent drafts. Later: review + send any verified openers from #29. Optional: 2-3 past-client referral asks from the kit | Posts and sends go out under his name/relationship | C1 activation; C0 send |
 | P4 | Take the discovery calls; run audits → proposals → close | The whole point; the human trust layer | D3 signing |
 
 If a card handoff says "waiting on Paul" for anything NOT in this table, that's a mis-scope — the agent should have done it.
@@ -96,7 +96,7 @@ These feed the C0/D1 cards without touching Paul's desk. Each is scoped to ≤1 
 | T8 | **Discovery kit** — call script + audit deliverable one-page template + 45-min agenda (Card D1 content), so Paul walks into calls with a script | `rescue-sprint/discovery-kit.md` | **Done** (2026-07-22 — 45-min agenda + SPIN/Four-Forces script + 1-page RAG scorecard/verdict template; devil's-advocate self-refute PASS, order-dependency noted) | A2 draft | HEAVY — devil's-advocate self-refute (verdict in-file §Cold-eyes) |
 | T9 | **Objection + FAQ + follow-up bank** — likely founder objections ("why not just re-hire the shop", "is $7,500 real"), answers, and a 3-touch no-reply follow-up sequence | `rescue-sprint/objection-followup-bank.md` | **Done** (T9 complete) | T8 ✓ | LIGHT — refute "does each answer hold up to a skeptical burned founder?" |
 
-**All T-tasks T1-T9 are Done except T3** (2026-08-08). T3 (warm-source pass) is the only open row — and it is now the **primary lane** per revised Rock 1: it waits only on Paul (Gmail consent, or simpler, ~10 names from memory into `warm-intro-referral-kit.md`). No grooming gate holds anything — sourcing ran and completed 2026-07-22; the Vote 3 v2 rubric governs *re-verification* (#29), not permission to run.
+**All T-tasks T1-T9 are Done except T3** (2026-08-08). T3 (warm-source pass) stays open but **OPTIONAL** — the warm-primary premise was partially falsified 2026-08-08 (Paul cannot enumerate warm ICP names; register C1 addendum). The primary lane is now **LinkedIn** (posting packet ready — Paul copies, pastes, posts); cold #29 is the load-bearing secondary (gated on the tooling unblock). No grooming gate holds anything — sourcing ran and completed 2026-07-22; the Vote 3 v2 rubric governs *re-verification* (#29), not permission to run.
 
 ---
 
@@ -175,9 +175,9 @@ These feed the C0/D1 cards without touching Paul's desk. Each is scoped to ≤1 
 - **cold-eyes gate**: HEAVY — `reflexion-critique` + devil's-advocate on price/positioning; verbatim verdict.
 - **handoff note**: _(verbatim verdict)_
 
-## CARD C0 — Paul's warm-intro + outbound target list  *(PRIMARY demand engine · human-path · counts)*
+## CARD C0 — Paul's outbound target list  *(demand engine · human-path · counts)*
 - **role**: Sales/Comms (Paul-led; agent drafts list + messages)
-- **status**: In progress (2026-08-08 — split state: the COLD lane is built but 100% unverified + blocked-on-tooling (#29); the **WARM sub-lane — the A0 C1 primary pick — has never started**: `warm-intro-referral-kit.md`'s target list is empty and waits ONLY on Paul (~10 names from memory, or Gmail consent for T3). Warm needs no tooling unblock and is the fastest path to a sendable touch.)
+- **status**: In progress (re-weighted 2026-08-08 — the warm-primary premise is partially falsified: Paul cannot enumerate warm ICP names [register C1 addendum]. The COLD lane is built but 100% unverified + blocked-on-tooling (#29, now the load-bearing sourcing path). The **WARM sub-lane is demoted to an OPTIONAL referral-ask**: 2-3 past clients via the kit templates, or T3 Gmail consent, or skip — nothing gates on it. The fastest path to a live touch is now C1: Paul posting LinkedIn #1 from the ready packet.)
 - **depends-on**: — (messages that quote price/offer wait on A2)
 - **skills**: `copywriting`, `linkedin-icp-validation-plan`
 - **inputs**: ICP `90.10`; existing network; control-loss pain phrases
@@ -275,7 +275,7 @@ These feed the C0/D1 cards without touching Paul's desk. Each is scoped to ≤1 
 
 ## Sprint map (rocks → cards, aligned with `operating-system.md` §4, 2026-08-08)
 
-- **Rock 1 (now) — demand flowing from three lanes, summing to KR2's 8-12 calls**: **C0 warm** (PRIMARY — Paul's ~10 names, no tooling needed) · **C1 LinkedIn** (drafts-only; Paul posts) · **#29 cold** (top-up; blocked-on-tooling). The cold lane alone maxes at ~2-3 calls — it cannot carry the KR.
+- **Rock 1 (now) — demand flowing from the live lanes, summing to KR2's 8-12 calls** (re-weighted 2026-08-08): **C1 LinkedIn** (PRIMARY — packet ready, Paul copies/pastes/posts) · **#29 cold** (load-bearing secondary; blocked-on-tooling) · **inbound floor** (6 funnel-linked posts + booking link, live) · **C0 referral-ask** (optional, 2-3 past clients, nothing gates on it). The cold lane alone maxes at ~2-3 calls — it cannot carry the KR.
 - **Rock 2 (Aug) landing**: B1 (after A2/S0 — both Done, so B1 is capacity-blocked only).
 - **Rock 3 (Aug→Sep) first send → first call**: #12 batch-1 (any lane that opens), then #20 reply-monitor; C2 stays support-only.
 - **Rock 4 (Oct) convert**: D3 with D1's kit, then B2 from the first real engagement.

--- a/docs/projects/2607-vibe-code-rescue/rescue-sprint/assumptions-register.md
+++ b/docs/projects/2607-vibe-code-rescue/rescue-sprint/assumptions-register.md
@@ -66,7 +66,16 @@
 | C4 inbound SEO | 1 | 4 | 3 | 5 | 18 |
 
 **Pick: C1 primary (warm + referral), C2 secondary (agent-sourced cold community).** **Rationale**: warm converts fastest and carries the trust the burned ICP demands; C2 is the agent-unattended top-up that doesn't wait on Paul. C3 (paid) is a deliberate *later* upgrade once a channel proves reply interest (runbook rule 3). C4 (SEO) cannot rank by Nov 30 — Q1-2027 compounding only.
-**Pre-validation test**: warm channel must produce ≥3 booked calls before we invest setup time in C3. **Kill-criteria**: if 2 weeks of warm outreach yields 0 booked calls, the ICP-to-network fit is wrong — pause and re-open A + C before spending on paid.
+
+> **ADDENDUM 2026-08-08 — C1 premise partially falsified; channel re-weight.** Paul: "I would not be able to provide 10 warm names." This confirms the pre-registered risk below (§Devil's-advocate: "C1 assumes Paul's network actually contains ICP-adjacent founders. If it doesn't... C1's speed advantage evaporates"). Re-weight, recorded per runbook rule 7:
+> - **Primary → LinkedIn** (Stream 0, agent drafts / Paul posts, 3-4/wk per 20.09 §7): days-scale feedback, reaches Paul's network passively without requiring him to enumerate anyone, drafts already exist.
+> - **Secondary → C2 cold community** (#29): re-promoted to load-bearing; its tooling unblock (thread-open access) returns to the critical path.
+> - **Live inbound floor**: 6 funnel-linked founder-intent posts → `/services/vibe-code-rescue/` + live booking link (verified 2026-08-08).
+> - **Warm demoted to an OPTIONAL referral-ask side lane**: 2-3 *past clients* as referral sources (a referral source need not be the ICP; JT has 32 clients at ~95% retention), or T3 Gmail consent, or skip. **Nothing gates on it.**
+>
+> **Kill-criteria (re-based, replaces the warm-only wording)**: if **2 weeks of active outreach across whatever lanes are live** (LinkedIn posts and/or verified sends) yields **0 booked calls**, pause and re-open A + C before spending on paid. The clock starts at the first post or first send, whichever lands first.
+
+**Pre-validation test**: the live lanes must produce ≥3 booked calls before we invest setup time in C3. **Kill-criteria**: see the 2026-08-08 addendum above — the original "2 weeks of warm outreach" wording is superseded (the warm lane may never run).
 
 ---
 

--- a/docs/projects/2607-vibe-code-rescue/rescue-sprint/warm-intro-referral-kit.md
+++ b/docs/projects/2607-vibe-code-rescue/rescue-sprint/warm-intro-referral-kit.md
@@ -1,37 +1,31 @@
-> 🔴 **PRIMARY CHANNEL (A0 C1 vote) — BLOCKED ONLY ON PAUL.** The warm lane needs no tooling unblock, no 30-day verification, no egress: it needs **~10 real names in the table below** (from memory, or via T3 Gmail consent). It is the fastest path from today to a sendable touch, and the kill-criteria clock cannot even start until it runs. Templates below are done and cold-eyes-fixed; booking link live.
+> ⚪ **OPTIONAL REFERRAL-ASK SIDE LANE (since 2026-08-08 — nothing gates on this file).** The original "warm = primary, fill in ~10 names" framing is dead: Paul cannot enumerate warm ICP names (register C1 addendum; the pre-registered devil's-advocate risk confirmed). What survives is the lower-bar version: **a referral source doesn't need to BE the ICP** — 2-3 *past clients* (JT: 32 clients, ~95% retention) forwarding the blurb to one struggling founder each is upside, not a requirement. Use the templates below if/when Paul wants; T3 Gmail consent is the other optional route; skipping entirely is fine. The demand plan runs on LinkedIn + cold + inbound regardless.
 
 # Warm-Intro + Referral Kit (Card C0)
 
-**Owner**: Paul Keen | **Card**: C0 (PRIMARY demand engine — warm sub-lane, Rock 1)
+**Owner**: Paul Keen | **Card**: C0 (optional referral-ask sub-lane)
 **Goal**: Paul sends trusted intro + referral asks THIS WEEK so founders with broken MVPs book the Free Rescue Context Call.
 **Offer these messages point to**: a free 45-minute Rescue Context Call - after the call our team runs an AI-assisted Rescue Audit on the founder's codebase, task board, and dev chats and sends back a one-page, plain-English scorecard. No pitch, no contract.
 **Where the calls land**: the live S0 booking link.
 
 ---
 
-## How to use this kit
+## How to use this kit (if at all)
 
-1. Fill in the target list below with real names. The seeded rows are categories to jog your memory, not real people - overwrite them.
-2. Pick the right template per contact: a past client gets the **referral ask**; a network contact gets the **warm-intro request** plus the **forwardable blurb**.
-3. Swap every `[SQUARE-BRACKET]` slot.
-4. Log who you contacted and their reply in the Status column so the pipeline sheet stays honest.
+1. Optional: pick 2-3 **past clients** for a referral ask - people who'd forward the blurb to one struggling founder. That's the whole ask; no target-list homework.
+2. Template per contact: a past client gets the **referral ask**; anyone else gets the **warm-intro request** plus the **forwardable blurb**.
+3. Swap every `[SQUARE-BRACKET]` slot; log any send in `pipeline.md`.
 
 ---
 
-## 1. Target list template
+## 1. Referral-ask shortlist (optional - 2-3 rows max, past clients first)
 
-Fill one row per person. Warm intros and past clients come first - they convert fastest. Add cold outbound only after you have worked the warm rows.
+*(The original 8-category "fill ~10 names" template was removed 2026-08-08 with the warm-primary premise - it demanded an enumeration Paul said he can't provide. The three highest-yield categories survive as prompts; ignore any that don't map to a real person.)*
 
-| Name | Relationship to Paul | Their company / role | Why they're near the ICP | Best intro path | Last touch | Status |
-|---|---|---|---|---|---|---|
-| _`<fill in>` - past client who referred before_ | Worked with us 3+ years; already sent us work | e.g. SaaS founder, still running the product we built | A happy past client who already refers us - founders trust a referral from a founder we delivered for | Direct email, reference the project | | Not started |
-| _`<fill in>` - investor / angel_ | Backed us or co-invested; you talk quarterly | Angel / seed fund partner | Sees broken MVPs across the whole portfolio; can forward to a struggling founder | Direct DM, offer the audit as a portfolio favor | | Not started |
-| _`<fill in>` - accelerator / program contact_ | Ran a batch you spoke at or mentored | Program director / partner | A cohort of early founders, several shipping shaky AI-built MVPs | Email the program lead, ask to share with the batch | | Not started |
-| _`<fill in>` - founder friend on a cheap dev shop_ | Personal friend, non-technical, building now | Founder, 1-20 people | IS the ICP - hired an offshore team or freelancer and cannot tell if it's working | Text / call directly, no forwarding needed | Not started |
-| _`<fill in>` - no-code / vibe-coding community peer_ | Met in a Lovable / Cursor / Bolt community | Solo or small-team founder shipping with AI tools | Built the whole app with an AI tool; real users are starting to break it | DM in the community, then move to email | Not started |
-| _`<fill in>` - ex-colleague now at a startup_ | Worked together years ago; stayed in touch | Operator / product lead at a funded startup | Sits next to the dev team; feels the progress-mirage pain daily | LinkedIn message or email | Not started |
-| _`<fill in>` - agency / fractional peer who turns down rescue work_ | Peer in the services world | Runs a design shop or a small agency | Gets rescue requests they can't take; a natural referral source | Email, offer a reciprocal referral | Not started |
-| _`<fill in>` - founder who already DM'd about a broken build_ | Reached out cold or in a thread | Founder mid-crisis | Told you directly the app is breaking - warmest lead in the list | Reply to their thread, offer the audit | Not started |
+| Name | Category prompt | Best path | Status |
+|---|---|---|---|
+| | Past client who already referred us once | Direct email, reference the project | |
+| | Investor/angel who sees broken portfolio MVPs | DM, offer the audit as a portfolio favor | |
+| | Agency/fractional peer who turns down rescue work | Email, offer a reciprocal referral | |
 
 ---
 

--- a/docs/projects/2607-vibe-code-rescue/strategy.md
+++ b/docs/projects/2607-vibe-code-rescue/strategy.md
@@ -53,10 +53,13 @@ end to end and produces the first case study.
    delivers; Paul owns the relationship. This is the conversion engine.
 2. **Landing page -> booking machine** - rescue positioning already live (PR #385); add the
    offer, case-study proof, one "Book a Rescue Audit" CTA.
-3. **Demand-gen, three lanes summing to the KR** (revised 2026-08-08) - warm intros
-   (PRIMARY per A0 C1) + LinkedIn (agent drafts, Paul posts, 3-4x/wk total) + cold community
-   re-source as top-up. Content is support-only (20.09 pipeline-first); the SEO cluster and
-   paid pilot are cut/archived - paid waits on an organic reply signal.
+3. **Demand-gen, lanes summing to the KR** (re-weighted 2026-08-08 after the warm-primary
+   premise was partially falsified - Paul cannot enumerate warm ICP names; register addendum) -
+   **LinkedIn primary** (agent drafts, Paul posts, 3-4x/wk total) + cold community re-source
+   (load-bearing secondary, gated on the tooling unblock) + live inbound (6 funnel-linked posts
+   + booking link) + optional past-client referral asks. Content is support-only (20.09
+   pipeline-first); the SEO cluster and paid pilot are cut/archived - paid waits on an organic
+   reply signal.
 4. **Lead magnets** - audit scorecard, GitHub/AWS ownership checklist, salvage-vs-rebuild
    decision tree -> email capture -> audit CTA.
 
@@ -64,7 +67,7 @@ end to end and produces the first case study.
 
 | Window | Focus | Client-getting milestone |
 |---|---|---|
-| **Aug** | Build the machine + open the lanes | Offer + price defined ✓ (2026-07-22); partner locked ✓ (2026-07-21); warm list populated (Paul's ~10 names) + first sends; LinkedIn drafts flowing at 3-4/wk total; landing CTA live |
+| **Aug** | Build the machine + open the lanes | Offer + price defined ✓ (2026-07-22); partner locked ✓ (2026-07-21); LinkedIn posting live (Paul posts #1 from the ready packet, then 3-4/wk); cold tooling unblocked → #29 re-source; landing CTA live; optional: 2-3 past-client referral asks |
 | **Sep** | Fill the funnel | All three lanes active; **Sep 30 gate: ≥3 discovery calls booked, else pause and re-open A + C**; sales-enablement artifacts only as calls need them |
 | **Oct** | Convert | Deliver first audits -> rescue proposals; first signing; publish our own rescue case study |
 | **Nov** | Compound | Referral + case-study loop; Q1 2027 pipeline full |

--- a/docs/workflows/linkedin-icp-validation-plan.md
+++ b/docs/workflows/linkedin-icp-validation-plan.md
@@ -1,6 +1,6 @@
 # LinkedIn ICP-E Validation Plan
 
-> **Status: PAUSED 2026-08-08** — 3 of 10 posts drafted, zero posted, zero data collected; the 2-week window never started. This plan is the **vehicle for the LinkedIn demand lane** in OS Rock 1 (agent drafts → Paul posts) and revives on Paul's go. When live, cadence fits inside 20.09 §7's **Stream 0 total of 3-4 posts/week** (shared with course-promo) — not the original 5/week. The hypotheses, hooks, and reply-keyword CTAs below remain the campaign design of record.
+> **Status: READY TO ACTIVATE (2026-08-08)** — 3 of 10 posts drafted, zero posted; the 2-week window starts when **Paul posts #1 from [`linkedin-posts/icp-validation/POSTING-PACKET.md`](../../linkedin-posts/icp-validation/POSTING-PACKET.md)** (copy, paste, post — nothing else). This campaign is now the **PRIMARY demand lane** (OS Rock 1, re-weighted 2026-08-08 after the warm-names premise fell). When live, cadence fits inside 20.09 §7's **Stream 0 total of 3-4 posts/week** (shared with course-promo) — not the original 5/week. The hypotheses, hooks, and reply-keyword CTAs below remain the campaign design of record.
 
 **Purpose:** Validate whether LinkedIn can surface and qualify ICP-E: non-technical founders who feel stuck with a dev shop, freelancer, offshore team, or AI-heavy build they cannot evaluate.
 **Window:** 2 weeks from first post (clock starts when Paul posts #1)

--- a/linkedin-posts/icp-validation/POSTING-PACKET.md
+++ b/linkedin-posts/icp-validation/POSTING-PACKET.md
@@ -1,0 +1,25 @@
+# Posting Packet — ICP post #1 (ready to publish)
+
+**For Paul. Total effort: copy the text block below, paste into LinkedIn, post.** Nothing else. This activates the campaign and starts the kill-criteria clock (register C1 addendum, 2026-08-08).
+
+Source draft: `week1-mon-jira-not-progress.md` — quoted **verbatim** below; it passed 5 documented critic passes including Paul's own 2026-05-11 corrections (cinematic beat-marking removed). Do not edit before posting; if you want changes, say so and the revision goes back through `reflexion-reflect` first.
+
+## The post (copy from the line below to the hashtags, inclusive)
+
+A founder pinged me last Tuesday wanting to know what her team had actually shipped that sprint. 14 tickets closed, standup that morning clean - and she still couldn't name one thing they'd built that she'd go and use.
+
+So I asked her when she'd last opened the product herself. She had to think about it, then said she couldn't remember - her dev shop had been on retainer since January and she hadn't clicked through anything they'd shipped.
+
+So she pulled it up while we were on the call. She didn't recognize half of what she was clicking through, and when I asked her to find one of those 14 closed tickets on screen, she couldn't point to any.
+
+Before we hung up she said she'd try one thing this Friday. Instead of asking her dev shop how the sprint went, she'd ask for a URL where the week's work was actually visible, and use it herself for ten minutes.
+
+Anyone else been in this version of it?
+
+#founders #startups #productmanagement
+
+## After posting (3 lines)
+
+1. Tell the assistant (or note it anywhere written) — the post date starts the 2-week kill-criteria clock and the weekly tally in `docs/projects/2607-vibe-code-rescue/rescue-sprint/pipeline.md`.
+2. Replies with a concrete symptom (their own version of the story) = qualified — the agent drafts responses; you send. No pitching in-thread; route real conversations to DM, then the booking link.
+3. Next drafts arrive at the 3-4/wk Stream 0 cadence (`week1-tue`, `week1-wed` are already written; the agent drafts onward as you post).


### PR DESCRIPTION
## Why

Paul: *"I would not be able to provide 10 warm names."* That partially falsifies the A0 C1 premise (warm = primary channel) — the exact risk the register's own devil's-advocate pre-registered ("C1 assumes Paul's network actually contains ICP-adjacent founders. If it doesn't... C1's speed advantage evaporates"). Per runbook rule 7, the premise change is recorded as a **dated addendum in the assumptions register**, not a silent rewrite — and then propagated to every surface that carried the warm-primary claim, because twelve agreeing copies never stopped two disagreeing ones.

## The re-weighted lane order (must still sum to KR2's 8-12 calls)

1. **LinkedIn Stream 0 — PRIMARY.** Agent drafts, Paul posts, 3-4/wk. New **`linkedin-posts/icp-validation/POSTING-PACKET.md`**: post #1 verbatim from the 5×-critic-passed `week1-mon` draft (zero new prose — no voice-gate re-run needed) plus a 3-line after-posting note. Paul's total activation effort: **copy, paste, post.**
2. **Cold #29 — re-promoted to load-bearing secondary.** The tooling unblock (`chrome-devtools` + egress to one of IH/Reddit) returns to the critical path.
3. **Inbound floor — LIVE.** Verified in-content: all 6 founder-intent posts link to `/services/vibe-code-rescue/` (shipped in the Aug-8 20.09 execution). 20.09 §P1 stamped EXECUTED; the P0 table updated with the new priority order.
4. **Referral-ask — OPTIONAL side lane, nothing gates on it.** The kit reframed: 2-3 *past clients* (a referral source need not BE the ICP; JT has 32 clients at ~95% retention), or T3 Gmail consent, or skip. The 8-category "fill ~10 names" template collapsed to a 3-row prompt list.

## Kill-criteria re-based (all four carriers: register, OS, portfolio, executive summary)

"2 weeks of warm outreach" → **"2 weeks of active outreach across live lanes (LinkedIn posts and/or verified sends), 0 booked calls → pause and re-open A + C."** The clock starts at the first post or first send.

The dead "10 warm names" ask is struck from Paul's desk — the F5Bot lesson applied: a dead ask parked on the CEO's desk displaces the real unblock. The cheapest unblock on the board is now **Paul posting #1**.

## Gates

Docs-only (the posting packet lives in `linkedin-posts/`, outside Hugo's content tree). Course validators 8/8 green. Greps confirm: zero live "10 names" asks; the re-based kill wording present in all four carrier files; zero surviving warm-PRIMARY claims. `.okf/log.md` carries the three durable rules (dead asks get re-planned not shrunk; a pre-registered risk firing is the register working; demote to the cheapest satisfiable form rather than delete).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtDh9gdEPMZjaFKauRaRRs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ready-to-publish LinkedIn posting packet with publishing guidance and follow-up steps.
* **Documentation**
  * Rebalanced the outreach strategy to prioritize LinkedIn, with cold outreach secondary, inbound active, and referrals optional.
  * Updated validation criteria to measure two weeks of active outreach across available channels.
  * Clarified campaign activation timing, prerequisites, responsibilities, and revised demand-generation priorities.
  * Simplified referral planning with an optional shortlist of up to three contacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->