### PR TITLE
Rescue page: stack-agnostic intake + restore the founder's actual words

### DIFF
--- a/themes/beaver/layouts/page/vibe-code-rescue.html
+++ b/themes/beaver/layouts/page/vibe-code-rescue.html
@@ -64,7 +64,7 @@
           <figcaption>- founder, IndieHackers</figcaption>
         </figure>
         <figure class="vcr-quote">
-          <blockquote>&ldquo;Vibe coding gave me a product. It also gave me a problem I couldn't fix.&rdquo;</blockquote>
+          <blockquote>&ldquo;Vibe coding gave me a product. It also gave me a problem I'm still paying for.&rdquo;</blockquote>
           <figcaption>- founder, r/startups</figcaption>
         </figure>
         <figure class="vcr-quote">
@@ -79,6 +79,7 @@
         <h2 class="vcr-h2">Step 1 - Free Rescue Context Call + AI-Intensive Audit</h2>
         <p class="vcr-step1-sub">45 minutes + 48-hour scorecard</p>
         <p>Book a 45-minute context call. We use that time to understand your business pain and collect read-only access to your code, task board, and dev chats.</p>
+        <p>The audit reads whatever you have - a Lovable, Bolt, or v0 build, React on a Firebase backend, or the code a dev shop left behind. If it runs, we can read it. If the verdict is salvage, we stabilize it in the stack it's already in; if it's rebuild, we rebuild on Rails.</p>
         <p>Then our team runs an intensive, AI-assisted technical due diligence offline. Within <strong>48 hours</strong> you get a <strong>one-page, plain-English scorecard</strong>: what's solid, what's fragile, whether to salvage or rebuild, and the exact next step.</p>
         <p><strong>You keep the scorecard whether or not we work together.</strong> No contract, and no follow-up calls you didn't ask for.</p>
         <a class="vcr-cta" href="{{ $booking }}">Book your free Rescue Context Call</a>


### PR DESCRIPTION
## Summary

Implements the CEO stack decision (2026-08-20, recorded in vault `jt-business-os` §Positioning): **audit is stack-agnostic; delivery = salvage-their-stack or rebuild-on-Rails; marketing stays Rails-authority; no new stack pages.**

### Changes (2 surgical edits, one template)
1. **Step-1 audit section** gains one sentence: the audit reads any stack (Lovable/Bolt/v0, React+Firebase, dev-shop leftovers) with the two-path verdict stated plainly. A non-technical founder with a Lovable build now sees their tool named and knows they qualify.
2. **Misquote fixed on the live page**: the testimonial "a problem I couldn't fix" was fabricated — the founder wrote "a problem I'm still paying for" (verified at source in the #29 re-audit, which fixed 5 docs files but missed this rendered template). The live landing page was quoting words a real founder never wrote.

### Review + gates
- Cold-eyes ICP/voice review: PASS, no changes
- `bin/hugo-build` green; rendered output greps verified (misquote gone, new sentence present)
- `bin/qtest --changed`: 34 runs / 0 failures / 53 screenshots clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)