### PR TITLE
P0: recover #2 organic page from a 404, fix unbootable published configs + broken sample code

### DIFF
--- a/content/blog/falcon-web-server-async-ruby-production/index.md
+++ b/content/blog/falcon-web-server-async-ruby-production/index.md
@@ -27,7 +27,7 @@ bundle install
 bundle exec falcon serve --bind http://0.0.0.0:3000
 ```
 
-For Rails, add `gem 'falcon'` to the production group, then point your process manager at `bundle exec falcon --config config/falcon.rb serve`. A minimal `config/falcon.rb` is in the [Rails Integration](#rails-integration) section below.
+For Rails, add `gem 'falcon'` to the production group, then point your process manager at `bundle exec falcon host`, which reads a `falcon.rb` service file from the application root. A minimal one is in the [Rails Integration](#rails-integration) section below.
 
 The rest of this post covers architecture, benchmarks against Puma and Unicorn, production configuration (systemd, Docker, Kubernetes), migration steps, and monitoring.
 
@@ -259,7 +259,7 @@ $ falcon serve
 $ falcon serve --bind http://0.0.0.0:3000
 
 # Custom configuration
-$ falcon --config config/falcon.rb serve
+$ bundle exec falcon host
 ```
 
 ### Rails Integration
@@ -284,7 +284,7 @@ Configure Falcon for Rails:
 
 ```ruby
 # config/falcon.rb
-#!/usr/bin/env falcon serve --config
+#!/usr/bin/env falcon-host
 
 load :rack
 
@@ -363,7 +363,7 @@ Running Falcon in production requires careful configuration for optimal performa
 
 ```ruby
 # config/falcon.rb
-#!/usr/bin/env falcon serve --config
+#!/usr/bin/env falcon-host
 
 load :rack
 
@@ -445,7 +445,7 @@ WorkingDirectory=/var/www/myapp
 Environment=RAILS_ENV=production
 EnvironmentFile=/var/www/myapp/.env.production
 
-ExecStart=/usr/local/bin/bundle exec falcon --config config/falcon.rb serve
+ExecStart=/usr/local/bin/bundle exec falcon host
 ExecReload=/bin/kill -USR2 $MAINPID
 
 Restart=always
@@ -511,7 +511,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD curl -f http://localhost:3000/health || exit 1
 
 # Start server
-CMD ["bundle", "exec", "falcon", "--config", "config/falcon.rb", "serve"]
+CMD ["bundle", "exec", "falcon", "host"]
 ```
 
 ### Kubernetes Deployment
@@ -657,7 +657,7 @@ ab -n 1000 -c 50 http://localhost:9292/
 
 ```ruby
 # config/falcon.rb for staging
-#!/usr/bin/env falcon serve --config
+#!/usr/bin/env falcon-host
 
 load :rack
 
@@ -709,7 +709,7 @@ environment ENV.fetch("RAILS_ENV", "development")
 preload_app!
 
 # After: config/falcon.rb
-#!/usr/bin/env falcon serve --config
+#!/usr/bin/env falcon-host
 
 load :rack
 
@@ -734,7 +734,7 @@ timeout 30
 preload_app true
 
 # After: config/falcon.rb
-#!/usr/bin/env falcon serve --config
+#!/usr/bin/env falcon-host
 
 load :rack
 

--- a/content/blog/falcon-web-server-async-ruby-production/index.md
+++ b/content/blog/falcon-web-server-async-ruby-production/index.md
@@ -780,7 +780,7 @@ config.middleware.use PerformanceMonitor if Rails.env.production?
 
 ## Real-World Use Cases
 
-Three patterns where Falcon's fiber model genuinely changes the architecture, with code you can adapt.
+Three patterns where Falcon's fiber model changes the architecture, with code you can adapt.
 
 ### High-Concurrency API Server
 

--- a/content/blog/falcon-web-server-async-ruby-production/index.md
+++ b/content/blog/falcon-web-server-async-ruby-production/index.md
@@ -265,14 +265,16 @@ $ bundle exec falcon host
 
 ### Rails Integration
 
