### PR TITLE
Vault-ownership banners + corrected vault path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 **Coding posture**: activate `/ponytail:ponytail ultra` at session start and hold it — radical KISS/YAGNI, deletion over addition, shortest working diff, naive over clever. Applies to every code/config change in this repo.
 
+> **Head lives in the vault:** [[jt-business-os]] / [[jt-vibe-code-rescue]] — `~/Documents/pkm`
+>
+> Business goals, decisions, and bet status are owned in the vault — **not** in `docs/business/`.
+> Do not create a parallel opportunity portfolio here. Working papers under `docs/projects/` stay put.
+>
+> Read the vault note before changing goals or status here. Verified by `bin/check-repo-links` in the vault.
+
+
 **Type**: Hugo static site blog | **Build**: `bin/hugo-build`
 **Test**: `bin/qtest --changed` (per change — tests the pages your diff touches) / `bin/test --smoke` (fixed 17-test core net, ~50s / ~30s CI) / `bin/rake test:critical` (milestones) / `bin/test` + `bin/dtest` (PR prep). qtest and smoke are complementary, not redundant: qtest follows your diff, smoke is a constant basics check.
 **CSS**: PostCSS pipeline | **Content**: `content/blog/` (Markdown + Hugo frontmatter)

--- a/docs/business/index.md
+++ b/docs/business/index.md
@@ -2,6 +2,10 @@
 
 This folder is the **company**, not any single project. It holds the durable things that persist across every opportunity we pursue. Individual bets (like validating the Vibe Code Rescue opportunity) live under [`docs/projects/`](../projects/) and are governed by what's here.
 
+> **Ownership split (2026-08-14).** Identity/positioning and the bets are owned in the vault
+> (`jt-business-os` in `~/Documents/pkm`); `operating-system.md` and this index stay owned here, because the weekly numbers
+> live beside the tooling that produces them in `rescue-sprint/pipeline.md`.
+
 ## The three company documents
 
 | File | What it is |

--- a/docs/business/opportunity-portfolio.md
+++ b/docs/business/opportunity-portfolio.md
@@ -1,6 +1,11 @@
 # JetThoughts - Opportunity Portfolio
 
 **Owner**: Paul Keen (CEO) | **Scope**: company-level | **Updated**: 2026-07-22
+> **Owned by the vault** (2026-08-14). JT's bets are Projects under the `opp-jt-service-revenue`
+> Opportunity in `~/Documents/pkm`; this table reflects that spine rather than defining a second one. Maintaining
+> two portfolios is how the vault's recommended sequence and this repo's dated bet drifted apart.
+> Canonical: `jt-business-os`. The state machine below stays here — it is JT's convention, and the repo uses it.
+
 **What this is**: the bets JetThoughts is making to grow, which one is active, and how we decide to validate, kill, or scale each. Every bet becomes a project under [`docs/projects/`](../projects/) and is run by the [operating system](operating-system.md).
 
 ---

--- a/docs/business/vision-mission.md
+++ b/docs/business/vision-mission.md
@@ -1,3 +1,7 @@
+> **Owned by the vault** (2026-08-14). Identity and positioning are durable and channel-independent —
+> the same positioning must serve a book, jetthoughts.com, or any next channel, so it cannot live
+> only in this repo. Canonical: `jt-business-os` in `~/Documents/pkm`. Edit there, reflect here.
+>
 > DRAFT - company identity for Paul to review. Grounded in verifiable JT facts; keep claims defensible.
 
 # JetThoughts - Vision, Mission, Positioning


### PR DESCRIPTION
Lands the vault-ownership migration that had been sitting uncommitted, with the dead path corrected.

## What

CLAUDE.md and the three `docs/business/` files now state that business goals, decisions, and bet status are owned in the vault rather than this repo's mirror.

**Path fix applied while landing:** the three `docs/business/` banners pointed at `~/Documents/Play Tolaria/Getting Started`, which **does not exist on this machine**, while CLAUDE.md pointed at `~/Documents/pkm`, which does. All four now agree on `~/Documents/pkm`. Found by a Codex review; verified by checking both paths on disk.

## Known and unresolved (recorded so it isn't lost)

Landing this ships two contradictions that a follow-up needs to settle:

1. **Startup routers still point at the mirror.** `AGENTS.md:32`, `docs/workflows/BASE_HANDBOOK.md:21`, and `docs/workflows/flow-router.md:7` all route company-layer work to `docs/business/`. Agents following mandatory startup guidance will keep editing the mirror and recreate exactly the drift this change exists to stop. Fixing them *commits to the ownership split*, which is a call for whoever owns this migration.
2. **The vault notes carry stale facts.** `jt-business-os.md` has founding year **2011** and **"4.8/5 from 32 clients"** — the canon is 2008-09-01 with no review count. `jt-vibe-code-rescue.md` has frontmatter `state: postponed` against a body and repo portfolio that both say **Validating**. Making the vault canonical while it holds the 2011/32 claims risks laundering back the exact numbers `test/unit/marketing_copy_test.rb` exists to block.

## Gates

`bin/hugo-build` 8/8. Docs-only change — no content, templates, or CSS, so no visual suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPY8ewGanoMnRToLeZJH24