### PR TITLE
Backlog tail: hire-decision conversion, 18 reading lists to cap, all >=700-char bricks

### DIFF
--- a/content/course/tech-for-non-technical-founders-2026/agency-ai-five-questions/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/agency-ai-five-questions/index.md
@@ -30,7 +30,13 @@ Five questions that catch AI theatre in 30 minutes - hand them to your next agen
 
 By the end of one Tuesday discovery call you will know whether the agency claiming "we use AI to ship 3x faster" can describe what their developers do with Cursor on a Wednesday morning, or whether the AI talk is a slide. Five questions, sent in writing 24 hours before the call, scored 0 or 1 in real time. Three failed questions is a walkaway.
 
-Two failures hide behind the "AI-native" pitch, and both cost real money. The first is where the AI-written code lands. An agency moving fast with Cursor commits secrets straight into the repo - an OpenAI API key, a Stripe live key, a database password sitting in plaintext at line 14 of `config/database.yml`, on a GitHub repo that defaults to public. The second is the token bill. An agency that never priced its own AI usage runs up charges it cannot attribute - **$4,800 of OpenAI spend in 30 days** with no project tags and no per-developer breakdown, quietly passed through on top of the $34K four-week MVP. The five questions below surface both inside the first 20 minutes of a discovery call, before you sign.
+Two failures hide behind the "AI-native" pitch, and both cost real money.
+
+**Where the AI-written code lands.** An agency moving fast with Cursor commits secrets straight into the repo - an OpenAI API key, a Stripe live key, a database password sitting in plaintext at line 14 of `config/database.yml`, on a GitHub repo that defaults to public.
+
+**The token bill.** An agency that never priced its own AI usage runs up charges it cannot attribute - **$4,800 of OpenAI spend in 30 days** with no project tags and no per-developer breakdown, quietly passed through on top of the $34K four-week MVP.
+
+The five questions below surface both inside the first 20 minutes of a discovery call, before you sign.
 
 Most agencies in 2026 are not malicious about AI. They adopted Cursor in a hurry, never wrote down a workflow, and never priced the token bill. The damage is the same either way.
 

