### PR TITLE
LinkedIn: applied-AI short-insight post type + comment-engagement motion

### DIFF
--- a/docs/workflows/linkedin-post-pipeline.md
+++ b/docs/workflows/linkedin-post-pipeline.md
@@ -211,6 +211,24 @@ The campaign tests 5 hypotheses (see validation plan). Not every post needs to t
 
 Without H5, the validation plan loses one mechanic. The trade-off was made consciously on 2026-05-09 in favor of authentic posting.
 
+## Applied-AI short insights + comment engagement (Paul, 2026-08-20)
+
+Two standing additions to the cadence:
+
+1. **Short-insight posts on the applied-AI wedge** are a recurring post type
+   (personal lane, build-in-public pillar): one concrete observation from
+   Paul's actual AI-assisted operation (an agent decision, a review catch, a
+   tool built), ~100-150 words, peer-question close. Same voice gates as every
+   post; specifics must come from real session/work material, never invented.
+   First instance: `linkedin-posts/personal/bip-agents-cancelled-own-backlog.md`.
+2. **Comment engagement rides every posting day**: alongside the post, Paul
+   (or an agent drafting for his review) engages substantively in **1-2
+   relevant threads** (founders posting about dev-shop pain, broken AI builds,
+   hiring dilemmas). Rationale (Paul): comments generate more inbound than
+   posts alone. Draft rules for comments = same voice gates, no links, no
+   pitch; add value in the thread's own terms. Agents may pre-select threads
+   and draft comments; posting stays with Paul.
+
 ---
 
 ## Frontmatter format

--- a/linkedin-posts/personal/bip-agents-cancelled-own-backlog.md
+++ b/linkedin-posts/personal/bip-agents-cancelled-own-backlog.md
@@ -1,0 +1,37 @@
+---
+title: "My AI agents cancelled half of their own to-do list"
+lane: personal
+pillar: build-in-public
+author: paul-keen
+voice: personal-first-person
+icp_test: Does "the review layer, not the output, is where applied AI pays" land with founders running AI tools - and do they share what their AI talked them out of?
+image: ""
+first_comment: |
+  (value post - no link; reply-CTA only)
+utm_campaign: ""
+utm_content: bip_agents_cancelled_own_backlog
+status: draft
+stage: next
+proposed_for: ""
+notes: |
+  Post type: SHORT INSIGHT on the applied-AI wedge (new type, Paul 2026-08-20:
+  "post one short insight on your applied-AI wedge... and engage in 1-2 relevant
+  threads"). All specifics real, from the 2026-08-20 session: agents triaged a
+  6-item queue and killed 3 as already-done/policy-blocked (one deferred by a
+  decision recorded the previous day); a reviewer agent found 3 blocking defects
+  in another agent's PR before merge. Register B, no credential stamps, peer
+  question close. AI self-score: 1/10 (one borderline aphoristic beat-5 line,
+  "confident waste at machine speed" - kept, it carries the insight).
+---
+
+Today my AI agents cancelled half of their own to-do list.
+
+I asked them to work through the backlog. Instead of executing top to bottom, they checked each item against decisions already on file. Three of six were already done or no longer worth doing - one had been explicitly rejected the day before.
+
+Doing them anyway would have looked great. A burned-down queue, green checks, and all of it waste.
+
+The same morning, a second agent reviewed the first one's pull request and found three real problems before anything merged. That review step is the part of my AI setup I'd keep if I had to drop everything else.
+
+Running AI without something positioned to say no gets you confident waste at machine speed.
+
+What's the last thing your AI talked you out of?


### PR DESCRIPTION
## Summary

Executes Paul's 2026-08-20 directive: "post one short insight on your applied-AI wedge (comments generate more inbound than posts alone) and engage in 1-2 relevant threads."

- **New draft** `linkedin-posts/personal/bip-agents-cancelled-own-backlog.md` (status: draft) — every specific is real from today's session (agents cancelled 3 of 6 backlog items against recorded decisions; a reviewer agent caught 3 blocking PR defects pre-merge). Voice gates: no credential stamps, no CTA, no em dashes, AI self-score 1/10; reflexion self-critique run pre-handback.
- **Pipeline doc**: records the short-insight post type and the standing comment-engagement motion (1-2 substantive thread comments per posting day; agents pre-select + draft, posting stays with Paul).

Docs + drafts only — no content/, themes/, or CSS; content gates only.

Review the draft: `/linkedin/personal/bip-agents-cancelled-own-backlog/` on a dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)