### PR TITLE
OKF: record the bet-park and target-suspension decisions

### DIFF
--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1,5 +1,25 @@
 # Bundle Update Log
 
+## 2026-08-17 (bet status) - Vibe Code Rescue Parked, Nov 30 suspended
+
+* **Parked until September 2026** (Paul). The vault frontmatter
+  (`state: postponed`) was correct and every "Validating" claim was stale - the
+  reverse of what the audit assumed. Fixed in the vault body,
+  `opportunity-portfolio.md`, `AGENTS.md` (which was routing agents into the
+  bet via "active bet ▶ START HERE") and `2607/strategy.md`.
+* **No bet is in Validating, by design.** Do not promote a candidate to keep
+  the slot warm.
+* **Nov 30 target SUSPENDED, not rescheduled.** KR1 was green (offer, partner,
+  pricing, booking link) while KR2-KR4 sat at zero and zero touches were ever
+  sent across four unparked weeks - the deadline was never the binding
+  constraint, execution was. A new date now would attach a schedule to unscoped
+  work. Set the target at the September restart instead.
+* **The Sep 30 mid-point gate is suspended and must be RE-SET, not dropped** -
+  it would have fired "≥3 calls else re-open ICP + channel" against a bet that
+  restarts *in* September, and it is what makes a re-plan falsifiable.
+* ~9 remaining "Nov 30" strings in `docs/projects/2607-*` and `2510-*` are
+  stale-by-decision; they get rewritten once, at restart, in one pass.
+
 ## 2026-08-17 (company-layer ownership settled) - vault vs repo vs canon
 
 * **New concept**: `workflows/company-layer-ownership.md` - the three-surface

--- a/.okf/workflows/company-layer-ownership.md
+++ b/.okf/workflows/company-layer-ownership.md
@@ -48,9 +48,20 @@ Aligned 2026-08-17: `AGENTS.md`, `docs/workflows/BASE_HANDBOOK.md`,
 `.agents/skills/async-first-communication/SKILL.md`. If a new doc tells an
 agent where company work lives, it must match this table.
 
-Still open: `jt-vibe-code-rescue.md` frontmatter says `state: postponed` while
-its body and `docs/business/opportunity-portfolio.md` both say **Validating**.
-Left for Paul - only he knows which is true.
+**Resolved 2026-08-17**: the frontmatter was right. Vibe Code Rescue is
+**Parked, postponed until September 2026** - the body and the repo portfolio
+were the stale side, and both now say Parked. This is the worked example of the
+ownership rule: the vault held the truth about bet status, and the repo was the
+mirror that had drifted. When the two disagree, the vault wins for status.
+
+Consequence, recorded in `docs/business/operating-system.md`: **no bet is in
+Validating** (intended - do not promote a candidate to fill the slot), and the
+**Nov 30 target is suspended, not rescheduled**. The evidence for suspending
+rather than moving it: KR1 was green while KR2-KR4 sat at zero and no outreach
+was ever sent, so the deadline was never the binding constraint. The new target
+is set at the September restart, together with a re-set of the Sep 30 mid-point
+gate (which must be re-set, not dropped - it is what makes a re-plan
+falsifiable).
 
 # Skills: we track only our own
 


### PR DESCRIPTION
Session wrap-up caught a gap: today's two biggest business decisions never reached the knowledge bundle, and `company-layer-ownership.md` still listed the bet status as *"left for Paul"* after he'd settled it.

- **`company-layer-ownership.md`** — question resolved, and it now reads as the worked example of the rule it documents: the vault held the truth about bet status, the repo mirror had drifted, **vault wins for status**.
- **`log.md`** — Parked until Sep 2026; **no bet in Validating by design**; Nov 30 suspended not rescheduled (with the evidence); the Sep 30 gate must be **re-set, not dropped**; ~9 stale `Nov 30` strings get one pass at restart.

A cold September session now gets the decision, the reasoning, and the restart checklist from the bundle alone — which is the whole point of the same-commit OKF rule.

## Gates
OKF `--strict` conformant · `bin/hugo-build` 8/8 · docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPY8ewGanoMnRToLeZJH24