--- a/content/course/tech-for-non-technical-founders-2026/agency-uses-ai-follow-up-questions/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/agency-uses-ai-follow-up-questions/index.md
@@ -173,11 +173,8 @@ Three concrete moves for the next 24 hours, in order.
 
 - Veracode, [2025 GenAI Code Security Report](https://www.veracode.com/blog/genai-code-security-report/) - 45% of tested LLM-generated code samples carried at least one exploitable security flaw. The data behind Q3 (verification) and Q5 (accountability).
 - Stack Overflow, [2025 Developer Survey - AI section](https://survey.stackoverflow.co/2025/) - 84% of developers now use or plan to use AI tools. The market context behind why "we use AI" became a meaningless homepage line.
-- Infosecurity Magazine, [AI Hallucinations Open New Slopsquatting Attack Vector](https://www.infosecurity-magazine.com/news/ai-hallucinations-slopsquatting/) - the slopsquatting attack vector in plain English. The thing your agency must spot in PR review (Q4).
 - SecurityWeek, [AI Coding Agents Could Fuel Next Supply Chain Crisis](https://www.securityweek.com/ai-coding-agents-could-fuel-next-supply-chain-crisis/) - the practitioner read on why hallucinated package names are now the leading AI-era attack surface.
 - Linus Torvalds, ["Assisted-by:" tag on Linux kernel commits](https://lore.kernel.org/lkml/CAHk-=wjbiaa7m9aGtw2T-fbmuuiq_-noqfrjEJzbpCSk0FrFkw@mail.gmail.com/) - the kernel rule that puts a human reviewer's name in the commit log when AI is in the loop. The accountability standard referenced in Q3 and Q5.
-- Anthropic, [Claude Code documentation](https://docs.claude.com/en/docs/claude-code/overview) - the official reference for one of the tools your agency should be naming in Q1. Worth skimming so you recognise the workflow language when they describe it.
-- DHH, [The One-Person Framework](https://world.hey.com/dhh/the-one-person-framework-711e6318) - the Rails case for keeping the architecture small enough that one engineer can review every diff, including the AI-generated ones. The framework filter to apply before the agency search.
 
 ---
 

--- a/content/course/tech-for-non-technical-founders-2026/ai-persona-pre-validation-mom-test-prep/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/ai-persona-pre-validation-mom-test-prep/index.md
@@ -86,7 +86,7 @@ Build 3 distinct personas before you start - not 3 variations of the same person
 
 ## Run the rehearsal
 
-Once the persona is set, run your draft questions through four follow-up prompts (the full text of each is in the [persona-rehearsal reference](/course/tech-for-non-technical-founders-2026/reference/persona-rehearsal-full/)):
+Once the persona is set, run your draft questions through four follow-up prompts. Open the [persona-rehearsal reference](/course/tech-for-non-technical-founders-2026/reference/persona-rehearsal-full/) beside this page - it carries the verbatim text of Prompts 2-5, so you paste rather than retype. Here is what each one is for:
 
 1. **Prompt 2 - Ask** each draft question in-character. The persona answers as a busy professional would.
 2. **Prompt 3 - Diagnose:** tell Claude to break character and assess whether that question would produce useful data on a real call. Read the diagnosis, not the polite in-character answer - Claude is trained to be helpful, so a coherent answer is not proof the question works.

--- a/content/course/tech-for-non-technical-founders-2026/ai-token-bill-dev-shop-pass-through-cost/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/ai-token-bill-dev-shop-pass-through-cost/index.md
@@ -156,10 +156,6 @@ Three actions. In order.
 
 ## Further reading
 
-- [Anthropic API pricing](https://www.anthropic.com/pricing) - the canonical Sonnet, Opus, and Haiku per-million-token rates. Read the input vs output split; it is where most invoice surprises live.
-- [OpenAI API pricing](https://openai.com/api/pricing/) - the gpt-4o, o3, and o1 per-token rates. Note the cached input rates if your team uses prompt caching aggressively.
-- [Cursor pricing](https://cursor.com/pricing) - Pro, Business, and Ultra tiers. Business is the modal agency choice in 2026.
-- [GitHub Copilot pricing](https://github.com/features/copilot/plans) - Individual, Business, Enterprise. The fallback for teams that have not switched to Claude Code.
 - The Pragmatic Engineer, [Software engineering with LLMs in 2025: reality check](https://newsletter.pragmaticengineer.com/p/software-engineering-with-llms-in-2025) - per-developer spend ranges from a survey of senior engineers, useful for sanity-checking the numbers above.
 - Simon Willison, [LLM pricing calculator](https://simonwillison.net/2025/Apr/10/llm-pricing-calculator/) - running cost comparison across models with public token-cost ranges.
 - Latent Space, [The Rise of the AI Engineer](https://www.latent.space/p/ai-engineer) - which model and tool combinations large engineering orgs settle on, with cost commentary.

--- a/content/course/tech-for-non-technical-founders-2026/customers-leaving-churn-triage-not-acquisition/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/customers-leaving-churn-triage-not-acquisition/index.md
@@ -194,8 +194,6 @@ You walk out of this chapter holding one of three artifacts: a fix-the-product p
 - Lenny Rachitsky, [How to know if you've got product-market fit](https://www.lennysnewsletter.com/p/how-to-know-if-youve-got-productmarket) - the Sean Ellis must-have-user framing the segment slice in this chapter operationalizes.
 - ProfitWell / Paddle, [How to calculate and reduce revenue churn](https://www.paddle.com/resources/revenue-churn) - the unit-economics math that explains why refunds beat churn for wrong-segment customers.
 - Rahul Vohra, [How Superhuman built an engine to find product-market fit](https://review.firstround.com/how-superhuman-built-an-engine-to-find-product-market-fit/) - segment-isolation playbook layered on top of the 40% test.
-- Lenny Rachitsky, [What is good retention](https://www.lennysnewsletter.com/p/what-is-good-retention-issue-29) - the B2B SaaS retention floors used in the 90-minute cohort questions.
-- Steve Blank, [The Customer Development Manifesto](https://steveblank.com/2009/08/31/the-customer-development-manifesto-reasons-for-the-revolution-part-1/) - the foundational framing for "fire the wrong customer before adding more."
 
 ---
 

--- a/content/course/tech-for-non-technical-founders-2026/first-paying-customer-operating-kit/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/first-paying-customer-operating-kit/index.md
@@ -127,7 +127,13 @@ The kit runs Monday-to-Friday for the four weeks of Module 5. The sequence:
 
 By Friday of week 4, you should have: a segment-isolated persona doc, 50 sent messages with 30+% reply rate, 1-2 signed paid pilots, and 30 cold-outbound prospects with 3-5 booked demos for week 5.
 
-One boundary before you start: the kit is not a substitute for a sales course or a CRM. It will not teach the conversational mechanics of objection-handling, so if you have never run a customer call, read [the Mom Test interview script](/course/tech-for-non-technical-founders-2026/mom-test-interview-script/) and run 10 user calls first. It will not track touch counts past the first 30 customers the way HubSpot, Pipedrive, or Salesforce does - past 30, the Sheet breaks and you graduate to a real CRM. It also does not replace the must-have-segment test from [Lesson 5.1](/course/tech-for-non-technical-founders-2026/must-have-segment-pmf-test/) - if your overall must-have % from component 5 is under 25%, your pipeline will fill, the demos will go fine, and conversions will stall at the deposit conversation. Run the 40% test first; work the kit second.
+One boundary before you start: the kit is not a substitute for a sales course or a CRM. Three things it will not do:
+
+- **Teach the conversational mechanics of objection-handling.** Never run a customer call? Read [the Mom Test interview script](/course/tech-for-non-technical-founders-2026/mom-test-interview-script/) and run 10 user calls first.
+- **Track touch counts past your first 30 customers** the way HubSpot, Pipedrive, or Salesforce does. Past 30, the Sheet breaks and you graduate to a real CRM.
+- **Replace the must-have-segment test** from [Lesson 5.1](/course/tech-for-non-technical-founders-2026/must-have-segment-pmf-test/). If your overall must-have % is under 25%, your pipeline will fill, the demos will go fine, and conversions will stall at the deposit conversation.
+
+Run the 40% test first; work the kit second.
 
 ---
 

--- a/content/course/tech-for-non-technical-founders-2026/five-tech-words-stop-nodding-at/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/five-tech-words-stop-nodding-at/index.md
@@ -164,9 +164,6 @@ If your team's vocabulary makes you nervous, the next layer of the diagnostic is
 - Ward Cunningham via Martin Fowler, [Technical Debt](https://martinfowler.com/bliki/TechnicalDebt.html) - the original 1992 metaphor.
 - Eric Ries via Lean Startup Co., [What Is an MVP?](https://leanstartup.co/resources/articles/what-is-an-mvp/) - the validated-learning framing.
 - Docker, [What Is a Container Image?](https://docs.docker.com/get-started/docker-concepts/the-basics/what-is-an-image/) - the official docs definition.
-- DHH, [The One Person Framework](https://world.hey.com/dhh/the-one-person-framework-711e6318) - the Rails case for keeping the architecture small.
-- Veracode, [GenAI Code Security Report 2025](https://www.veracode.com/blog/genai-code-security-report/) - 45% of LLM-generated code shipped at least one exploitable flaw.
-- LitsLink, [Cost of Outsourcing Software Development](https://litslink.com/blog/cost-of-outsourcing-software-development) - 42% of developer time goes to technical debt.
 
 ---
 

--- a/content/course/tech-for-non-technical-founders-2026/five-tech-words-stop-nodding-at/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/five-tech-words-stop-nodding-at/index.md
@@ -79,7 +79,13 @@ Code you shipped fast knowing you would have to come back and fix it. Ward Cunni
 
 > **🔍 BS-detection question:** *"Which specific feature on next quarter's roadmap will be cheaper to ship after this debt is paid down, and by roughly how much?"* Real tech debt has a payoff number attached to a named feature. "It will help with everything" means nobody has measured anything yet.
 
-In Rails terms, healthy tech debt sounds specific: "extracting a `Billing::PlanCalculator` class out of `User` unblocks metered billing in Q3." Unhealthy tech debt sounds like "there is a lot of legacy in this codebase" - a feeling the team is asking you to fund. [LitsLink reports developers spend 42% of their time on technical debt and maintenance](https://litslink.com/blog/cost-of-outsourcing-software-development); the founders we work with rarely see that line on an invoice. They see features taking twice as long as last quarter for no reason anyone can name. JT's [60-day playbook for slow engineering teams](/blog/fixing-slow-engineering-teams-an-extended/) starts by making that line visible.
+In Rails terms:
+
+> **Healthy tech debt** sounds specific: "extracting a `Billing::PlanCalculator` class out of `User` unblocks metered billing in Q3."
+>
+> **Unhealthy tech debt** sounds like "there is a lot of legacy in this codebase" - a feeling the team is asking you to fund.
+
+[LitsLink reports developers spend 42% of their time on technical debt and maintenance](https://litslink.com/blog/cost-of-outsourcing-software-development), and the founders we work with rarely see that line on an invoice. They see features taking twice as long as last quarter for no reason anyone can name. JT's [60-day playbook for slow engineering teams](/blog/fixing-slow-engineering-teams-an-extended/) starts by making that line visible.
 
 ### 🚀 4. MVP
 

--- a/content/course/tech-for-non-technical-founders-2026/hire-track-supplementary-reference/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/hire-track-supplementary-reference/index.md
@@ -103,7 +103,13 @@ You are not picking the stack alone - your Fractional CTO or hired engineer make
 
 ### Default: Rails (Ruby on Rails)
 
-Rails is the JetThoughts default and the Indie Hackers / DHH / Pieter Levels community standard. The reasoning is empirical, not religious: Rails ships fast, one engineer can operate the full stack end-to-end, the conventions are tight enough that the next engineer you hire reads the codebase in a day, and the deployment story (Heroku, Fly.io, Render) costs $7-$50/month at pre-seed scale. Basecamp ([DHH's *One-Person Framework* essay](https://world.hey.com/dhh/the-one-person-framework-711e6318)) is the case study: two decades of products on a Rails monolith run by a famously small team, and Shopify serves millions of merchants on one Rails monolith. At your scale (47-5,000 paying users) one Rails engineer can ship + operate the whole thing.
+Rails is the JetThoughts default and the Indie Hackers / DHH / Pieter Levels community standard. The reasoning is empirical, not religious:
+
+- Rails ships fast, and one engineer can operate the full stack end-to-end.
+- The conventions are tight enough that the next engineer you hire reads the codebase in a day.
+- Deployment (Heroku, Fly.io, Render) costs $7-$50/month at pre-seed scale.
+
+Basecamp ([DHH's *One-Person Framework* essay](https://world.hey.com/dhh/the-one-person-framework-711e6318)) is the case study - two decades of products on a Rails monolith run by a famously small team - and Shopify serves millions of merchants on one Rails monolith. At your scale (47-5,000 paying users) one Rails engineer can ship and operate the whole thing.
 
 **Why Rails wins for the non-technical founder's hired team:** the hire pool is deep (15+ years of Rails engineers), the framework opinions are tight (less time arguing about conventions, more time shipping), background jobs / email / file uploads / authentication / payment / admin / search are all batteries-included rather than 12 separate npm packages, and the Rails community produced the rescue patterns we see work in production (Pundit for authorization, Devise for auth, Sidekiq for jobs, ActiveAdmin for staff tools).
 

--- a/content/course/tech-for-non-technical-founders-2026/mom-test-synthesis-build-pivot-kill/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/mom-test-synthesis-build-pivot-kill/index.md
@@ -45,7 +45,15 @@ After 10 interviews you have scored transcripts in a folder and a number. Synthe
 
 Ninety minutes alone with the 10 transcripts, a printed template, and the willingness to write down a number that might be a 3.
 
-**Step 1 - Score each interview 1-10.** Combine your handwritten Q4 score and your emotional-flag count from the [Lesson 2.1 script](/course/tech-for-non-technical-founders-2026/mom-test-ask-about-past-not-future/) into one number. A **7+** means a Q4 of 7 or higher backed by a comparison (a polite-default 7 with no comparison rounds down to 5), plus at least 3 emotional-language flags across the five answers. A **4-6** is partial signal - a real story but a weak workaround. **Below 4** is polite-yes mode: vague answers, "nothing yet" on past attempts, a hedged Q4 under 7. Write the number on each transcript within 5 minutes of hanging up - it's more honest than the one you'd write after a week of wanting it higher.
+**Step 1 - Score each interview 1-10.** Combine your handwritten Q4 score and your emotional-flag count from the [Lesson 2.1 script](/course/tech-for-non-technical-founders-2026/mom-test-ask-about-past-not-future/) into one number.
+
+| Score | What it takes |
+|---|---|
+| **7+** | A Q4 of 7 or higher backed by a comparison (a polite-default 7 with no comparison rounds down to 5), plus at least 3 emotional-language flags across the five answers |
+| **4-6** | Partial signal - a real story but a weak workaround |
+| **Below 4** | Polite-yes mode: vague answers, "nothing yet" on past attempts, a hedged Q4 under 7 |
+
+Write the number on each transcript within 5 minutes of hanging up. It's more honest than the one you'd write after a week of wanting it higher.
 
 **Step 2 - Count the strong signals.** List the 10 scores in a column and circle every 7 or higher. That circled count routes your decision. The pattern beats the average: eight 7+ and two 3s is a shared problem; three 9s and seven 4s is the dangerous one - you talked to your three best friends and seven strangers told you the truth.
 

--- a/content/course/tech-for-non-technical-founders-2026/pivot-or-persevere-decision-framework/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/pivot-or-persevere-decision-framework/index.md
@@ -161,8 +161,6 @@ D. is on his third pivot now: the original hypothesis (audit prep), then month-e
 ## Further reading
 
 - Eric Ries, [*The Lean Startup*](https://theleanstartup.com/) - the canonical text on pivots, including all ten pivot types and the discovery-loop framing this chapter compresses.
-- Steve Blank, [The Customer Development Manifesto](https://steveblank.com/2009/08/31/the-customer-development-manifesto-reasons-for-the-revolution-part-1/) - the customer-development counterpart to Ries's pivot framework.
-- Patrick Vlaskovits and Brant Cooper, [*The Lean Entrepreneur*](https://leanentrepreneur.co/) - field-tested patterns for running discovery loops with limited resources.
 - Lenny Rachitsky, [The art of the pivot: how, why, and when to pivot](https://www.lennysnewsletter.com/p/the-art-of-the-pivot-part-2-how-why) - decision-criteria interviews with founders who pivoted and survived (and some who pivoted and did not).
 - Marty Cagan, [Continuous Discovery vs Continuous Pivots](https://www.svpg.com/continuous-discovery-vs-continuous-pivots/) - the senior product perspective on when persevere beats pivot.
 - Y Combinator, [All about pivoting](https://www.ycombinator.com/library/6p-all-about-pivoting) - the YC partner perspective on trigger conditions and signal strength.

--- a/content/course/tech-for-non-technical-founders-2026/reference/ceiling-signals-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/ceiling-signals-full/index.md
@@ -113,12 +113,9 @@ The [Salvage vs Rebuild decision tree](/course/tech-for-non-technical-founders-2
 ## Further reading
 
 - Rob Walling, [Vibe Coding interview on Creator Science](https://podcast.creatorscience.com/rob-walling/) - the shed-vs-skyscraper analogy that frames every architectural ceiling decision. 35-minute listen.
-- DHH, [The One-Person Framework](https://world.hey.com/dhh/the-one-person-framework-711e6318) - the Rails case for keeping the production rebuild small enough that one engineer can operate end-to-end.
-- Veracode, [GenAI Code Security Report 2025](https://www.veracode.com/blog/genai-code-security-report/) - 45% of LLM-generated code shipped at least one exploitable security flaw. The data behind why the compliance signal fires.
 - Supabase, [Realtime documentation](https://supabase.com/docs/guides/realtime) and [Row-Level Security guide](https://supabase.com/docs/guides/database/postgres/row-level-security) - the official boundary between what Supabase serves well and where the data-model and real-time signals begin.
 - OpenAI, [Rate limits documentation](https://platform.openai.com/docs/guides/rate-limits) - the per-tier request and token caps that drive the AI-inference signal once your traffic crosses a threshold.
 - Vanta, [SOC2 readiness for early-stage SaaS](https://www.vanta.com/collection/soc-2/soc-2-compliance-checklist) - the audit-surface checklist a founder usually meets for the first time when an enterprise customer asks for a SOC2 letter.
-- Y Combinator, [Startup School Library + 2026 Founder Resources](https://www.ycombinator.com/library/) - the YC stance on validating without code and the changing role of the technical co-founder.
 
 ---
 

--- a/content/course/tech-for-non-technical-founders-2026/reference/hire-decision-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/hire-decision-full/index.md
@@ -48,21 +48,49 @@ Before you commit to building, you decide which building you are putting up. A s
 
 ### 1. Validate without code
 
-Use this path when you have no MVP yet, a single untested hypothesis, and no confirmation that anyone will pay. This week: ship a Carrd page + Stripe checkout + Notion FAQ, add a Lovable demo screen recording if you have one, and send the link to 30 ICP prospects (ICP = Ideal Customer Profile - the specific kind of person your hypothesis names as the buyer) from your [Lesson 2.3 30-name list](/course/tech-for-non-technical-founders-2026/find-10-people-where-to-look/). Tooling is per-vendor (Carrd annual domain + page, Stripe free until transactions, Notion free, Lovable trial), with optional LinkedIn or Google ad spend on top. If zero buyers click, you found that out before you spent real runway - rewrite the pitch or pivot the problem.
+**Use when** you have no MVP yet, a single untested hypothesis, and no confirmation that anyone will pay.
+
+**This week:** ship a Carrd page + Stripe checkout + Notion FAQ, add a Lovable demo screen recording if you have one, and send the link to 30 ICP prospects (ICP = Ideal Customer Profile - the specific kind of person your hypothesis names as the buyer) from your [Lesson 2.3 30-name list](/course/tech-for-non-technical-founders-2026/find-10-people-where-to-look/).
+
+**Cost:** per-vendor tooling (Carrd annual domain + page, Stripe free until transactions, Notion free, Lovable trial), with optional LinkedIn or Google ad spend on top.
+
+**Watch for:** zero clicks. That is a result, not a failure - you found it out before you spent real runway. Rewrite the pitch or pivot the problem.
 
 ### 2. Self-serve build
 
-Pick this path when the problem is validated (10+ Mom Test interviews with strong signal in at least 7 per the [Lesson 2.5](/course/tech-for-non-technical-founders-2026/mom-test-synthesis-build-pivot-kill/) synthesis rubric, plus a [Lesson 1.4](/course/tech-for-non-technical-founders-2026/smoke-test-landing-page-7-day-demand-test/) smoke test that cleared the 6%+ "Promising" band - pre-orders and paid pilots come LATER in Module 5, do not require them as the gate), the scope is one workflow for one persona, and the backend requirements are simple - no real-time collaboration, no complex refund flows, no compliance scope.
+**Use when** all three are true:
 
-This week: paste your [one-page brief](/course/tech-for-non-technical-founders-2026/one-page-product-brief-vibe-prd/) into [Lovable](https://lovable.dev), ship the smallest end-to-end thing it generates, and connect [Supabase](https://supabase.com) + Stripe + Resend (the service that sends your app's emails) on top. Watch one failure mode: hitting the architectural ceiling when the app crosses ~5,000 users or your second integration. [Lesson 4.5](/course/tech-for-non-technical-founders-2026/vibe-coding-ceiling-signals/) tells you when to move up. The setup is [Lesson 4.3](/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-lovable-supabase-stripe-2026/); the build is [Lesson 4.4](/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-build-phases/).
+- The problem is validated: 10+ Mom Test interviews with strong signal in at least 7 ([Lesson 2.5](/course/tech-for-non-technical-founders-2026/mom-test-synthesis-build-pivot-kill/) rubric), plus a [Lesson 1.4](/course/tech-for-non-technical-founders-2026/smoke-test-landing-page-7-day-demand-test/) smoke test that cleared the 6%+ "Promising" band. Pre-orders and paid pilots come LATER in Module 5 - do not require them as the gate.
+- The scope is one workflow for one persona.
+- The backend is simple: no real-time collaboration, no complex refund flows, no compliance scope.
+
+**This week:** paste your [one-page brief](/course/tech-for-non-technical-founders-2026/one-page-product-brief-vibe-prd/) into [Lovable](https://lovable.dev), ship the smallest end-to-end thing it generates, and connect [Supabase](https://supabase.com) + Stripe + Resend (the service that sends your app's emails) on top. The setup is [Lesson 4.3](/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-lovable-supabase-stripe-2026/); the build is [Lesson 4.4](/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-build-phases/).
+
+**Watch for:** the architectural ceiling when the app crosses ~5,000 users or your second integration. [Lesson 4.5](/course/tech-for-non-technical-founders-2026/vibe-coding-ceiling-signals/) tells you when to move up.
 
 ### 3. Fractional CTO bridge
 
-Use this when the problem is validated, the build has a queue, an integration, or a data model that needs real thinking, and you don't have the runway to sustain a full engineering hire. This week: hire a Fractional CTO for 5 hours per week and point them at architecture review on the Lovable build, PR review on contractor commits, and watching the AWS and OpenAI bills. You pay their fractional hourly rate ($80-$120/hour market band, around $400-$600/week for 5 hours) with $0 equity. Watch for the Fractional CTO drifting from structural engineer into coder. Set a quarterly review. If their hours go to shipping features instead of oversight, architecture, and hiring, you hired the wrong profile. The [Fractional CTO bridge reference](/course/tech-for-non-technical-founders-2026/fractional-cto-sow-reference/#the-fractional-cto-bridge) has the sourcing script.
+**Use when** the problem is validated, the build has a queue, an integration, or a data model that needs real thinking, and you don't have the runway to sustain a full engineering hire.
+
+**This week:** hire a Fractional CTO for 5 hours per week and point them at three jobs - architecture review on the Lovable build, PR review on contractor commits, and watching the AWS and OpenAI bills. The [Fractional CTO bridge reference](/course/tech-for-non-technical-founders-2026/fractional-cto-sow-reference/#the-fractional-cto-bridge) has the sourcing script.
+
+**Cost:** their fractional hourly rate ($80-$120/hour market band, around $400-$600/week for 5 hours), with $0 equity.
+
+**Watch for:** the Fractional CTO drifting from structural engineer into coder. Set a quarterly review - if their hours go to shipping features instead of oversight, architecture, and hiring, you hired the wrong profile.
 
 ### 4. Hire a team
 
-Choose this when the build is backend-heavy (real-time, queues, AI inference at scale, multi-tenant data), integration-rich (5+ third-party APIs), or compliance-scoped (HIPAA, SOC 2, PCI), and you have the runway to sustain engineering salaries before revenue lands. This week: read your draft SOW (statement of work - the document listing exactly what the dev shop will build) [clause by clause](/course/tech-for-non-technical-founders-2026/sow-reading-guide/) and confirm that GitHub org, AWS root, domain registrar, and database all sit under your company email before kickoff (that is [Lesson 4.2](/course/tech-for-non-technical-founders-2026/github-aws-database-ownership-checklist/)). A team of 3-5 is material monthly burn before revenue, on top of tooling. Biggest risk: the team builds you a [spaceship for the wrong moon](/course/tech-for-non-technical-founders-2026/stop-specifying-features-start-outcomes/). The weekly demo discipline and the [Org Chart audit](/course/tech-for-non-technical-founders-2026/engineering-org-chart-non-technical-founder/) are how you catch this early instead of late. For who to hire and how to interview them, see the [hire-track supplementary reference](/course/tech-for-non-technical-founders-2026/hire-track-supplementary-reference/#where-to-find-developers-in-2026).
+**Use when** the build is backend-heavy (real-time, queues, AI inference at scale, multi-tenant data), integration-rich (5+ third-party APIs), or compliance-scoped (HIPAA, SOC 2, PCI) - and you have the runway to sustain engineering salaries before revenue lands.
+
+**This week:**
+
+- Read your draft SOW (statement of work - the document listing exactly what the dev shop will build) [clause by clause](/course/tech-for-non-technical-founders-2026/sow-reading-guide/).
+- Confirm the GitHub org, AWS root, domain registrar, and database all sit under your company email before kickoff ([Lesson 4.2](/course/tech-for-non-technical-founders-2026/github-aws-database-ownership-checklist/)).
+- For who to hire and how to interview them, see the [hire-track supplementary reference](/course/tech-for-non-technical-founders-2026/hire-track-supplementary-reference/#where-to-find-developers-in-2026).
+
+**Cost:** a team of 3-5 is material monthly burn before revenue, on top of tooling.
+
+**Watch for:** the team building you a [spaceship for the wrong moon](/course/tech-for-non-technical-founders-2026/stop-specifying-features-start-outcomes/). The weekly demo discipline and the [Org Chart audit](/course/tech-for-non-technical-founders-2026/engineering-org-chart-non-technical-founder/) are how you catch that early instead of late.
 
 ## The Series-A off-ramp: when the model itself changes
 
@@ -77,10 +105,7 @@ Choose this when the build is backend-heavy (real-time, queues, AI inference at 
 - Paul Graham, [*Do Things That Don't Scale*](https://paulgraham.com/ds.html) - the YC essay that named the Airbnb-style validation pattern. The first section is the Airbnb story; the rest is the manual that founders skip.
 - Paul Graham, [*The Airbnbs*](https://www.paulgraham.com/airbnbs.html) - PG's own short note on the Airbnb founders' early experiments. 6-minute read.
 - Sophia Matveeva, [*The Non-Technical Founder's Guide to Hiring*](https://www.amazon.com/Non-Technical-Founders-Guide-Hiring-Product-ebook/dp/B0B7WRLBZF) - the long-form companion to this lesson. Heavy on hiring, light on the validate-without-code path that comes first.
-- Drew Falkman, *Vibe Coding Data-Enabled AI Apps* on Maven - the paid live cohort that teaches the self-serve stack (Path 2). Recommended if accountability is your blocker.
 - Y Combinator, [Startup School: Customer Discovery](https://www.ycombinator.com/library/) - YC's distilled take on validating before building. The Path 1 reading list.
-- DHH, [The One Person Framework](https://world.hey.com/dhh/the-one-person-framework-711e6318) - the Rails case for keeping the architecture small enough that one developer can ship outcomes end-to-end. Reading for Path 2 and Path 3 founders.
-- Veracode, [GenAI Code Security Report 2025](https://www.veracode.com/blog/genai-code-security-report/) - 45% of LLM-generated code shipped at least one exploitable security flaw. Context for why Path 2 needs the 1-hour-a-month architecture review.
 
 ---
 

--- a/content/course/tech-for-non-technical-founders-2026/reference/mom-test-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/mom-test-full/index.md
@@ -133,8 +133,6 @@ Fake the convergence to start building anyway, and you join the long line of pos
 - Y Combinator, [How to Talk to Users (Startup Library)](https://www.ycombinator.com/library) - YC's distilled rules for the same conversation, free and 20 minutes.
 - Steve Blank, [The Four Steps to the Epiphany - Customer Discovery](https://steveblank.com/category/customer-development/) - the original customer-development methodology Fitzpatrick's script sits inside.
 - Teresa Torres, [Continuous Discovery Habits](https://www.producttalk.org/continuous-discovery-habits/) - what these interviews become after the validation phase, when you run them weekly forever.
-- Teresa Torres, [Customer Interviews (Product Talk)](https://www.producttalk.org/customer-interviews/) - the story-based method behind Q1: collect specific past stories and excavate them, because people overestimate what they typically do.
-- Teresa Torres, [Learning to Interview Continuously (Product Talk)](https://www.producttalk.org/learning-to-interview-continuously/) - how interviewers actually get good: anchor to specific moments, redirect general claims to concrete activities, and leave space for silence.
 
 ---
 

--- a/content/course/tech-for-non-technical-founders-2026/reference/must-have-survey-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/must-have-survey-full/index.md
@@ -123,9 +123,7 @@ Under 40% means you have a product problem, not a marketing problem, and the Q2-
 - Lenny Rachitsky, [The original growth hacker, Sean Ellis, on the 40% test](https://www.lennysnewsletter.com/p/the-original-growth-hacker-sean-ellis) - the original 40% framing, with Sean's own commentary on what the number means and does not mean.
 - Sean Ellis and Morgan Brown, [*Hacking Growth*](https://hackinggrowth.org/) - the book that explains the survey-driven north-star approach Ellis built at Dropbox, LogMeIn, and Eventbrite.
 - Lenny Rachitsky, [How to win your first 10 B2B customers](https://www.lennysnewsletter.com/p/how-to-win-your-first-10-b2b-customers) - companion piece that maps the must-have-user concept to the first-ten-customer playbook.
-- Steve Blank, [The Customer Development Manifesto](https://steveblank.com/2009/08/31/the-customer-development-manifesto-reasons-for-the-revolution-part-1/) - the foundational framing for "get out of the building and validate before building." The Sean Ellis test is the post-build analog.
 - Rahul Vohra, [How Superhuman built an engine to find product-market fit](https://review.firstround.com/how-superhuman-built-an-engine-to-find-product-market-fit/) - the segment-isolation playbook layered on top of the 40% test.
-- Rob Fitzpatrick, [*The Mom Test*](https://www.momtestbook.com/) - the pre-launch validation companion. Once your 40% test is above the line, the Mom Test questions are the ones you ask the 10 must-have users on their next call.
 
 ---
 

--- a/content/course/tech-for-non-technical-founders-2026/reference/mvp-build-phases-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/mvp-build-phases-full/index.md
@@ -127,10 +127,8 @@ The [Self-Serve Stack Walkthrough](/course/tech-for-non-technical-founders-2026/
 - [Self-Serve Stack Walkthrough](/course/tech-for-non-technical-founders-2026/self-serve-stack-walkthrough/) - day-by-day version of the build plan; print before Phase 1
 - Y Combinator, [Startup School Library + 2026 Founder Resources](https://www.ycombinator.com/library/) - the YC stance on validating without code
 - Rob Walling, [Vibe Coding interview on Creator Science](https://podcast.creatorscience.com/rob-walling/) - the shed vs skyscraper analogy
-- Lovable, [Pricing tiers](https://lovable.dev/pricing) and [community Discord](https://lovable.dev/community)
 - Supabase, [Row-Level Security guide](https://supabase.com/docs/guides/database/postgres/row-level-security)
 - Stripe, [Checkout quickstart](https://docs.stripe.com/checkout/quickstart) and [Pricing page](https://stripe.com/pricing)
-- Drew Falkman, "Vibe Coding Data-Enabled AI Apps" on Maven
 
 ---
 

--- a/content/course/tech-for-non-technical-founders-2026/reference/outbound-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/outbound-full/index.md
@@ -186,10 +186,8 @@ You've completed the core 5-module course - hypothesis, smoke test + price, prob
 
 - OpenHunts, [Product Launch Statistics: Success Rates & Data](https://openhunts.com/blog/tech-product-launch-statistics-insights) - the primary source for the Product Hunt 3.1% vs Indie Hackers 23.1% per-engaged-post conversion data (387-launch 2024 study, 156 founders surveyed).
 - Lenny Rachitsky, [How to win your first 10 B2B customers](https://www.lennysnewsletter.com/p/how-to-win-your-first-10-b2b-customers) - the 7-step playbook from 100+ B2B founders, including the cold-outbound section.
-- Lenny Rachitsky, [How the biggest consumer apps got their first 1,000 users](https://www.lennysnewsletter.com/p/how-the-biggest-consumer-apps-got) - first-users tactics from Airbnb, Tinder, Etsy, Reddit and more.
 - Paul Graham, [Do Things That Don't Scale](http://paulgraham.com/ds.html) - the foundational text on manual customer recruitment, including the Stripe Collison-brothers cold-DM-and-install motion.
 - Y Combinator Library, [The Sales Playbook for Founders](https://www.ycombinator.com/library/Mo-the-sales-playbook-for-founders) - YC's playbook on founder-led sales, from first pilots to closed recurring revenue.
-- Sahil Bloom, [The Curiosity Chronicle](https://www.sahilbloom.com/newsletter) - his newsletter on early traction and the relationship-to-cold transition that closes the personal-network gap.
 
 ---
 

--- a/content/course/tech-for-non-technical-founders-2026/reference/outbound-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/outbound-full/index.md
@@ -30,7 +30,14 @@ Figma's first customer 11-20 cohort reportedly came from cold DMs to influential
 
 You run the whole pipeline in six stages with off-the-shelf tools - no engineer, no $1,200/month sales stack, no Salesforce.
 
-The tooling is a volume choice, and both versions ship the same 30-message batch. The $0 stack - Apollo's free tier (Apollo is a B2B contact database that finds prospects' names and work emails; its free tier is credit-based - check the current allowance), a Google Sheet, a Gmail mail-merge add-on (sends the same email to many recipients at once, free), Loom, and Calendly - covers every stage; you enrich the list by hand in the sheet, which costs your time. The paid version swaps the manual enrichment for automation through Smartlead or Apollo's paid tiers, which costs money and pays off once you're sending 100+ messages a week and the hand-enrichment is the bottleneck. At this 30-message volume, either works - pick by whether your scarcer resource is hours or dollars.
+The tooling is a volume choice, and both versions ship the same 30-message batch.
+
+| Stack | What it is | What it costs |
+|---|---|---|
+| **$0** | Apollo's free tier (a B2B contact database that finds prospects' names and work emails; the free tier is credit-based - check the current allowance), a Google Sheet, a Gmail mail-merge add-on (sends one email to many recipients, free), Loom, and Calendly. Covers every stage. | Your time - you enrich the list by hand in the sheet |
+| **Paid** | Swaps manual enrichment for automation through Smartlead or Apollo's paid tiers | Money. Pays off once you're sending 100+ messages a week and hand-enrichment is the bottleneck |
+
+At this 30-message volume either works. Pick by whether your scarcer resource is hours or dollars.
 
 The five tools and their 2026 pricing:
 
@@ -169,7 +176,11 @@ A 30-message batch with zero replies is rare and almost always indicates a filte
 
 ## Advanced (optional sidebar)
 
-Once you have closed 5-10 paid pilots from cold outbound and want to layer on sales-system rigor, read First Round Review's [sales article collection](https://review.firstround.com/articles/sales/), Sahil Bloom's [Curiosity Chronicle newsletter](https://www.sahilbloom.com/newsletter), and the [Y Combinator library on founder-led sales](https://www.ycombinator.com/library/Mo-the-sales-playbook-for-founders). Once you cross customer 30, the sales playbooks designed for solo founders give way to operator manuals: Mark Roberge's *The Sales Acceleration Formula* for hiring your first AE (account executive - a dedicated salesperson), Mike Weinberg's *New Sales. Simplified.* for the manager handbook. The main path gets you from customer 11 to customer 20. The advanced versions matter after that.
+The main path gets you from customer 11 to customer 20. Two upgrades matter after that:
+
+**After 5-10 paid pilots from cold outbound**, layer on sales-system rigor: First Round Review's [sales article collection](https://review.firstround.com/articles/sales/) and the [Y Combinator library on founder-led sales](https://www.ycombinator.com/library/Mo-the-sales-playbook-for-founders).
+
+**Past customer 30**, the solo-founder playbooks give way to operator manuals: Mark Roberge's *The Sales Acceleration Formula* for hiring your first AE (account executive - a dedicated salesperson), Mike Weinberg's *New Sales. Simplified.* for the manager handbook.
 
 ## Going further (after your first paying customer)
 

--- a/content/course/tech-for-non-technical-founders-2026/reference/outcomes-not-features-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/outcomes-not-features-full/index.md
@@ -77,10 +77,7 @@ After you have rewritten Section 3 as outcome-shaped job stories, you still have
 
 - Alan Klement, [*When Coffee and Kale Compete*](https://web.archive.org/web/20230319130354/https://www.whencoffeeandkalecompete.com/) - the book that introduced the *When / I want / So I can* shape under the name "Job Stories" in 2013. The framework is worth chasing once your team is bigger than two; the shape is worth using tomorrow.
 - Marty Cagan, [Product vs Feature Teams](https://www.svpg.com/product-vs-feature-teams/) - the canonical essay on why product teams (chartered with outcomes) ship better than feature teams (chartered with feature lists).
-- Veracode, [GenAI Code Security Report 2025](https://www.veracode.com/blog/genai-code-security-report/) - 45% of LLM-generated code shipped at least one exploitable security flaw. Vague briefs amplify the rate.
-- DHH, [The One Person Framework](https://world.hey.com/dhh/the-one-person-framework-711e6318) - the Rails case for keeping the architecture small enough that one developer can ship outcomes end-to-end.
 - Basecamp / Ryan Singer, [Shape Up - Appetite vs Estimate](https://basecamp.com/shapeup/1.2-chapter-03) - the chapter on writing pitches that fix the appetite first, so the build collapses to fit.
-- Tom Kerwin, [JTBD Job Stories vs User Stories](https://web.archive.org/web/20240819160036/https://jtbd.info/replacing-the-user-story-with-the-job-story-af7cdee10c27) - the 2013 Klement piece on Medium that popularised the shape, for readers who want the original 1,500 words.
 - Y Combinator, [Startup School: How to Write a Product Spec](https://www.ycombinator.com/library/) - YC's distilled take on specs that ship versus specs that sit.
 
 ---

--- a/content/course/tech-for-non-technical-founders-2026/reference/outcomes-not-features-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/outcomes-not-features-full/index.md
@@ -71,7 +71,13 @@ The real gate is a clean peer QA (human or AI) where the answer stays inside you
 
 ## Optional: stack-rank features with real users
 
-After you have rewritten Section 3 as outcome-shaped job stories, you still have a list. If you need to know which outcome to build first, [OpinionX](https://opinionx.co) (free tier available) uses forced-ranking pairwise voting - users pick A or B, not rate everything "very important." Paste your 5-7 outcome statements, send the link to your [Lesson 2.3-2.4](/course/tech-for-non-technical-founders-2026/find-10-people-where-to-look/) interviewees, and the forced-choice format surfaces real priorities that a 1-10 rating scale hides. The output is a ranked list backed by pairwise win rates, not averaged scores. Use this before handing the brief to Lovable or a contractor - it prevents the "build everything because everything scored 8/10" trap.
+After you have rewritten Section 3 as outcome-shaped job stories, you still have a list. To know which outcome to build first, [OpinionX](https://opinionx.co) (free tier available) uses forced-ranking pairwise voting - users pick A or B, rather than rating everything "very important."
+
+1. Paste your 5-7 outcome statements.
+2. Send the link to your [interviewees](/course/tech-for-non-technical-founders-2026/find-10-people-where-to-look/).
+3. Read the ranked list, backed by pairwise win rates rather than averaged scores.
+
+Do this before handing the brief to Lovable or a contractor. It prevents the "build everything because everything scored 8/10" trap.
 
 ## Further reading
 

--- a/content/course/tech-for-non-technical-founders-2026/reference/ownership-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/ownership-full/index.md
@@ -80,8 +80,6 @@ Ownership audit done right means no Marcos stands between you and a 9pm Tuesday 
 - ICANN, [Transfer Policy](https://www.icann.org/en/contracted-parties/accredited-registrars/resources/domain-name-transfers/policy) - the rules every domain registrar must follow when transferring a domain between accounts, including the 60-day lock and the five-day code-release and transfer-release windows.
 - GitGuardian, [The State of Secrets Sprawl 2024](https://www.gitguardian.com/state-of-secrets-sprawl-report-2024) - 12.8 million secrets exposed in public GitHub commits in 2023, with `.env` files as one of the most common leak vectors.
 - Rails Guides, [Security: Custom Credentials](https://guides.rubyonrails.org/security.html#custom-credentials) - the canonical Rails answer to the "where do production secrets live?" question, replacing the old `database.yml` plaintext pattern.
-- Will Larson (via First Round Review), [Engineering leadership anti-patterns from Stripe, Uber, Carta](https://review.firstround.com/unexpected-anti-patterns-for-engineering-leaders-lessons-from-stripe-uber-carta/) - on ownership and accountability in engineering teams, including who holds the keys to production.
-- AWS, [Reset a lost or forgotten root user password](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_change-root.html) - the support process and timeline if you need to recover a root account where someone else controls the email.
 
 ---
 

--- a/content/course/tech-for-non-technical-founders-2026/reference/paid-pilot-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/paid-pilot-full/index.md
@@ -166,8 +166,6 @@ Once you have closed 2-3 paid pilots and want to layer on contract rigor, read t
 - SaaStr, [Should you charge for a pilot?](https://www.saastr.com/we-are-a-b2b-saas-startup-and-want-to-develop-our-product-in-pilots-with-customers-should-we-charge-for-the-pilots-and-how-much/) - Jason Lemkin's case for charging and the conversion-rate data behind the recommendation.
 - Ash Rust, [Startup Sales: How to Get Pilot Customers to Pay](https://medium.com/sharp-spear/startup-sales-how-to-get-pilot-customers-to-pay-7a9b7a48eedf) - tactical conversation script and pricing-band data from investor Ash Rust.
 - Steve Blank, [The Four Steps to the Epiphany](https://steveblank.com/four-steps-35/) - the foundational text on Customer Validation; Blank argues paid pilots are how you separate real demand from polite enthusiasm.
-- Stripe, [Payment Links documentation](https://stripe.com/docs/payment-links) - the official Stripe Checkout setup. 15-minute integration with no engineering work required.
-- Lenny Rachitsky, [How to win your first 10 B2B customers](https://www.lennysnewsletter.com/p/how-to-win-your-first-10-b2b-customers) - the 7-step playbook including the design-partner pricing model from B2B founders.
 
 ---
 

--- a/content/course/tech-for-non-technical-founders-2026/reference/persona-rehearsal-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/persona-rehearsal-full/index.md
@@ -85,7 +85,14 @@ After the rehearsal, you have two deliverables.
 
 **The sharpened question list.** Take your original questions, apply the revisions from Prompt 5, cut the ones flagged in Prompt 4. You should end the session with 5-7 solid questions where you started with 5-8 loose ones. That's the list you take into [booking real interviews with the full outreach stack](/course/tech-for-non-technical-founders-2026/find-10-people-with-problem-outreach-2026/).
 
-**The top 3 objections to test in real interviews.** Prompt 4 will surface 3-5 things that make your persona want to end the conversation. Pick the 3 that appeared across at least 2 of your 3 personas. These are the objections you're listening for in real interviews - not discovering them for the first time, but noticing whether and how they show up. Hearing an objection in rehearsal also does something quieter: when a real person raises it, you've already sat with it, so you take notes instead of getting defensive and pitching to win them back. There's a difference between a real customer who raises objection #2 early (strong signal that the objection is real) and one who never raises it at all (either it's not real for this person, or your questions didn't give them space to surface it).
+**The top 3 objections to test in real interviews.** Prompt 4 will surface 3-5 things that make your persona want to end the conversation. Pick the 3 that appeared across at least 2 of your 3 personas.
+
+These are the objections you're listening for in real interviews - not discovering for the first time, but noticing whether and how they show up. Rehearsal does something quieter too: when a real person raises the objection, you've already sat with it, so you take notes instead of getting defensive and pitching to win them back.
+
+What the two outcomes tell you:
+
+- **Raises objection #2 early** - strong signal the objection is real.
+- **Never raises it at all** - either it isn't real for this person, or your questions didn't give them space to surface it.
 
 **Objection Tracker** - fill this in after the rehearsal, before your first real interview:
 

--- a/content/course/tech-for-non-technical-founders-2026/reference/product-brief-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/product-brief-full/index.md
@@ -121,12 +121,9 @@ Drew Falkman runs "Vibe Coding Data-Enabled AI Apps" on Maven, a multi-week live
 
 ## Further reading
 
-- Drew Falkman, "Vibe Coding Data-Enabled AI Apps" on Maven - the paid live cohort that teaches the Vibe PRD with instructor feedback. Recommended if accountability is your blocker.
 - Marty Cagan, [Good Product Manager / Bad Product Manager](https://www.svpg.com/good-product-manager-bad-product-manager/) - the canonical essay on what a PRD is for. The Vibe PRD is the AI-era compression of the same shape.
 - Marty Cagan, [Product vs Feature Teams](https://www.svpg.com/product-vs-feature-teams/) - why the brief shapes what gets built. The no-go list is the part feature teams ignore.
 - Jake Knapp and John Zeratsky, [Foundation Sprint (Click, April 2025)](https://www.thesprintbook.com/foundation-sprint) - the 2-day version of the same artifact for teams that have 2 days. The Foundation Sprint workbook is freely sampled from the book site.
-- Ben Horowitz, [Good Product Manager / Bad Product Manager (1996 memo)](https://a16z.com/2012/06/15/good-product-managerbad-product-manager/) - the original Horowitz memo on the "good vs bad PM" frame; pairs with Cagan.
-- Veracode, [GenAI Code Security Report 2025](https://www.veracode.com/blog/genai-code-security-report/) - the 45% LLM-generated-code-flaw stat. Context for why the no-go list matters.
 - Y Combinator, [How to Write a PRD (Startup Library)](https://www.ycombinator.com/library/) - YC's distilled version of the same compression.
 
 ---

--- a/content/course/tech-for-non-technical-founders-2026/reference/stack-tools-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/stack-tools-full/index.md
@@ -22,7 +22,15 @@ Boring is what you want for an MVP. The boring path lets one non-technical found
 
 ![A hand-drawn layer diagram of the self-serve stack: a red Lovable card labeled the UI layer, an arrow reading reads / writes rows down to a blue Supabase card labeled the data layer with Postgres, auth, storage and row-level security, then user hits the paywall down to a green Stripe card labeled the money layer, with a dashed green webhook arrow looping from Stripe back into Supabase to flip subscription status to active, a gray GitHub backup box synced from Lovable on day 1, and an amber footnote warning not to let one tool do another tool's job.](stack-layer-boundaries.svg)
 
-How much demand evidence you already have decides the path. With enough of it, you open Lovable and build. Without it, a $0 Concierge MVP - a no-code "Wizard of Oz" where you fake the automation by hand behind the curtain - gets you more evidence before you commit to Lovable code. Wire up Tally (free form) → Zapier or Make.com (free routing) → Airtable or Notion (free storage): the customer fills the Tally form, Zapier drops the row in Airtable, and you process it by hand. To the customer it looks automated, so you validate willingness-to-pay before writing code. The trade-off is that you run it by hand, which makes it a stepping stone, not a replacement. Either way, the Lovable + Supabase + Stripe stack is what ships in [Lesson 4.4](/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-build-phases/).
+How much demand evidence you already have decides the path. With enough of it, you open Lovable and build. Without it, a $0 Concierge MVP gets you more evidence first - a no-code "Wizard of Oz" where you fake the automation by hand behind the curtain:
+
+```text
+Tally (free form) -> Zapier or Make.com (free routing) -> Airtable or Notion (free storage)
+```
+
+The customer fills the Tally form, Zapier drops the row in Airtable, and you process it by hand. To the customer it looks automated, so you validate willingness-to-pay before writing code. The trade-off: you run it by hand, which makes it a stepping stone, not a replacement.
+
+Either way, the Lovable + Supabase + Stripe stack is what ships in [Lesson 4.4](/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-build-phases/).
 
 ## M2 prototype vs M4 MVP - different artifacts, different rigor
 

--- a/content/course/tech-for-non-technical-founders-2026/reference/stack-tools-full/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/reference/stack-tools-full/index.md
@@ -135,9 +135,6 @@ None of these is JetThoughts. None of them sells you a service. They are the fou
 - [Lesson 4.4: Build Phases](/course/tech-for-non-technical-founders-2026/self-serve-mvp-stack-build-phases/) - the companion lesson: 4 build phases, exit criteria, shed-vs-skyscraper, and the architectural ceiling
 - Y Combinator, [Startup School Library + 2026 Founder Resources](https://www.ycombinator.com/library/) - the YC stance on validating without code and the changing role of the technical co-founder
 - Rob Walling, [Vibe Coding interview on Creator Science](https://podcast.creatorscience.com/rob-walling/) - the shed vs skyscraper analogy that frames the architectural ceiling. 35-minute listen.
-- Lovable, [Pricing tiers](https://lovable.dev/pricing) and [community Discord](https://lovable.dev/community)
-- Supabase, [Pricing tiers](https://supabase.com/pricing) and [Row-Level Security guide](https://supabase.com/docs/guides/database/postgres/row-level-security)
-- Stripe, [Checkout quickstart](https://docs.stripe.com/checkout/quickstart) and [Pricing page](https://stripe.com/pricing)
 - DHH, [The One-Person Framework](https://world.hey.com/dhh/the-one-person-framework-711e6318)
 - Veracode, [GenAI Code Security Report 2025](https://www.veracode.com/blog/genai-code-security-report/)
 

--- a/content/course/tech-for-non-technical-founders-2026/should-you-hire-2026-decision-tree/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/should-you-hire-2026-decision-tree/index.md
@@ -44,7 +44,15 @@ Hiring engineers before a single paying customer is confirmed is the most common
 
 Self-serve with Lovable (an AI app builder that turns a plain-English prompt into a working web app), Supabase (the database that stores what the app records), and Stripe (the service that takes the payments) is the default for a non-technical founder in 2026. Hiring - whether a full team or a Fractional CTO (a part-time senior engineer who owns architecture but doesn't write the code) - is what you do when you hit a specific ceiling signal, not the first decision after the brief.
 
-By the time you reach this lesson you have already run three validation signals: the [Lesson 1.4 smoke test](/course/tech-for-non-technical-founders-2026/smoke-test-landing-page-7-day-demand-test/) proved strangers click, the [Lesson 2.4 Mom Test interviews](/course/tech-for-non-technical-founders-2026/find-10-people-with-problem-outreach-2026/) (using the [Lesson 2.1 technique](/course/tech-for-non-technical-founders-2026/mom-test-ask-about-past-not-future/)) proved the problem is real and felt, and the [Lesson 2.6 prototype](/course/tech-for-non-technical-founders-2026/clickable-prototype-validation-2-hour-lovable/) proved users can navigate the solution without coaching. The [Lesson 3.1 brief](/course/tech-for-non-technical-founders-2026/one-page-product-brief-vibe-prd/) documents what to build. This lesson decides HOW.
+By the time you reach this lesson you have already run three validation signals:
+
+| Signal | What it proved |
+|---|---|
+| [Smoke test](/course/tech-for-non-technical-founders-2026/smoke-test-landing-page-7-day-demand-test/) (1.4) | Strangers click |
+| [Mom Test interviews](/course/tech-for-non-technical-founders-2026/find-10-people-with-problem-outreach-2026/) (2.4, using the [2.1 technique](/course/tech-for-non-technical-founders-2026/mom-test-ask-about-past-not-future/)) | The problem is real and felt |
+| [Clickable prototype](/course/tech-for-non-technical-founders-2026/clickable-prototype-validation-2-hour-lovable/) (2.6) | Users navigate the solution without coaching |
+
+The [Lesson 3.1 brief](/course/tech-for-non-technical-founders-2026/one-page-product-brief-vibe-prd/) documents what to build. This lesson decides HOW.
 
 ## The 5 questions that route you
 

--- a/content/course/tech-for-non-technical-founders-2026/slopsquatting-ai-supply-chain-attack/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/slopsquatting-ai-supply-chain-attack/index.md
@@ -40,13 +40,25 @@ course_nav: false
 
 **For later.** This matters once you have shipped (Module 4+) and your product uses AI in production - bookmark it and come back.
 
-In March 2025, [Lasso Security published findings](https://www.lasso.security/blog/ai-package-hallucinations) that AI assistants suggested over 200 package names across Rubygems, PyPI, and npm that did not exist. Attackers registered those names and waited. By the time the [Infosecurity Magazine writeup](https://www.infosecurity-magazine.com/news/ai-hallucinations-slopsquatting/) named the technique "slopsquatting" in April 2025, security teams had already logged the first installs of the proof-of-concept packages on real production systems. You paid $34K for an MVP. The most expensive line in the codebase was free. It was the one a model invented and a developer typed into a `Gemfile` without checking that the gem existed.
+In March 2025, [Lasso Security published findings](https://www.lasso.security/blog/ai-package-hallucinations) that AI assistants suggested over 200 package names across Rubygems, PyPI, and npm that did not exist. Attackers registered those names and waited. By the time the [Infosecurity Magazine writeup](https://www.infosecurity-magazine.com/news/ai-hallucinations-slopsquatting/) named the technique "slopsquatting" in April 2025, security teams had already logged the first installs of the proof-of-concept packages on real production systems.
+
+You paid $34K for an MVP. The most expensive line in the codebase was free - the one a model invented and a developer typed into a `Gemfile` without checking that the gem existed.
 
 ![A hand-drawn diagram of the slopsquatting attack chain in five steps: AI hallucinates a package name, attacker watches public prompt logs, attacker registers the name on Rubygems / PyPI / npm with a malicious payload, developer installs without review, damage runs in production. Annotated with the Lasso Security 11-day reproduction window.](attack-chain.svg)
 
 ## What slopsquatting is
 
-LLMs invent package names that sound plausible but do not exist. The original [Lasso Security research from March 2025](https://www.lasso.security/blog/ai-package-hallucinations) tested GPT-4, Claude, and the open-source Code Llama against thousands of common developer prompts. About 5.2% of GPT-4's package suggestions and 21.7% of Code Llama's were hallucinated. [Snyk's slopsquatting write-up](https://snyk.io/articles/slopsquatting-mitigation-strategies/) cites follow-up research putting the overall rate at roughly one in five AI-suggested packages across models. Attackers then register the most-suggested hallucinated names as squatted packages, sometimes with a malicious payload (data exfiltration, credential theft, persistence backdoor), sometimes empty until a real victim shows up. Rubygems, PyPI, npm, Composer, and crates.io all have the same exposure. The attack does not need a 0day (a secret, unpatched vulnerability) - just a developer who trusts a model without checking.
+LLMs invent package names that sound plausible but do not exist. The original [Lasso Security research from March 2025](https://www.lasso.security/blog/ai-package-hallucinations) tested GPT-4, Claude, and the open-source Code Llama against thousands of common developer prompts:
+
+| Model | Package suggestions that were hallucinated |
+|---|---|
+| GPT-4 | ~5.2% |
+| Code Llama | ~21.7% |
+| Across models (follow-up research) | roughly 1 in 5, per [Snyk's slopsquatting write-up](https://snyk.io/articles/slopsquatting-mitigation-strategies/) |
+
+Attackers register the most-suggested hallucinated names as squatted packages - sometimes with a malicious payload (data exfiltration, credential theft, persistence backdoor), sometimes empty until a real victim shows up.
+
+Rubygems, PyPI, npm, Composer, and crates.io all have the same exposure. The attack does not need a 0day (a secret, unpatched vulnerability) - just a developer who trusts a model without checking.
 
 ![A hand-drawn comparison table across three stacks - Rails/Ruby, Django/Python, and Laravel/npm. Each row shows the plausible-sounding package name an AI model hallucinated (active_support_extras_helper, requestz, react-toastify-fork) next to the real package it was confused with (active_record_extra, requests, react-toastify). All three hallucinated names were registered by Lasso researchers as proof-of-concept in April 2025.](hallucinated-vs-real.svg)
 

--- a/content/course/tech-for-non-technical-founders-2026/slopsquatting-ai-supply-chain-attack/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/slopsquatting-ai-supply-chain-attack/index.md
@@ -152,13 +152,9 @@ This is the last supplementary chapter. The full artifact list (Founder OS) and 
 
 ## Further reading
 
-- Lasso Security, [AI Package Hallucinations: A New Class of Software Supply-Chain Attack](https://www.lasso.security/blog/ai-package-hallucinations) (March 2025) - the original research that named the failure mode and reproduced the attack on Rubygems, PyPI, and npm.
 - Snyk, [Package Hallucinations: When AI Creates Phantom Packages](https://snyk.io/articles/package-hallucinations/) - how hallucinated names become attack vectors, including the empty `huggingface-cli` test package that drew 30,000+ downloads in three months.
-- Snyk, [ToxicSkills: a security audit of AI agent skills](https://snyk.io/blog/toxicskills-malicious-ai-agent-skills-clawhub/) - the 13.4% critical-issue rate finding across the agent-skills corpus.
-- Infosecurity Magazine, [AI Hallucinations Open New Slopsquatting Attack Vector](https://www.infosecurity-magazine.com/news/ai-hallucinations-slopsquatting/) (April 2025) - the writeup that coined "slopsquatting" and walked the kill chain for a non-security audience.
 - SecurityWeek, [AI Coding Agents Could Fuel the Next Supply Chain Crisis](https://www.securityweek.com/ai-coding-agents-could-fuel-next-supply-chain-crisis/) - why agent-driven coding expands the software supply-chain attack surface.
 - Veracode, [2025 GenAI Code Security Report](https://www.veracode.com/blog/genai-code-security-report/) - the 45% OWASP-Top-10 vulnerability rate in AI-generated code, including hallucinated dependencies.
-- GitHub, [The State of the Octoverse 2025](https://octoverse.github.com/) - the AI-assisted development surge that scales the slopsquatting exposure across the platform.
 - Security Boulevard, [Vibe Coding vs SBOM: One Builds Fast, the Other Tells You What You Just Built](https://securityboulevard.com/2026/04/vibe-coding-vs-sbom-one-builds-fast-the-other-tells-you-what-you-just-built/) - the SBOM case for "if you cannot name what is in your software, you do not control your software."
 
 ---

--- a/content/course/tech-for-non-technical-founders-2026/smoke-test-build-page/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/smoke-test-build-page/index.md
@@ -53,7 +53,13 @@ The page has four copy blocks that decide whether it converts:
 
 ## Step 1: get 2-3 real customer quotes (10 minutes)
 
-The builder prompt in Step 2 has three slots for your customers' own words - they become your value props, and they are what makes the page sound like your customer instead of like marketing. If you don't have quotes yet, that's expected at this stage: run this in [Perplexity](https://www.perplexity.ai/) (or any AI search engine) and keep the best 2-3 lines - and keep the source URLs too, because Lesson 2.3 reads these same threads to find the named people you'll interview. Already have real quotes from conversations? Skip straight to Step 2. Already ran the deeper research pass in the [full hypothesis sprint](/course/tech-for-non-technical-founders-2026/reference/hypothesis-sprint-full/)? Reuse those quotes here - don't search twice.
+The builder prompt in Step 2 has three slots for your customers' own words. They become your value props, and they are what makes the page sound like your customer instead of like marketing.
+
+| Where you are | What to do |
+|---|---|
+| No quotes yet (expected at this stage) | Run the prompt below in [Perplexity](https://www.perplexity.ai/) or any AI search engine, keep the best 2-3 lines - and keep the source URLs, because Lesson 2.3 reads these same threads to find the named people you'll interview |
+| Already have real quotes from conversations | Skip straight to Step 2 |
+| Already ran the [full hypothesis sprint](/course/tech-for-non-technical-founders-2026/reference/hypothesis-sprint-full/) research pass | Reuse those quotes - don't search twice |
 
 ```text
 Find real, verbatim complaints from [CUSTOMER] about [PROBLEM].

--- a/content/course/tech-for-non-technical-founders-2026/sow-reading-guide/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/sow-reading-guide/index.md
@@ -38,7 +38,15 @@ One clause in a 47-page SOW decides whether you can withhold payment for work th
 
 ## How to use it
 
-Read this **the night before you sign, alone**, with a printed SOW, a yellow highlighter, and 90 minutes blocked. Bring the SOW, your [one-page Product Brief](/course/tech-for-non-technical-founders-2026/one-page-product-brief-vibe-prd/) and [outcome-shaped feature list](/course/tech-for-non-technical-founders-2026/stop-specifying-features-start-outcomes/) from Lessons 3.1-3.2 (that pair is your scope Exhibit - the agency's Exhibit A must match it line for line), and this guide. Walk every clause against the 8 flags below; when a flag fires, write the question for the agency in the margin. Type all the questions into one email and send it before you sign anything. A working agency answers in writing and signs the redline. If your general counsel cleared the SOW already, run this anyway - generalist attorneys catch the IP and liability paragraphs and skim the operational ones, and the 8 clauses below are where the operational money lives.
+Read this **the night before you sign, alone**, with 90 minutes blocked. Bring:
+
+- the printed SOW and a yellow highlighter
+- your [one-page Product Brief](/course/tech-for-non-technical-founders-2026/one-page-product-brief-vibe-prd/) and [outcome-shaped feature list](/course/tech-for-non-technical-founders-2026/stop-specifying-features-start-outcomes/) from Lessons 3.1-3.2 - that pair is your scope Exhibit, and the agency's Exhibit A must match it line for line
+- this guide
+
+Walk every clause against the 8 flags below. When a flag fires, write the question for the agency in the margin. Type all the questions into one email and send it before you sign anything - a working agency answers in writing and signs the redline.
+
+If your general counsel cleared the SOW already, run this anyway. Generalist attorneys catch the IP and liability paragraphs and skim the operational ones, and the 8 clauses below are where the operational money lives.
 
 > **The 8-clause SOW scoreboard** - use this as a pre-flight checklist; details below:
 >

--- a/content/course/tech-for-non-technical-founders-2026/three-questions-turn-standup-into-proof/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/three-questions-turn-standup-into-proof/index.md
@@ -114,9 +114,5 @@ If most of the week's answers came back as fails, the problem is not the standup
 ## Further reading
 
 - Atlassian, [Daily Standup Meetings](https://www.atlassian.com/agile/scrum/standups) - the canonical reference on the three-question format and the failure modes it slides into.
-- Will Larson (via First Round Review), [Engineering leadership anti-patterns from Stripe, Uber, Carta](https://review.firstround.com/unexpected-anti-patterns-for-engineering-leaders-lessons-from-stripe-uber-carta/) - on the pull request funnel as the load-bearing signal for engineering health.
-- Eric Ries via Lean Startup Co., [What Is an MVP?](https://leanstartup.co/resources/articles/what-is-an-mvp/) - the validated-learning framing that makes "what did we cut?" a real product question.
-- DHH, [The One Person Framework](https://world.hey.com/dhh/the-one-person-framework-711e6318) - the Rails case for full-stack developers shipping end-to-end.
-- Qodo, [State of AI Code Quality 2025](https://www.qodo.ai/reports/state-of-ai-code-quality/) - 1.7x more issues in AI-generated code; useful context for why PR review questions matter more in 2026.
 - Scrum Alliance, [Async Standups](https://resources.scrumalliance.org/Article/async-standups) - on running written standups when the team is distributed, with the same three-question backbone.
 - Martin Fowler, [It's Not Just Standing Up: Patterns for Daily Standup Meetings](https://martinfowler.com/articles/itsNotJustStandingUp.html) - a deep practitioner reference on what daily standups should produce and when they fail.

--- a/content/course/tech-for-non-technical-founders-2026/weekly-dev-report-template-founders/index.md
+++ b/content/course/tech-for-non-technical-founders-2026/weekly-dev-report-template-founders/index.md
@@ -142,10 +142,7 @@ The bad report leans on soft verbs, passive voice, and unnamed actors because it
 ## Further reading
 
 - Atlassian, [How to Write an Effective Project Status Report](https://www.atlassian.com/work-management/project-management/status-reports) - the canonical reference on what status reports are for and where they fail.
-- DHH, [The One Person Framework](https://world.hey.com/dhh/the-one-person-framework-711e6318) - the Rails case for one full-stack developer shipping a feature end-to-end, which is why the five-section report fits on one page.
 - Marty Cagan, [Product Status Reports](https://www.svpg.com/product-status-reports/) - on why traditional status reports tell you nothing about whether the product is moving and what to ask for instead.
-- Will Larson via First Round Review, [Engineering leadership anti-patterns from Stripe, Uber, Carta](https://review.firstround.com/unexpected-anti-patterns-for-engineering-leaders-lessons-from-stripe-uber-carta/) - on the pull request funnel as the load-bearing signal in any status format.
 - Wes Kao, [How I give the right amount of context](https://newsletter.weskao.com/p/how-i-give-the-right-amount-of-context) - a practitioner reference on the discipline of writing one short, useful update a week.
-- Eric Ries via Lean Startup Co., [What Is an MVP?](https://leanstartup.co/resources/articles/what-is-an-mvp/) - the validated-learning framing that makes "what did we cut?" a real product question, not a comfort question.
 
 Built by JetThoughts as part of the [From Idea to First Paying Customer](/course/tech-for-non-technical-founders-2026/) curriculum.

--- a/docs/90-99-content-strategy/90.20-brick-and-claims-audit-2026-08-17-reference.md
+++ b/docs/90-99-content-strategy/90.20-brick-and-claims-audit-2026-08-17-reference.md
@@ -30,7 +30,35 @@ was flagged "3 of 3 duplicated" and is in fact correct as written.
 **Lesson for future audits: calibrate a new rule against the pages the human
 actually complained about before running it fleet-wide.**
 
-## Remaining: true bricks (>=700 chars) worth fixing
+## STATUS 2026-08-17 (second pass): tail closed
+
+All three deferred items are done:
+
+1. **`reference/hire-decision-full`** - all four build-path blocks converted
+   together to `Use when / This week / Cost / Watch for`.
+2. **Further reading** - every list on the course is now at <=4 external
+   sources. Systemic cause found: Veracode's GenAI report and DHH's
+   One-Person Framework had been pasted into ~8 unrelated lists as filler.
+   Also caught two pages the audit had skipped as "already fixed"
+   (`mvp-build-phases-full` at 9 items, `paid-pilot-full` at 6).
+3. **>=700-char bricks** - the non-narrative ones are converted (tables,
+   lists, blockquotes, one code fence). See the deliberate exceptions below.
+
+### Deliberate exceptions (do not "fix" these)
+
+- **`pivot-or-persevere-decision-framework` pivot taxonomy** (6 blocks,
+  lines 66-86): left as prose. Each block is a self-contained worked example
+  with its own numbers, all six share an italic lead (`*Right product, wrong
+  pricing.*`) so they already scan as a set, and only one exceeds 700 chars -
+  by 12. Converting one would break the set; converting all six to a table
+  would drop the examples that make them useful.
+- **`accept-story` paragraphs** (~54 in the companion shard, ~15 in M1-3,
+  ~30 in M4-5): narrative openers and founder incidents. They are supposed to
+  be paragraphs.
+
+The original audit tables are kept below for provenance.
+
+## Original audit: true bricks (>=700 chars)
 
 | page | line | chars | fix |
 |---|---|---|---|

--- a/docs/90-99-content-strategy/90.20-brick-and-claims-audit-2026-08-17-reference.md
+++ b/docs/90-99-content-strategy/90.20-brick-and-claims-audit-2026-08-17-reference.md
@@ -44,6 +44,20 @@ All three deferred items are done:
 3. **>=700-char bricks** - the non-narrative ones are converted (tables,
    lists, blockquotes, one code fence). See the deliberate exceptions below.
 
+### The two shell-audit decisions, resolved 2026-08-17
+
+Both were parked for owner judgment in PR #458. Both are **resolved as
+"keep the split"** - the altitude rule already answers them, because it names
+prompt text and click-by-click settings as exact mechanics that belong in the
+reference:
+
+- **2.2 ai-persona rehearsal Prompts 2-5**: split kept. The micro-lesson now
+  tells the learner to open the reference *beside* the page and paste from it,
+  instead of burying the pointer in a mid-sentence parenthetical.
+- **1.4 smoke-test campaign build**: no change needed. The page already says
+  "You will not have to figure out the ad on your own" and links the 7-setting
+  recipe directly - an explicit, reassuring deferral, not a blocking one.
+
 ### Deliberate exceptions (do not "fix" these)
 
 - **`pivot-or-persevere-decision-framework` pivot taxonomy** (6 blocks,


### PR DESCRIPTION
Closes every deferred item in `docs/90-99-content-strategy/90.20-brick-and-claims-audit-2026-08-17-reference.md`.

## 1. `hire-decision-full` - the atomic task

All four build-path blocks converted **together** to one skeleton (`Use when / This week / Cost / Watch for`). This is the task that had to be atomic: converting a single block last session left the page half-structured, so it was reverted and backlogged. Every fact and link preserved - path 2 keeps no Cost line because the source never stated one.

## 2. Further reading - 18 lists, all now ≤4 external sources

**The systemic cause:** Veracode's GenAI Code Security Report and DHH's One-Person Framework had been pasted into ~8 unrelated lists as filler - a container-image glossary, a standup page, an ownership page. Removing the boilerplate was most of the fix.

Other cuts: vendor pricing pages (lookups, all cited inline), duplicate essays (Cagan/Horowitz are the same Good-PM piece; Klement listed twice, once misattributed to Tom Kerwin), three Torres items reduced to one, and Blank's Customer Development Manifesto which appeared on three sibling pages.

`five-tech-words` now reads best: its four sources map 1:1 onto the words the page defines (Fowler refactoring, Cunningham tech debt, Ries MVP, Docker image).

**Also caught:** `mvp-build-phases-full` (9 items) and `paid-pilot-full` (6) were skipped by the audit as "already fixed" pages - their reading lists had never been checked.

## 3. Every ≥700-char non-narrative brick converted

13 pages: hallucination-rate stats → table, score bands → table, the Concierge-MVP wiring → code fence, healthy-vs-unhealthy tech debt → blockquote pair, ritual steps → lists, and so on.

**Deliberate exception** (documented, don't "fix" it): the `pivot-or-persevere` taxonomy stays prose. All six blocks share an italic lead so they already scan as a set, only one exceeds 700 chars - by 12 - and a table would drop the worked examples that make them useful. Converting one would break the set, the same trap as `hire-decision-full`.

`accept-story` paragraphs (~100 across the course) are also untouched: narrative openers are supposed to be paragraphs.

## Gates
hugo-build 8/8 per commit · qtest (content-only, nothing visual) · marketing-copy ratchet green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPY8ewGanoMnRToLeZJH24