### PR TITLE
40.01: re-point the engagement after-clock at the rebuild SHA

### DIFF
--- a/.okf/log.md
+++ b/.okf/log.md
@@ -2311,3 +2311,23 @@ lands in several merges, the marker has to name the LAST one that changes the
 thing being measured - and the tell that it's stale is the doc still
 describing its own scope in the old phase language ("the before for phases
 2.1+2.2" when the pivot had already made it the before for the whole blog).
+
+## 2026-08-20 - I parked GA4 work on Paul twice; the UI was always reachable
+
+PR #495 (another session) marked `contact_cta_click` a key event through the
+GA4 UI and recorded the path. That falsifies something I told Paul twice today
+and wrote into 2608 twice: that the key-event toggles were "console-only,
+yours". They are agent-doable - Admin -> Data display -> Events -> Create
+event -> "Create with code" needs no API and no already-received data. Both
+claims corrected in the plan and README.
+
+The generalisable failure is not about GA4. I inferred a capability limit from
+the tool I happened to reach for (the read-only Data API) and reported it as a
+property of the task. A parked item is a gate that never opens, so the cost is
+not a wrong sentence - it is work that silently stops. Same shape as the
+already-recorded rule about checking tool reach before routing to Paul; this
+extends it past tools to interfaces: exhaust the UI before declaring blocked.
+
+Still genuinely open and now correctly owned by 2608 Phase 0.1, not Paul:
+`page_view` is still marked a key event, so 4,063 page views read as
+conversions and bury any real one.

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -2295,3 +2295,19 @@ mobileWidth/mobileSizes/loading params), `architecture/blog-list-page.md`
 (shared partials + the dev-kind, date-fallback and string-tags traps),
 `build/test-gates.md` (bin/record-baselines replaces the manual re-record).
 
