### PR TITLE
P4 proof wiring: artifact links on outreach landing pages + fabricated-claims purge

### DIFF
--- a/.okf/log.md
+++ b/.okf/log.md
@@ -69,6 +69,28 @@
 * **Zero visual drift**: postcss-import@17 + hugo 0.165 produced no macOS or
   linux baseline shifts — all gates green (critical 53 shots, dtest 34, unit
   278, integration 11, smoke 17).
+## 2026-08-20 (P4 proof wiring + fabrication purge) - claims hide where text ratchets can't see
+
+* **Fabricated claims hid in two surfaces the banned-strings ratchet never
+  scans**: (1) *unrendered frontmatter* - emergency-cto-leadership carried 76
+  lines of fake credentials (CISSP, Harvard/Stanford training, invented
+  conferences, two fictional case studies) referenced by zero templates; (2)
+  *JSON-LD schema partials* - fake awards ("Forbes '30 CTOs to Watch' 2023"),
+  invented success-rate/team-size properties, and a fabricated street address
+  ("1234 Technology Blvd" + geo coords) served to Google as structured facts.
+  Both purged (PR #475). Lesson: a claims sweep must read frontmatter and
+  `partials/seo/*` too, not just rendered prose.
+* **`markdownify` strips the outer `<p>` for single-paragraph values** - the
+  services overview needed `<p>{{ .value | markdownify }}</p>` to keep the
+  `.fl-rich-text p` CSS working. Caught by the pre-commit reviewer, verified
+  by scratch build.
+* **Tenure now computed in the template** (`services/single.html`) from
+  `site.Params.foundingYear` for the "Years of Industry Experience" stat - six
+  pages had rotted to a hardcoded 17. The canon rule ("derive, never
+  hardcode") now has template enforcement on that stat.
+* Queued for a later canon sweep: `content/pages/clients/index.md:3` "540+
+  projects delivered" (mutated claim - 540+ is the articles count); the stat
+  template's "+" suffix rendering "95+" for percentage stats.
 
 ## 2026-08-17 (bet status) - Vibe Code Rescue Parked, Nov 30 suspended
 

--- a/content/pages/about-us/index.md
+++ b/content/pages/about-us/index.md
@@ -24,10 +24,10 @@ founder_expertise:
       value: "Our leadership team averages 12+ years of industry experience, with specializations in Ruby on Rails, React, startup MVP development, and fractional CTO services. We've contributed to 50+ open-source projects and published 540+ technical articles sharing our expertise with the developer community."
 
     - name: Industry Recognition
-      value: "Clutch Top Ruby on Rails Developers (2023-2024), featured in Forbes and Inc. Magazine for technical leadership, with 95% of clients continuing past their first engagement."
+      value: "Rated 4.8/5 on Clutch (clutch.co/profile/jetthoughts), with 95% of clients continuing past their first engagement and client relationships averaging five years."
 
     - name: Proven Track Record
-      value: "Delivered 200+ successful projects for startups and growing companies across healthcare, education, SaaS, and e-commerce sectors. Our clients achieve 89% fundraising success rate and 3x faster time-to-market compared to traditional development approaches."
+      value: "Since 2008 we have shipped production software for startups and growing companies across healthcare, education, SaaS, and e-commerce sectors - MVPs in 8-12 weeks where traditional agencies quote 24."
 
 about_us_block1:
   headline: Our Mission

--- a/content/services/app-web-development/index.md
+++ b/content/services/app-web-development/index.md
@@ -34,7 +34,7 @@ overview:
     - name: The Problem
       value: You raised funding and need a working product. Hiring a full-time team takes months. Most dev shops ship fast with AI-generated code and no tests - then your first real users break everything. You end up paying twice - once to build, once to fix.
     - name: How We’re Different
-      value: We write tests before code, review every pull request with two engineers, and send you a plain-English report every Friday. You own the code from day one. No lock-in, no surprises, milestone billing so you only pay for working software.
+      value: We write tests before code, review every pull request with two engineers, and send you a plain-English report every Friday. You own the code from day one - verify it yourself with our [code ownership checklist](/course/tech-for-non-technical-founders-2026/ownership-checklist/). No lock-in, no surprises, milestone billing so you only pay for working software.
     - name: What You Get
       value: A production-ready MVP in 8 weeks, built with Ruby on Rails by senior engineers averaging 8 years of experience. Test coverage above 70%, weekly demos, and a codebase your next CTO won’t need to rewrite.
   outcome:

--- a/content/services/emergency-cto-leadership/index.md
+++ b/content/services/emergency-cto-leadership/index.md
@@ -1,9 +1,9 @@
 ---
 
 title: "Rescue Your Failed Software Project | 48-Hour Response | JetThoughts"
-description: "Your dev shop failed. Your codebase is broken. We rescue startup projects in 48 hours - code audit, team stabilization, recovery plan. 40+ projects rescued."
+description: "Your dev shop failed. Your codebase is broken. We rescue startup projects in 48 hours - code audit, team stabilization, recovery plan."
 headline: Rescue Your Failed Software Project
-excerpt: Your dev shop missed every deadline, the code has no tests, and your investors are asking questions. We've rescued 40+ projects exactly like yours. Within 48 hours, a senior engineer audits your codebase and gives you a written recovery plan - what to fix, what to rewrite, and what it costs. No jargon, no surprises.
+excerpt: Your dev shop missed every deadline, the code has no tests, and your investors are asking questions. Within 48 hours, a senior engineer audits your codebase and gives you a written recovery plan - what to fix, what to rewrite, and what it costs. No jargon, no surprises.
 slug: emergency-cto-leadership
 author: Paul Keen
 cover_image: emergency-cto-leadership.jpg
@@ -38,91 +38,15 @@ overview:
     - name: The Crisis Response Imperative  
       value: "Technical disasters require immediate expert crisis intervention, not lengthy hiring processes. Every hour of ineffective response increases damage exponentially. You need someone who has navigated every type of technical catastrophe, can rapidly assess the damage, contain the crisis, stabilize shell-shocked teams, and execute battle-tested emergency recovery protocols under extreme pressure."
     - name: Our Emergency CTO Crisis Response
-      value: "Our emergency CTO crisis response delivers immediate disaster recovery with proven stabilization protocols. We've rescued startups from data breaches, team collapses, system meltdowns, and delivery disasters. Our rapid response focuses on damage containment, crisis communication, team stabilization, and systematic recovery execution - transforming technical catastrophes into survival stories. For prevention, our [startup CTO consulting](/services/fractional-cto/) builds resilient foundations that avoid these disasters."
+      value: "Our emergency CTO crisis response delivers immediate disaster recovery with proven stabilization protocols. We've rescued startups from data breaches, team collapses, system meltdowns, and delivery disasters. Our rapid response focuses on damage containment, crisis communication, team stabilization, and systematic recovery execution - transforming technical catastrophes into survival stories. For prevention, our [startup CTO consulting](/services/fractional-cto/) builds resilient foundations that avoid these disasters. Not sure your dev shop is failing yet? Run through our [dev shop red flags checklist](/blog/dev-shop-red-flags-checklist/) before it becomes an emergency."
   outcome:
     - name: Crisis Response Time (Hours)
       value: 48
-    - name: Team Confidence Recovery (Days)
-      value: 14
-    - name: Crisis Resolution Success Rate (%)
-      value: 87
+    - name: Client Retention (%)
+      value: 95
+    - name: Average Client Relationship (Years)
+      value: 5
 
-author_expertise:
-  headline: Crisis-Tested Emergency CTO Leadership Team
-  description: Our emergency CTO leaders have resolved 200+ critical technical crises, specializing in rapid stabilization and recovery.
-  crisis_lead:
-    name: Paul Keen
-    title: "Emergency CTO & Crisis Response Specialist"
-    experience: "12+ years in technical crisis management"
-    crisis_credentials:
-      - "200+ emergency CTO interventions successfully resolved"
-      - "48-hour average crisis stabilization time"
-      - "Former Chief Technology Officer at 3 high-growth startups"
-      - "Expert in team psychology during technical crises"
-      - "Certified in Crisis Management and Business Continuity"
-      - "Speaker at EmergencyJS, CTO Emergency Response Summit"
-    crisis_specialties:
-      - "Technical team exodus and knowledge transfer crises"
-      - "Security breach response and system recovery"
-      - "Performance catastrophes and system stabilization"
-      - "Pre-funding technical due diligence failures"
-      - "Mission-critical system failures and recovery"
-    emergency_metrics:
-      - "87% crisis resolution rate within first week"
-      - "95% client satisfaction during crisis periods"
-      - "Average team confidence restoration: 14 days"
-      - "Zero client business failures during engagement"
-
-emergency_response_credentials:
-  certifications:
-    - "CISSP (Certified Information Systems Security Professional)"
-    - "ITIL Expert in IT Service Management"  
-    - "AWS Disaster Recovery Specialist"
-    - "ISO 27035 Incident Management Certified"
-  
-  emergency_training:
-    - "Crisis Leadership and Decision Making (Harvard Business School)"
-    - "Technical Crisis Communication (Stanford Executive Education)"
-    - "Incident Command System (ICS-100)"
-    - "Business Continuity Professional (CBCP)"
-    
-  rapid_response_protocols:
-    - "24/7 emergency response hotline"
-    - "Pre-established technical assessment frameworks"
-    - "Crisis communication templates for stakeholders"
-    - "Emergency team mobilization within 4 hours"
-
-crisis_success_stories:
-  headline: Crisis Recovery Success Stories
-  description: Real emergency CTO interventions that saved companies from technical disasters.
-  featured_cases:
-    - crisis_type: "Complete Engineering Team Departure"
-      timeline: "3 weeks before Series A deadline"
-      challenge: "Entire 8-person development team resigned, leaving startup with broken deployment pipeline and no documentation"
-      intervention: 
-        - "Emergency knowledge transfer sessions with departing team"
-        - "Rapid hiring of interim development team"
-        - "System documentation and deployment recovery"
-        - "Stakeholder communication and investor confidence restoration"
-      results:
-        - "New team operational in 10 days"
-        - "Deployment pipeline restored in 5 days"
-        - "Successfully closed $8M Series A on schedule"
-        - "Zero code or data loss during transition"
-    
-    - crisis_type: "Security Breach & Data Compromise"
-      timeline: "Customer data at risk, 48-hour regulatory deadline"
-      challenge: "Database breach exposed 50,000 customer records, compliance violations threatened business license"
-      intervention:
-        - "Immediate system isolation and breach containment"
-        - "Forensic analysis and vulnerability assessment"
-        - "Regulatory compliance documentation and communication"
-        - "Customer notification and trust restoration plan"
-      results:
-        - "Breach contained within 8 hours"
-        - "Zero additional data compromise"
-        - "Compliance deadlines met with full documentation"
-        - "Customer retention rate maintained at 94%"
 
 created_at: 2025-01-12T14:30:00+00:00
 ---

--- a/content/services/react-development/index.md
+++ b/content/services/react-development/index.md
@@ -26,7 +26,7 @@ overview:
     - name: The Problem
       value: You raised funding, you need React work shipped, and you can't read the code yourself. The last shop quoted by the hour, sent vague Jira updates, and disappeared when bugs hit production. Your investors want a working demo. You don't know if the existing code can be saved or if you're throwing money at a rewrite that's already needed.
     - name: How We're Different
-      value: Two senior engineers review every pull request before it merges. We send a one-page report every Friday in plain English - what shipped, what broke, what's next. Code ownership transfers to your GitHub and your cloud accounts on day one, not at the end. Every contract has a termination clause, so if we miss two milestones, you walk with the code and no penalty.
+      value: Two senior engineers review every pull request before it merges. We send a one-page report every Friday in plain English - what shipped, what broke, what's next. Code ownership transfers to your GitHub and your cloud accounts on day one, not at the end. Every contract has a termination clause, so if we miss two milestones, you walk with the code and no penalty. Our [SOW reading guide](/course/tech-for-non-technical-founders-2026/sow-reading-guide/) shows the exact clause to look for in any contract.
     - name: What You Get
       value: A production React app or a rescued one, 70%+ test coverage, weekly demos that prove progress instead of describing it, and a codebase your next CTO won't ask you to throw away. If we can't ship what we promised, you get the work to date and your money back for what didn't ship.
   outcome:

--- a/content/use-cases/startup-mvp-prototyping-development/index.md
+++ b/content/use-cases/startup-mvp-prototyping-development/index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Expert Development Services for Startups: Accelerate Revenue Growth"
-description: "Startup MVP development in 8-12 weeks. Fractional CTO support, Rails/React expertise, 89% funding success rate. Launch faster without overspending ✓"
+description: "Startup MVP development in 8-12 weeks. Fractional CTO support, Rails/React expertise. Launch faster without overspending ✓"
 headline: Launch faster, go to market smarter
 excerpt: Gain market feedback, secure product validation, and accelerate the path to revenue without slowing down or going broke.
 slug: startup-mvp-prototyping-development
@@ -27,13 +27,13 @@ outcome:
 
 faqs:
   - question: "How long does it take to build a startup MVP with JetThoughts?"
-    answer: "Most startup MVPs take 8-12 weeks with our rapid development process. Week 1-2: Technical discovery and architecture planning with fractional CTO oversight. Week 3-8: Agile development with senior Rails/React developers (8+ years experience). Week 9-10: QA, deployment, and launch preparation. This delivers functional MVPs 3x faster than traditional 24-week agency timelines."
+    answer: "Most startup MVPs take 8-12 weeks with our rapid development process. Week 1-2: Technical discovery and architecture planning with fractional CTO oversight. Week 3-8: Agile development with senior Rails/React developers (8+ years experience). Week 9-10: QA, deployment, and launch preparation. This delivers functional MVPs in 8-12 weeks where traditional agencies quote 24."
 
   - question: "What's the cost of MVP development compared to hiring a full development team?"
     answer: "Our MVP development costs 50% less than hiring full-time developers. Typical MVP investment: $40K-80K over 8-12 weeks vs $120K-200K+ for 6-month full-time team hiring and development. You get immediate access to senior developers without recruiting costs, equity dilution, or long-term employment commitments."
 
   - question: "How do you ensure MVP quality while delivering quickly?"
-    answer: "We maintain quality through experienced team oversight (8+ years average developer experience), proven Rails/React architecture patterns, continuous code review, automated testing, and fractional CTO strategic guidance. Our 95% client retention rate reflects consistent quality delivery across 200+ successful projects."
+    answer: "We maintain quality through experienced team oversight (8+ years average developer experience), proven Rails/React architecture patterns, continuous code review, automated testing, and fractional CTO strategic guidance. Our 95% client retention rate reflects consistent quality delivery."
 
 created_at: 2022-10-17T08:30:34+00:00
 ---
@@ -84,7 +84,7 @@ With 18+ years of startup development experience, JetThoughts provides a proven 
 ## Quantified Results for Startup MVPs
 
 **Time to Market**:
-- ⏱️ **3x faster delivery**: 8-12 weeks average vs 24 weeks traditional agencies
+- ⏱️ **Faster delivery**: 8-12 weeks average vs 24 weeks traditional agencies
 - 🚀 **48-hour start**: Team onboarding and project kickoff within 2 days
 - 📅 **Weekly milestones**: Visible progress every sprint with working software
 
@@ -99,9 +99,9 @@ With 18+ years of startup development experience, JetThoughts provides a proven 
 - 🔒 **Zero critical security issues**: Security-first development prevents costly post-launch fixes
 
 **Business Impact**:
-- 📈 **89% funding success rate**: Startups we've helped successfully raised seed/Series A
+- 📈 **Funding-ready delivery**: MVPs built to survive technical due diligence at seed/Series A
 - 👥 **Average 5-year client relationships**: Long-term partnerships support growth beyond MVP
-- 🏆 **200+ successful projects**: Proven track record across diverse startup sectors
+- 🏆 **Shipping since 2008**: Startups across healthcare, education, SaaS, and e-commerce
 
 **Real Startup Example**:
 - **Before**: 6 months attempting to hire developers, no progress on product
@@ -115,6 +115,6 @@ We've helped startups across healthcare, education, SaaS, and e-commerce transfo
 - **Technical Expertise**: 18+ years Rails experience, 540+ published technical articles
 - **Startup Focus**: Specialized processes for rapid MVP development and validation
 - **Fractional CTO Services**: Strategic guidance without full-time executive costs
-- **Proven Results**: 89% fundraising success, 95% client retention, 3x faster delivery
+- **Proven Results**: 95% client retention, MVPs in 8-12 weeks vs the traditional 24
 
 ...ensures your startup achieves product-market fit faster while building technical foundations that support long-term growth from pre-seed through Series A and beyond.

--- a/themes/beaver/layouts/partials/seo/comprehensive-service-schema.html
+++ b/themes/beaver/layouts/partials/seo/comprehensive-service-schema.html
@@ -100,23 +100,9 @@
   )
 -}}
 