-For Rails applications, Falcon works as a drop-in replacement for Puma, and it configures the one setting that matters on your behalf. Its [Railtie](https://github.com/socketry/falcon/blob/main/lib/falcon/railtie.rb) sets this unconditionally at boot:
+For Rails applications, Falcon works as a drop-in replacement for Puma, and it configures the setting most migration guides tell you to add. Its [Railtie](https://github.com/socketry/falcon/blob/v0.57.0/lib/falcon/railtie.rb) sets this whenever Falcon is loaded:
 
 ```ruby
-# what Falcon's Railtie already does for you - you do not add this
+# Falcon's Railtie sets this for you wherever the gem is loaded
 config.active_support.isolation_level = :fiber
 ```
 
-That scopes per-request state - `CurrentAttributes`, ActiveRecord connection leases - to the fiber rather than the thread. Size `pool:` in `config/database.yml` against the concurrency you expect; that one is your job.
+That scopes per-request state - `CurrentAttributes`, ActiveRecord connection leases - to the fiber rather than the thread. One caveat if you keep `falcon` in the production group only: in development the Railtie never loads, so the isolation level stays `:thread` there.
+
+The setting that is your job is `pool:` in `config/database.yml`, sized against the concurrency you expect rather than a thread count.
 
 Configure Falcon for Rails:
 

--- a/content/blog/falcon-web-server-async-ruby-production/index.md
+++ b/content/blog/falcon-web-server-async-ruby-production/index.md
@@ -265,16 +265,14 @@ $ bundle exec falcon host
 
 ### Rails Integration
 
-For Rails applications, Falcon works as a drop-in replacement for Puma:
+For Rails applications, Falcon works as a drop-in replacement for Puma, and it configures the one setting that matters on your behalf. Its [Railtie](https://github.com/socketry/falcon/blob/main/lib/falcon/railtie.rb) sets this unconditionally at boot:
 
 ```ruby
-# config/application.rb
-Rails.application.configure do
-  # Scope per-request state (CurrentAttributes, AR connection leases)
-  # to the fiber rather than the thread. Required under Falcon.
-  config.active_support.isolation_level = :fiber
-end
+# what Falcon's Railtie already does for you - you do not add this
+config.active_support.isolation_level = :fiber
 ```
+
+That scopes per-request state - `CurrentAttributes`, ActiveRecord connection leases - to the fiber rather than the thread. Size `pool:` in `config/database.yml` against the concurrency you expect; that one is your job.
 
 Configure Falcon for Rails:
 

--- a/content/blog/falcon-web-server-async-ruby-production/index.md
+++ b/content/blog/falcon-web-server-async-ruby-production/index.md
@@ -268,16 +268,11 @@ $ bundle exec falcon host
 For Rails applications, Falcon works as a drop-in replacement for Puma:
 
 ```ruby
-# config/environments/production.rb
+# config/application.rb
 Rails.application.configure do
-  # Enable async features
-  config.allow_concurrency = true
-
-  # Use fibers for isolation (Rails 7+)
+  # Scope per-request state (CurrentAttributes, AR connection leases)
+  # to the fiber rather than the thread. Required under Falcon.
   config.active_support.isolation_level = :fiber
-
-  # Optimize for async workloads
-  config.active_record.async_query_executor = :fiber_pool
 end
 ```
 

--- a/content/blog/falcon-web-server-async-ruby-production/index.md
+++ b/content/blog/falcon-web-server-async-ruby-production/index.md
@@ -9,7 +9,7 @@ draft: false
 tags: ["ruby", "performance", "async", "fibers", "falcon", "web-server", "concurrency"]
 slug: "falcon-web-server-async-ruby-production"
 canonical_url: "https://jetthoughts.com/blog/falcon-web-server-async-ruby-production/"
-cover_image: "https://res.cloudinary.com/practicaldev/image/fetch/s--92P8r_Mn--/c_imagga_scale,f_auto,fl_progressive,h_420,q_auto,w_1000/https://raw.githubusercontent.com/socketry/falcon/master/assets/falcon.png"
+cover_image: cover.png
 series: "Ruby Web Servers"
 metatags:
   image: cover.png

--- a/content/blog/falcon-web-server-async-ruby-production/index.md
+++ b/content/blog/falcon-web-server-async-ruby-production/index.md
@@ -1,5 +1,4 @@
 ---
-dev_to_id: 1
 title: "Falcon Web Server: Async Ruby in Production"
 description: "Falcon async web server for Ruby: Master fiber-based concurrency, benchmark vs Puma/Unicorn, deploy in production. Scale Rails apps, handle concurrent connections, boost performance ✓"
 date: 2025-09-25
@@ -8,8 +7,10 @@ edited_at: "2025-09-25T22:27:00Z"
 draft: false
 tags: ["ruby", "performance", "async", "fibers", "falcon", "web-server", "concurrency"]
 slug: "falcon-web-server-async-ruby-production"
+aliases: ["/blog/falcon-web-server-async-ruby-in-production/"]
 canonical_url: "https://jetthoughts.com/blog/falcon-web-server-async-ruby-production/"
-cover_image: cover.png
+cover_image: "cover.png"
+cover_image_alt: "Falcon, the fiber-based async Rack server for Ruby, running a Rails app in production"
 series: "Ruby Web Servers"
 metatags:
   image: cover.png

--- a/content/blog/fibers-async-ruby-llm-streaming-rails/index.md
+++ b/content/blog/fibers-async-ruby-llm-streaming-rails/index.md
@@ -54,7 +54,7 @@ The production setup is its own post. We've covered [Falcon's benchmarks, config
 
 Less than you'd expect. The fiber scheduler hooks Ruby's own I/O, so `Net::HTTP`, and everything built on it, yields automatically inside Falcon. The `pg` driver has cooperated with the fiber scheduler since version 1.3. Your models, controllers, and service objects don't know the difference.
 
-Per-request state has to be scoped to the fiber rather than the thread, and you almost certainly get that for free: [Falcon ships a Railtie](https://github.com/socketry/falcon/blob/main/lib/falcon/railtie.rb) that sets it for you.
+Per-request state has to be scoped to the fiber rather than the thread, and you almost certainly get that for free: [Falcon ships a Railtie](https://github.com/socketry/falcon/blob/v0.57.0/lib/falcon/railtie.rb) that sets it for you.
 
 ```ruby
 # what Falcon's Railtie already does on your behalf

--- a/content/blog/fibers-async-ruby-llm-streaming-rails/index.md
+++ b/content/blog/fibers-async-ruby-llm-streaming-rails/index.md
@@ -54,12 +54,14 @@ The production setup is its own post. We've covered [Falcon's benchmarks, config
 
 Less than you'd expect. The fiber scheduler hooks Ruby's own I/O, so `Net::HTTP`, and everything built on it, yields automatically inside Falcon. The `pg` driver has cooperated with the fiber scheduler since version 1.3. Your models, controllers, and service objects don't know the difference.
 
-Two settings matter: isolate per-request state by fiber instead of by thread, and raise `pool:` in `config/database.yml` to match the concurrency you actually expect. The first one is a single line:
+Per-request state has to be scoped to the fiber rather than the thread, and you almost certainly get that for free: [Falcon ships a Railtie](https://github.com/socketry/falcon/blob/main/lib/falcon/railtie.rb) that sets it for you.
 
 ```ruby
-# config/application.rb
+# what Falcon's Railtie already does on your behalf
 config.active_support.isolation_level = :fiber
 ```
+
+The setting you do have to think about is `pool:` in `config/database.yml`, sized against the concurrency you actually expect rather than a thread count.
 
 Here's a streaming endpoint using [RubyLLM](https://rubyllm.com/streaming), whose `ask` method yields chunks as they arrive:
 
@@ -126,7 +128,7 @@ Falcon's costs are real too. Some gems assume thread-local state and thread-size
 
 ## Where to start
 
-Measure your peak concurrent streams for a week. If the number stays under workers times threads, raise a thread count and move on. Past that ceiling, prototype one streaming endpoint on Falcon in staging with `isolation_level = :fiber` set, and watch the database pool, since that's the first thing the extra concurrency exhausts.
+Measure your peak concurrent streams for a week. If the number stays under workers times threads, raise a thread count and move on. Past that ceiling, prototype one streaming endpoint on Falcon in staging and watch the database pool, since that's the first thing the extra concurrency exhausts.
 
 If you're adding LLM features to a Rails app and want someone who has shipped this stack in production to look at your traffic profile first, [our Rails team does that assessment](/services/app-web-development/) before any migration work starts.
 

--- a/content/blog/multi-agent-llm-rails-rubyllm/index.md
+++ b/content/blog/multi-agent-llm-rails-rubyllm/index.md
@@ -31,20 +31,20 @@ RubyLLM ships an [`Agent` class](https://rubyllm.com/agents/): instructions, an 
 
 ```ruby
 class AgentBase < RubyLLM::Agent
-  class_attribute :model_name, default: AgentConfig.default_model
-
-  model { self.class.model_name }
+  model ENV.fetch("LLM_MODEL"), provider: ENV.fetch("LLM_PROVIDER")
   temperature 0.2
 end
 ```
 
 Twenty-one lines, in the real file.
 
-The lazy block is the point: `model` accepts a block that resolves at call time, so pointing an agent at a different model is a class-attribute assignment that takes effect without reloading anything. Temperature gets no such block - the gem treats it as a static value, so subclasses that need a different one declare it directly.
+Read the gem source before you reach for a block here. In `ruby_llm` 1.16.0 only `instructions`, `tools`, and `schema` take one. `model` is `def model(model_id = nil, **options)`, and a block form leaves `model_id` as `nil`, so the method assigns an empty hash to `@chat_kwargs` - it wipes the model and provider you thought you were setting, and the agent quietly falls back to the configured default. `temperature` ignores a block harmlessly. Declare both as plain values.
+
+Subclasses that need their own settings redeclare them, and `Agent.inherited` copies the parent's down to every child that doesn't.
 
 Eight agents subclass it - a scorer, a reflector, a query expander, a scrubber, four more. Every one has the same shape: an instructions heredoc, a [Schematist](https://rubygems.org/gems/schematist) schema for structured output, and one public method that builds a prompt and returns `ask(prompt).content`. When a new step needs an agent, the diff is one small file.
 
-Deploys don't trust the gem's live model list. A pinned registry in `config/ruby_llm/models.json`, loaded with `RubyLLM.models.load_from_json!`, means the models we reference exist on every boot, whether or not the registry upstream changed overnight. Dev and test run `qwen3:0.6b` on Ollama, a model small enough to answer in milliseconds on a laptop; production runs a large hosted model, and no agent code knows the difference.
+Deploys don't trust the gem's live model list. A pinned registry in `config/ruby_llm/models.json`, loaded with `RubyLLM.models.load_from_json!`, means the models we reference exist on every boot, whether or not the registry upstream changed overnight. Dev and test run `qwen3:0.6b` on Ollama - 523MB, small enough to sit on a laptop; production runs a large hosted model, and no agent code knows the difference.
 
 Retries live in gem config too: `request_timeout 300`, `max_retries 10`, a 1.5x backoff. There is no hand-rolled retry loop anywhere in the eight agents, which is eight places a subtle retry bug can't live.
 

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
@@ -438,19 +438,24 @@ Paul asked to schedule a Puma→Falcon migration post on 2026-08-20. The audit s
 write it, but *inside the page that already ranks*:
 
 1. **We already own the section.** `falcon-web-server-async-ruby-production` contains
-   `## Migration from Puma/Unicorn` at line 580 - roughly 200 lines of it. A second page
-   on the same intent is the exact §4 cannibalization defect that forced the Rails 8 auth
-   consolidation.
-2. **That page is a top earner.** It is the site's #2 organic page and the cluster ranks
-   at **position 4.8 for "falcon ruby"** (206 impressions/90d), 7.9 for "falcon server",
-   8.5 for "falcon rails". Splitting a position-4.8 cluster to chase the same readers is
-   a downgrade dressed as new content.
-3. **There is no separate migration intent to capture.** Zero "puma to falcon" /
-   "migrate falcon" queries drew impressions in 90 days. The demand is on the head term,
-   which we already hold.
-4. **The existing section is the weak part of a strong page** - generic filler prose
-   ("requires understanding the differences and planning the transition carefully"),
-   which is *why* the upgrade is worth doing.
+   `## Migration from Puma/Unicorn` at line 580 - 207 lines of it, through to line 787.
+   A second page on the same intent is the exact §4 cannibalization defect that forced
+   the Rails 8 auth consolidation.
+2. **The Falcon demand is real but it is landing on a 404** (see §12b - filed as P0).
+   All of it sits on `/blog/falcon-web-server-async-ruby-**in**-production/`: 37 clicks,
+   3,778 impressions, position 10.1 over 90 days, which makes it the site's #2 organic
+   page by clicks. That URL returns **404**. The live post at
+   `/blog/falcon-web-server-async-ruby-production/` (no "in") records **zero** GSC data.
+   Publishing a *third* Falcon URL while the ranking one is dead would compound the
+   problem, not fix it.
+3. **Migration is not a separate intent worth its own page.** The head terms carry the
+   cluster ("falcon ruby" 206 impr @4.8, "falcon server" 119 @7.9, "falcon rails" 68
+   @8.5 - all on the 404). Explicit comparison queries barely register: "falcon vs puma"
+   and "puma vs falcon" drew 1 impression each, at positions 17 and 14.
+4. **The existing section is the weak part of the page** - generic filler prose
+   ("requires understanding the differences and planning the transition carefully") and
+   a "Pre-Migration Checklist" of snippets annotated "should be fine", which is *why*
+   the upgrade is worth doing.
 
 **Scope when scheduled** (one surgical pass, no new URL): rewrite the migration section
 as a real runbook - thread-safety audit of the app before switching, Gemfile/config diff,
@@ -460,10 +465,34 @@ pools sized per fiber), a staged canary rollout, and the rollback trigger. Cross
 `falcon-web-server-production-tuning-benchmarks` for post-switch tuning. The page is
 **not** in `sync_status.yml`, so an in-place rewrite is safe from the dev.to clobber trap.
 
-**Also found during this audit (fixed 2026-08-20, same branch):** that page's
-`cover_image` pointed at an external practicaldev/Cloudinary URL while a local
-`cover.png` sat unused in the bundle - a STEP 6b pre-publish violation making og:image
-depend on a third-party CDN, on our #2 page.
+### 12b. P0 - the site's #2 organic page is a 404 (found 2026-08-20, fixed same branch)
+
+Google ranks `/blog/falcon-web-server-async-ruby-in-production/` - **37 clicks / 3,778
+impressions / position 10.1 in 90 days**, second only to the homepage - and that URL has
+**never existed in this repo** (`git log --all -S` finds no trace of the slug). It
+returns 404 with no redirect, so every click on our best-ranking blog result hits an
+error page. The whole `falcon *` head-term cluster sits there.
+
+**Fix applied**: `aliases: ["/blog/falcon-web-server-async-ruby-in-production/"]` on the
+live post, so Hugo emits a redirect and the equity consolidates onto the real URL. The
+live slug keeps its name because every internal link (including the three posts shipped
+2026-08-20) already points at it.
+
+**Lesson for future audits**: this was nearly missed twice. The page-dimension GSC pull
+lists the 404 slug and the live slug differs by one word ("-in-"), which reads as
+identical at a glance; a per-page query on the live URL returned "no data" and *that*
+was the signal, not noise. **When a page you believe ranks returns no GSC rows, check
+the URL character by character and curl it before concluding anything.** A sweep of the
+other top-10 pages by clicks and the highest-impression pages found no further drift, so
+this is isolated rather than systemic.
+
+**Corrected note on the cover image** (the audit's original claim was wrong): that page's
+`cover_image` did point at an external practicaldev/Cloudinary URL, and it is now a local
+`"cover.png"` with `cover_image_alt` added - correct hygiene per STEP 6b. But og:image
+never depended on it: `seo/enhanced-meta-tags.html` resolves `metatags.image` first, which
+was already `cover.png`, and an absolute URL passed to `Resources.Get` returns nil and can
+never win. The live page's og:image was already serving the local asset. Hygiene, not a
+defect fix - recorded so the claim is not repeated.
 
 Sequencing: R1 (or the upgrade of the existing import) first, then R5 - basics own the head
 term, the multi-agent post owns the white space. One per Rails-technical slot; the §1 gate and

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
@@ -482,9 +482,36 @@ live slug keeps its name because every internal link (including the three posts 
 lists the 404 slug and the live slug differs by one word ("-in-"), which reads as
 identical at a glance; a per-page query on the live URL returned "no data" and *that*
 was the signal, not noise. **When a page you believe ranks returns no GSC rows, check
-the URL character by character and curl it before concluding anything.** A sweep of the
-other top-10 pages by clicks and the highest-impression pages found no further drift, so
-this is isolated rather than systemic.
+the URL character by character and curl it before concluding anything.**
+
+**Isolated, verified across the whole population.** A reviewer pulled all **450 ranking
+`/blog/` URLs** from the 90-day GSC page report and diffed them against published output:
+`falcon-web-server-async-ruby-in-production` is the only 404. **Methodology note for
+anyone automating this**: do *not* diff GSC URLs against `ls content/blog/`. Many posts
+carry a frontmatter `slug:` that differs from their directory name, so the directory
+heuristic produced 17 false positives against 1 real hit here (including
+`rails-testing-best-practices-complete-guide-2025`, 7,284 impressions, which looked
+alarming and returns 200). The check has to hit the built `public/` tree or curl.
+
+### 12c. Fabricated Rails config on the same page (found + partly fixed 2026-08-20)
+
+While scoping the §12a rewrite, the writer flagged copyable config on this page that does
+not exist in Rails. Verified against Rails source before acting:
+
+| Snippet | Verdict | Source |
+|---|---|---|
+| `config.active_record.async_query_executor = :fiber_pool` | **invalid value** - the only options are `nil`, `:global_thread_pool`, `:multi_thread_pool` | `activerecord/lib/active_record.rb` |
+| `config.allow_concurrency = true` | **no-op**, and the "enable async features" comment was wrong - only an explicit `false` does anything (inserts `Rack::Lock`) | `railties/.../default_middleware_stack.rb` |
+| `async: true` in `database.yml` | **not a real key** - `HashConfig` exposes `pool`, `min_threads`, `max_threads`, `checkout_timeout`, `idle_timeout`, `reaping_frequency` | `activerecord/.../hash_config.rb` |
+
+The first two are fixed here (that block now carries only `isolation_level = :fiber` with an
+accurate comment). The third sits inside the 580-786 window being rewritten on
+`upgrade/falcon-puma-migration-runbook`, so it is fixed there rather than conflicting.
+
+**Why this matters beyond one page**: this is a dev.to-era import ranking on head terms,
+and three of its config examples were invented. The de-fabrication sweep that ran on
+`ruby-3-4-yjit-performance-guide` needs to extend to the rest of the imported technical
+cluster - fabrications survive in exactly the posts nobody re-reads because they already rank.
 
 **Corrected note on the cover image** (the audit's original claim was wrong): that page's
 `cover_image` did point at an external practicaldev/Cloudinary URL, and it is now a local

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
@@ -438,7 +438,8 @@ Paul asked to schedule a Puma→Falcon migration post on 2026-08-20. The audit s
 write it, but *inside the page that already ranks*:
 
 1. **We already own the section.** `falcon-web-server-async-ruby-production` contains
-   `## Migration from Puma/Unicorn` at line 580 - 207 lines of it, through to line 787.
+   `## Migration from Puma/Unicorn` - 207 lines of it, running to `## Real-World Use
+   Cases`. (Line numbers move as the page is edited; find it by heading, not by number.)
    A second page on the same intent is the exact §4 cannibalization defect that forced
    the Rails 8 auth consolidation.
 2. **The Falcon demand is real but it is landing on a 404** (see §12b - filed as P0).
@@ -506,9 +507,19 @@ not exist in Rails. Verified against Rails source before acting:
 | `load :rack` / `rack hostname do` in `config/falcon.rb` | **outdated DSL** - current Falcon uses `require "falcon/environment/rack"` with `service … do include Falcon::Environment::Rack` | falcon docs/source |
 | "No explicit timeout needed as fibers are cooperative" | **unsupported** hand-wave presented as guidance | - |
 
-The first two are fixed here (that block now carries only `isolation_level = :fiber` with an
-accurate comment). The last three sit inside the 580-786 window being rewritten on
-`upgrade/falcon-puma-migration-runbook`, so they are fixed there rather than conflicting.
+The first two are fixed here (that block now explains that Falcon's Railtie sets
+`isolation_level` for you rather than handing the reader a line to add). The last three sit
+inside the migration section being rewritten on `upgrade/falcon-puma-migration-runbook`, so
+they are fixed there rather than conflicting.
+
+**Merge order (two branches, one top-ranking file)**: this branch edits only the frontmatter
+and the "Rails Integration" block; the upgrade branch rewrites only the migration section.
+Disjoint regions, but **this branch merges first** - it carries the 404 recovery, which is the
+time-sensitive part - and the upgrade branch then rebases onto the new master before opening
+its PR. Verified by an independent build: the alias emits the correct meta-refresh + canonical,
+is excluded from the sitemap, and the page's hero image and og:image are unchanged (the theme
+resolves the hero via `.Resources.GetMatch "cover.*"` and og:image via `metatags.image`, so the
+`cover_image` value never drove either - the only rendered change is the alt attribute).
 
 Two further corrections the same verification pass produced, both applied:
 

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
@@ -430,6 +430,40 @@ Why this fits the plan: AI+Ruby is inside the authority zone that already earns 
 | R6 | AI + Rails tips roundup (Reddit-sourced) | - | Likely LinkedIn material, not a blog slot - groom before committing |
 | R7 | Evaluating RubyLLM agents: schemas, golden sets, audit logs (Paul, 2026-08-20) | `testing-monitoring-llm-applications-production` exists - R7 is agent-EVAL specific, link it, don't re-cover monitoring | First-hand material ready: per-iteration agent_logs audit trail (STOP/CONTINUE + reasoning persisted), bounded-schema scoring as an eval primitive |
 | R8 | Debugging RubyLLM agents in Rails (Paul, 2026-08-20) | - | First-hand material ready: the VCR method+URI matching trap (wire-format change passed a whole suite unnoticed), fakes-over-mocks, key-scrubbing regexes, the active_connection? invariant test that survives transactional pinning |
+| R9 | "Migrate from Puma to Falcon" (Paul, 2026-08-20) | 🔴 **COLLISION - do NOT ship as a new post** | See §12a below. Verdict: **upgrade in place**. |
+
+### 12a. R9 premise audit - why Puma→Falcon is an upgrade, not a new post
+
+Paul asked to schedule a Puma→Falcon migration post on 2026-08-20. The audit says
+write it, but *inside the page that already ranks*:
+
+1. **We already own the section.** `falcon-web-server-async-ruby-production` contains
+   `## Migration from Puma/Unicorn` at line 580 - roughly 200 lines of it. A second page
+   on the same intent is the exact §4 cannibalization defect that forced the Rails 8 auth
+   consolidation.
+2. **That page is a top earner.** It is the site's #2 organic page and the cluster ranks
+   at **position 4.8 for "falcon ruby"** (206 impressions/90d), 7.9 for "falcon server",
+   8.5 for "falcon rails". Splitting a position-4.8 cluster to chase the same readers is
+   a downgrade dressed as new content.
+3. **There is no separate migration intent to capture.** Zero "puma to falcon" /
+   "migrate falcon" queries drew impressions in 90 days. The demand is on the head term,
+   which we already hold.
+4. **The existing section is the weak part of a strong page** - generic filler prose
+   ("requires understanding the differences and planning the transition carefully"),
+   which is *why* the upgrade is worth doing.
+
+**Scope when scheduled** (one surgical pass, no new URL): rewrite the migration section
+as a real runbook - thread-safety audit of the app before switching, Gemfile/config diff,
+what actually breaks (C extensions blocking the reactor, thread-local state, connection
+pools sized per fiber), a staged canary rollout, and the rollback trigger. Cross-link
+`fibers-async-ruby-llm-streaming-rails` for the arithmetic and
+`falcon-web-server-production-tuning-benchmarks` for post-switch tuning. The page is
+**not** in `sync_status.yml`, so an in-place rewrite is safe from the dev.to clobber trap.
+
+**Also found during this audit (fixed 2026-08-20, same branch):** that page's
+`cover_image` pointed at an external practicaldev/Cloudinary URL while a local
+`cover.png` sat unused in the bundle - a STEP 6b pre-publish violation making og:image
+depend on a third-party CDN, on our #2 page.
 
 Sequencing: R1 (or the upgrade of the existing import) first, then R5 - basics own the head
 term, the multi-agent post owns the white space. One per Rails-technical slot; the §1 gate and

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
@@ -503,15 +503,34 @@ not exist in Rails. Verified against Rails source before acting:
 | `config.active_record.async_query_executor = :fiber_pool` | **invalid value** - the only options are `nil`, `:global_thread_pool`, `:multi_thread_pool` | `activerecord/lib/active_record.rb` |
 | `config.allow_concurrency = true` | **no-op**, and the "enable async features" comment was wrong - only an explicit `false` does anything (inserts `Rack::Lock`) | `railties/.../default_middleware_stack.rb` |
 | `async: true` in `database.yml` | **not a real key** - `HashConfig` exposes `pool`, `min_threads`, `max_threads`, `checkout_timeout`, `idle_timeout`, `reaping_frequency` | `activerecord/.../hash_config.rb` |
+| `load :rack` / `rack hostname do` in `config/falcon.rb` | **outdated DSL** - current Falcon uses `require "falcon/environment/rack"` with `service … do include Falcon::Environment::Rack` | falcon docs/source |
+| "No explicit timeout needed as fibers are cooperative" | **unsupported** hand-wave presented as guidance | - |
 
 The first two are fixed here (that block now carries only `isolation_level = :fiber` with an
-accurate comment). The third sits inside the 580-786 window being rewritten on
-`upgrade/falcon-puma-migration-runbook`, so it is fixed there rather than conflicting.
+accurate comment). The last three sit inside the 580-786 window being rewritten on
+`upgrade/falcon-puma-migration-runbook`, so they are fixed there rather than conflicting.
 
-**Why this matters beyond one page**: this is a dev.to-era import ranking on head terms,
-and three of its config examples were invented. The de-fabrication sweep that ran on
-`ruby-3-4-yjit-performance-guide` needs to extend to the rest of the imported technical
-cluster - fabrications survive in exactly the posts nobody re-reads because they already rank.
+Two further corrections the same verification pass produced, both applied:
+
+- **`Thread#[]` is fiber-local, not thread-local.** Ruby's docs are explicit ("each fiber has
+  its own bucket for `Thread#[]` storage"); `thread_variable_get/set` is the genuinely
+  thread-local pair. So the intuitive migration advice - "move thread-local state to
+  fiber-local" - is **inverted** for the API people actually reach for. The real failure
+  modes are the reverse: `thread_variable_set` for per-request state leaks request A's data
+  into request B (a correctness bug in the API that sounds safe), while `Thread.current[:cache]`
+  used as a memoization cache silently never hits (rebuilt per fiber). A generic rewrite would
+  have stated the opposite with confidence.
+- **Falcon's Railtie already sets `isolation_level = :fiber`** (`lib/falcon/railtie.rb`,
+  unconditional). `fibers-async-ruby-llm-streaming-rails`, shipped the same day, framed it as
+  a setting the reader must add - corrected in place to "you get this for free, here is what
+  it governs".
+
+**Why this matters beyond one page**: this is a dev.to-era import ranking on head terms, and
+five of its technical examples were invented, invalid, or stale. The de-fabrication sweep that
+ran on `ruby-3-4-yjit-performance-guide` needs to extend to the rest of the imported technical
+cluster - fabrications survive in exactly the posts nobody re-reads *because* they already rank.
+**Queue this as a P1 sweep**: the imported technical posts with real impressions, checked
+against primary sources, config examples first.
 
 **Corrected note on the cover image** (the audit's original claim was wrong): that page's
 `cover_image` did point at an external practicaldev/Cloudinary URL, and it is now a local

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
@@ -506,11 +506,16 @@ not exist in Rails. Verified against Rails source before acting:
 | `async: true` in `database.yml` | **not a real key** - `HashConfig` exposes `pool`, `min_threads`, `max_threads`, `checkout_timeout`, `idle_timeout`, `reaping_frequency` | `activerecord/.../hash_config.rb` |
 | `load :rack` / `rack hostname do` in `config/falcon.rb` | **outdated DSL** - current Falcon uses `require "falcon/environment/rack"` with `service … do include Falcon::Environment::Rack` | falcon docs/source |
 | "No explicit timeout needed as fibers are cooperative" | **unsupported** hand-wave presented as guidance | - |
+| `after_connect:` with a Ruby logger call in a second `database.yml` block | **not a real key** either - same class, found on a later pass | `activerecord/.../hash_config.rb` |
 
 The first two are fixed here (that block now explains that Falcon's Railtie sets
-`isolation_level` for you rather than handing the reader a line to add). The last three sit
-inside the migration section being rewritten on `upgrade/falcon-puma-migration-runbook`, so
-they are fixed there rather than conflicting.
+`isolation_level` for you rather than handing the reader a line to add).
+
+🔴 **The last three are still LIVE on the page.** They sit inside the migration section, which
+is being rewritten on `upgrade/falcon-puma-migration-runbook` - a branch that at time of
+writing is **not pushed and has no commits**. Until that PR merges, this page carries three
+items this document identifies as invalid, and this PR routes 3,778 monthly impressions onto
+it. Do not read this section as an all-clear. Tracked, not done.
 
 **Merge order (two branches, one top-ranking file)**: this branch edits only the frontmatter
 and the "Rails Integration" block; the upgrade branch rewrites only the migration section.
@@ -521,9 +526,12 @@ is excluded from the sitemap, and the page's hero image and og:image are unchang
 resolves the hero via `.Resources.GetMatch "cover.*"` and og:image via `metatags.image`, so the
 `cover_image` value never drove either - the only rendered change is the alt attribute).
 
-Two further corrections the same verification pass produced, both applied:
+Two further findings from the same verification pass. **Only the second is applied to live
+content**; the first informs the rewrite but has not yet corrected anything on the page:
 
-- **`Thread#[]` is fiber-local, not thread-local.** Ruby's docs are explicit ("each fiber has
+- **`Thread#[]` is fiber-local, not thread-local** (NOT yet applied - the page still carries
+  `@user = User.find(params[:id])  # OK - fiber-local` untouched, and the corrected treatment
+  ships with the migration-section rewrite). Ruby's docs are explicit ("each fiber has
   its own bucket for `Thread#[]` storage"); `thread_variable_get/set` is the genuinely
   thread-local pair. So the intuitive migration advice - "move thread-local state to
   fiber-local" - is **inverted** for the API people actually reach for. The real failure


### PR DESCRIPTION
**Supersedes #493** (which was blocked by a stray commit from another session — see below). Same work, clean base off current master, plus two live defects found after it was opened.

## P0 — the site's #2 organic page was a 404

Google ranks `/blog/falcon-web-server-async-ruby-**in**-production/` at **37 clicks / 3,778 impressions / position 10.1** over 90 days — second only to the homepage — and that slug has never existed in this repo. Every click on our best-ranking blog result hit an error page, and the whole `falcon *` head-term cluster sits there.

Fixed with a Hugo `aliases:` entry (redirect verified in built output; correctly excluded from the sitemap). A reviewer swept **all 450 ranking `/blog/` URLs** against published output — this is the only 404.

## P0 — published boot configs that cannot boot

`falcon --config config/falcon.rb serve` appeared **seven times** on that page. It is invalid CLI — it errors `Could not parse token "serve"` because `-c` belongs to the subcommand. Two of the seven were the **systemd `ExecStart`** and the **Dockerfile `CMD`**. All replaced with `falcon host`, which reads `falcon.rb` from the app root; the multi-word `env` shebangs (which also fail on Linux) became `falcon-host`.

## Broken copyable code in a post shipped this morning

`multi-agent-llm-rails-rubyllm` demonstrated `model { ... }` and claimed the block resolves lazily. In ruby_llm 1.16.0 `model` takes no block: with a nil argument it assigns an empty hash to `@chat_kwargs`, so the block form **wipes** the model and provider and the agent silently falls back to the configured default. Replaced with plain values and an explanation of the trap. Also cut "answers in milliseconds on a laptop" — the exact claim a sibling post dropped as unsupported — for the sourced 523MB figure.

## Fabricated Rails config removed

Verified against Rails source, not memory:

| Snippet | Reality |
|---|---|
| `async_query_executor = :fiber_pool` | Not a valid value — only `nil`, `:global_thread_pool`, `:multi_thread_pool` |
| `allow_concurrency = true` | A no-op; only an explicit `false` does anything (inserts `Rack::Lock`) |

## Corrections to my own earlier claims

- The `isolation_level` guidance in **both** the Falcon page and the fibers post told readers to add a line Falcon's Railtie sets unconditionally. Corrected in both; Railtie links pinned to `v0.57.0`.
- An earlier commit claimed the external `cover_image` broke og:image. It didn't — `metatags.image` resolves first. Retracted in the doc; the frontmatter change stays as hygiene with `cover_image_alt` added.
- §12c no longer certifies work that hasn't happened (three defects remain live in a section being rewritten separately, and the doc now says so).

## Why this supersedes #493

A worktree collision landed another session's post (`12e2ab1ac`) inside #493, and my session lost write access to that branch before it could be dropped. This branch is that work cherry-picked onto current master **without** the stray commit, so the other session's post stays owned by its own branch.

## Gates

`bin/hugo-build` green · `check-post-visuals` at floor (72) · alias redirect verified in built output · content-only diff, so visual suites correctly skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