+## 2026-08-20 - Blog rebuild fully merged; measurement clock re-pointed
+
+All three blog merges landed: `f80de8088` (index + tag pages), `f3f9353b6`
+(Phase 0 instrumentation + bin/record-baselines) and `e1fa5409d` (the post
+template rebuild). 40.01's ship marker still named the FIRST of those as the
+after-clock trigger, which would have started the 28-day window against a
+blog that was still two-thirds old - the exact error the whole-blog pivot was
+meant to avoid. Re-pointed at `e1fa5409d`, and the read date is now derived
+from the actual deploy rather than pinned to a guessed 2026-09-17, since a
+delayed deploy shifts the window rather than shortening it.
+
+Worth generalising: a "ship marker" written mid-sprint ages badly. When work
+lands in several merges, the marker has to name the LAST one that changes the
+thing being measured - and the tell that it's stale is the doc still
+describing its own scope in the old phase language ("the before for phases
+2.1+2.2" when the pivot had already made it the before for the whole blog).

--- a/.okf/workflows/analytics-access.md
+++ b/.okf/workflows/analytics-access.md
@@ -161,6 +161,22 @@ conversion is buried under thousands of page-view "conversions". Un-marking
 `page_view` was deliberately **not** done here - it changes how a headline
 metric reads and belongs to 2608 Phase 0.1, not to this request.
 
+### Which browser channel you have decides whether it's doable *this session*
+
+Follow-up to the above, 2026-08-20: the UI path is right, but it needs an
+**authenticated** browser. Two channels exist and they are not equivalent:
+
+| Channel | GA session |
+|---|---|
+| `claude-in-chrome` extension | drives Paul's real Chrome - **signed in**, this is the one that worked for #495 |
+| `chrome-devtools` MCP | a separate Chrome-for-Testing profile - **signed out**; `analytics.google.com` redirects to `accounts.google.com` |
+
+If the extension reports "Browser extension is not connected", the GA UI is
+genuinely out of reach for that session and the honest report names *that*
+(with the fix: connect the extension / restart Chrome), not "console-only,
+Paul's". Never sign in to reach it - entering credentials is prohibited, and
+the block is the channel, not the task.
+
 ### Marking a key event is an agent-doable UI task, not an Admin-API task
 
 Recorded because the opposite was asserted twice in one session. The read-only

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.01-rollout-plan.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.01-rollout-plan.md
@@ -65,6 +65,16 @@ start accumulating before the revisit threshold is ever met.
 production, before Phase 1a starts. No sampling window needed — either it fires
 or it does not.
 
+**The key-event toggles are NOT "Paul's console-only work"** — this plan said
+so twice and it was wrong (corrected 2026-08-20 after PR #495 marked
+`contact_cta_click` through the browser). The read-only Data API cannot mark
+key events, but the task never needed an API: **Admin → Data display → Events →
+Create event → "Create with code"** takes an event name plus a Mark-as-key-event
+toggle and needs no already-received data. Two dialog traps: it pre-selects a
+$1 default key-event value (set it to "don't set", or every click books phantom
+revenue), and the counting method stays "Once per event". Generalised rule:
+exhaust the UI before declaring something blocked.
+
 ### 0.2 `bin/record-baselines <path>...`
 
 Already a named automation candidate in `CLAUDE.md`; done by hand three times on

--- a/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
+++ b/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
@@ -1,11 +1,16 @@
-# 40.01 — Blog engagement baseline (the "before" for phases 2.1+2.2)
+# 40.01 — Blog engagement baseline (the "before" for the whole-blog rebuild)
 
 **Recorded:** 2026-08-20, Clarity project `xum05dgnec` (bot-filtered), pages
 under `/blog/`.
-**Ship marker:** phases 2.1+2.2 merged to master `f80de8088` at 14:35 UTC,
-2026-08-20. **The "after" clock starts at the first successful production
-deploy of that SHA or later** — deploys were being managed by another session
-at merge time; confirm the live-date before reading.
+**Ship marker:** the rebuild landed in three merges on 2026-08-20 —
+`f80de8088` (2.1: index + tag pages, 14:35 UTC), `f3f9353b6` (Phase 0:
+instrumentation + tooling, 16:29 UTC) and **`e1fa5409d` (2.2b: the post
+template rebuild, 17:16 UTC)**. Per Paul's 2026-08-20 pivot the read covers
+the rebuilt blog as a WHOLE, so **the "after" clock starts at the first
+successful production deploy of `e1fa5409d` or later** — not the earlier
+two. Deploys were being managed by another session at merge time; confirm
+the live-date before reading, and do not start counting from the merge
+timestamps above.
 
 ## The baseline — and why it is three windows, not one
 
@@ -43,4 +48,6 @@ pre/post read on a single short window would be noise dressed as a result.
    numbers. Per 20.01: an unwritten result blocks the homepage/chrome phases;
    a flat result does not.
 
-**Read due: 2026-09-17.**
+**Read due:** 28 days after the `e1fa5409d` deploy date (≈2026-09-17 if it
+deploys same-day; re-date from the actual deploy, since a delayed deploy
+shifts the whole window rather than shortening it).

--- a/docs/projects/2608-site-design-system/README.md
+++ b/docs/projects/2608-site-design-system/README.md
@@ -45,7 +45,7 @@ engagement** vs site avg 33–40% / 28–34s.
 
 | Phase | What | Gate | Status |
 |---|---|---|---|
-| 0 (slim) | record-baselines wrapper, blog scroll/CTA events, coverage, baseline doc | events verified firing | **PR #489** (GA4 admin steps manual) |
+| 0 (slim) | record-baselines wrapper, blog scroll/CTA events, coverage, baseline doc | events verified firing | **merged #489**; GA4 key-event toggles are agent-doable via the GA4 UI (see #495), not Paul's |
 | 2.1 | `blog-list` restyle + tag pages | A + B + C | **shipped 2026-08-20** (PR pending) |
 | 2.2 | posts: article-end CTA, ink tags (measure/full-bleed/code-ink deferred to 1a) | A + B + C | **shipped 2026-08-20** (PR pending) |
 | 2.2b | **Whole-blog rebuild** (post template: full-bleed cover, ink code blocks, meta-above-title; mobile covers on lists) | A + C | **in progress** (Paul 2026-08-20: no measure gates) |


### PR DESCRIPTION
Docs-only. Caught by a scheduled `/okf:okf maintain` tick.

The blog rebuild landed in **three** merges today — `f80de8088` (index + tag
pages), `f3f9353b6` (Phase 0 instrumentation + tooling), `e1fa5409d` (the post
template rebuild). `40.01`'s ship marker still named the **first** as the
after-clock trigger, so the 28-day engagement window would have started
measuring a blog that was still two-thirds old — precisely the error the
whole-blog measurement pivot was meant to avoid.

- After-clock re-pointed at **`e1fa5409d`** (last merge that changes the
  measured thing).
- Read date now derived from the actual deploy rather than pinned to a guessed
  2026-09-17 — a delayed deploy shifts the window, it doesn't shorten it.
- Title/scope updated from "the before for phases 2.1+2.2" to "for the
  whole-blog rebuild", matching the pivot.

Generalised in `.okf/log.md`: a ship marker written mid-sprint ages badly, and
the tell that it's stale is the doc still describing its own scope in
pre-pivot phase language.

`bin/hugo-build` green; OKF conformant under `--strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)