-{{/* Build conditional property values based on service type */}}
-{{- $projectDuration := "3-6 months" -}}
-{{- $successRate := "92%" -}}
-{{- $responseTime := "24 hours" -}}
-{{- $teamSize := "2-4 consultants" -}}
-
-{{- if in .Title "CTO" -}}
-  {{- $projectDuration = "6-12 months" -}}
-  {{- $successRate = "95%" -}}
-{{- else if in .Title "Emergency" -}}
-  {{- $projectDuration = "2-8 weeks" -}}
-  {{- $successRate = "87%" -}}
-  {{- $responseTime = "48 hours" -}}
-  {{- $teamSize = "3-5 experts" -}}
-{{- else if in .Title "Development" -}}
-  {{- $teamSize = "5-10 developers" -}}
-{{- end -}}
+{{/* Response time is the published offer promise; other per-service metrics were
+     unsourced and removed per claims canon (no number without an in-repo source) */}}
+{{- $responseTime := cond (in .Title "Emergency") "48 hours" "24 hours" -}}
 
 {{- $serviceSchema = merge $serviceSchema (dict
   "additionalProperty" (slice
@@ -135,27 +121,9 @@
     )
     (dict
       "@type" "PropertyValue"
-      "name" "Average Project Duration"
-      "value" $projectDuration
-      "description" (printf "Typical engagement timeline for %s projects" (lower $serviceType))
-    )
-    (dict
-      "@type" "PropertyValue"
-      "name" "Success Rate"
-      "value" $successRate
-      "description" "Project success rate based on defined client objectives and deliverable completion"
-    )
-    (dict
-      "@type" "PropertyValue"
       "name" "Response Time"
       "value" $responseTime
       "description" "Initial consultation and project assessment response time"
-    )
-    (dict
-      "@type" "PropertyValue"
-      "name" "Team Size"
-      "value" $teamSize
-      "description" (printf "Typical team size assigned to %s projects" (lower $serviceType))
     )
   )
   "knowsAbout" (slice
@@ -169,11 +137,6 @@
     $serviceType
   )
   "slogan" "Technology leadership that scales with your growth"
-  "award" (slice
-    "Clutch Top Technology Consultant 2024"
-    "Inc. Magazine Technology Leadership Award"
-    "Featured in Forbes '30 CTOs to Watch' 2023"
-  )
 ) -}}
 
 {{/* Primary Service Schema using jsonify */}}

--- a/themes/beaver/layouts/partials/seo/enhanced-organization-schema.html
+++ b/themes/beaver/layouts/partials/seo/enhanced-organization-schema.html
@@ -28,10 +28,7 @@
   
   "address": {
     "@type": "PostalAddress",
-    "addressCountry": "US",
-    "addressLocality": "Fort Lauderdale",
-    "addressRegion": "FL",
-    "postalCode": "33301"
+    "addressCountry": "US"
   },
   
   "contactPoint": [

--- a/themes/beaver/layouts/partials/seo/shared/organization-data.html
+++ b/themes/beaver/layouts/partials/seo/shared/organization-data.html
@@ -26,16 +26,7 @@
   )
   "address" (dict
     "@type" "PostalAddress"
-    "streetAddress" "1234 Technology Blvd"
-    "addressLocality" "Fort Lauderdale"
-    "addressRegion" "FL"
-    "postalCode" "33301"
     "addressCountry" "US"
-  )
-  "geo" (dict
-    "@type" "GeoCoordinates"
-    "latitude" "26.1224"
-    "longitude" "-80.1373"
   )
   "contactPoint" (slice
     (dict

--- a/themes/beaver/layouts/services/single.html
+++ b/themes/beaver/layouts/services/single.html
@@ -190,7 +190,7 @@
                                       data-node="dfqgrol9zs2j">
                                       <div class="fl-module-content">
                                         <div class="fl-rich-text">
-                                          <p>{{ .value }}</p>
+                                          <p>{{ .value | markdownify }}</p>
                                         </div>
                                       </div>
                                     </div>
@@ -224,6 +224,11 @@
                         class="fl-col-group fl-col-group-custom-width"
                         data-node="28twkcfhlqbp">
                         {{ range .Page.Params.overview.outcome }}
+                          {{/* tenure derives from foundingYear (claims canon) — frontmatter values rot */}}
+                          {{ $statValue := .value }}
+                          {{ if eq .name "Years of Industry Experience" }}
+                            {{ $statValue = sub now.Year (int site.Params.foundingYear) }}
+                          {{ end }}
                           <div
                             class="fl-col service-stat fl-col-small fl-col-small-custom-width"
                             data-node="26tqf1ykpsiv">
@@ -236,8 +241,8 @@
                                     <p>
                                       <span
                                         class="counter-value active"
-                                        data-count="{{ .value }}"
-                                        >{{ .value }}</span
+                                        data-count="{{ $statValue }}"
+                                        >{{ $statValue }}</span
                                       >+
                                     </p>
                                   </div>


### PR DESCRIPTION
## Summary

Executes the remaining scope of 20.09 §11 (P4 — close the proof gap on the pages outreach lands on). The cliché kill (§11.6-1) and Clutch linking (§11.6-3) had already shipped in #454; this PR delivers the proof-WIRING and a fabricated-claims purge the audit uncovered along the way.

## Proof wiring (§11.6-2)
| Claim | Now links to |
|---|---|
| "You own the code from day one" (app-web-development) | course ownership-checklist |
| Termination clause (react-development) | course sow-reading-guide |
| Rescue prevention (emergency-cto-leadership) | blog dev-shop-red-flags-checklist |

Enabler: `services/single.html` overview values render via `markdownify` inside the original `<p>` wrapper — this also fixes a live defect (a raw `[markdown](link)` rendered literally on the rescue page).

## Fabricated-claims purge (claims canon)
- Removed everywhere touched: "40+ projects rescued", "200+ successful projects", "89% fundraising success", "3x faster" (incl. FAQ schema), "featured in Forbes and Inc." (no source exists in-repo).
- emergency-cto-leadership: **76 lines of unrendered fabricated frontmatter deleted** — fake CISSP/Harvard/Stanford credentials, invented conference names, two fictional case studies. Verified referenced by zero templates.
- JSON-LD schema partials: fake awards ("Forbes '30 CTOs to Watch' 2023", "Inc. Magazine Technology Leadership Award"), invented Success-Rate/Duration/Team-Size properties, and a fabricated street address + geo coords ("1234 Technology Blvd") removed. These were served to Google as structured facts.
- "Years of Industry Experience" stat now computed from `site.Params.foundingYear` (six pages had stale hardcoded 17; canon forbids hardcoded tenure).

## Review (4-eyes)
- **p4-reviewer** (correctness): APPROVE after 1 blocking fix (the `<p>` wrapper — applied) + consistency decision (remaining "3x faster" purged — applied). Verified canon compliance, link resolution, no dangling schema refs, nothing true deleted.
- **p4-coldeyes** (ICP/voice): PASS with 3 fixes — all applied (link moved to prevention beat, intimacy claim cut, run-on split).

## Gates
- `bin/hugo-build` ✓ (×3)
- `bin/qtest --changed` ✓ ×2 (before and after the wrapper fix): 34 runs / 0 failures / 53 screenshots clean

## Follow-ups (queued, not here)
- `content/pages/clients/index.md:3` "540+ projects delivered" — mutated claim (540+ is the articles count); canon sweep.
- Stat template's "+" suffix renders "95+" for percentage stats — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)