### PR TITLE
CI hotfix: blobless clone for the full-history job (checkout stalls are upstream)

### DIFF
--- a/.github/workflows/_hugo.yml
+++ b/.github/workflows/_hugo.yml
@@ -17,7 +17,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          # fetch-depth: 0 is REQUIRED - hugo.toml sets enableGitInfo, and
+          # .Lastmod feeds article:modified_time and schema dateModified.
+          # But this repo's pack is 1.70 GiB, and since 2026-05-19 EU runners
+          # have been stalling silently inside "Fetching the repository"
+          # (actions/checkout#2441, still open upstream) - three such stalls
+          # in one session on 2026-08-20, all killed by timeout-minutes, all
+          # cleared by a plain re-run.
+          #
+          # filter: blob:none = blobless clone. Commits and trees come down
+          # in full (so GitInfo still resolves every path), and HISTORICAL
+          # file contents are skipped; the working tree's own blobs are
+          # fetched once during checkout. Measured 2026-08-20: bare blobless
+          # clone 4.7 MB in 1.1s vs a 1.70 GiB pack, and
+          # `git log -1 -- content/blog/<post>/index.md` still returned the
+          # right commit date in 0.02s with zero blobs fetched.
+          #
+          # This is a MITIGATION, not a cure - it cuts what we ask for, it
+          # cannot fix an upstream stall. Keep the re-run rule.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Setup Pages
         id: pages

--- a/.okf/build/ci-gates.md
+++ b/.okf/build/ci-gates.md
@@ -49,21 +49,41 @@ now 15 and 25. Do not trim them back toward the observed average: a gate that
 flakes on timeout teaches people to ignore red, which costs more than the
 runner minutes.
 
-**Slow is not the same as stalled — check which before raising a timeout**
-(2026-08-20, three occurrences in one session). `Unit Tests` failed at exactly
-10m twice and `build_and_deploy / build` at 15m1s, every one of them inside
-`##[group]Fetching the repository` and ending `##[error]The operation was
-canceled.` — i.e. they hit the cap, they did not run long and finish. Each
-plain `gh run rerun <id> --failed` then completed the SAME job in **2-3
-minutes**.
+**Slow is not the same as stalled — and the stall is UPSTREAM** (2026-08-20).
+Three failures in one session — `Unit Tests` at exactly 10m twice,
+`build_and_deploy / build` at 15m1s — every one inside
+`##[group]Fetching the repository`, ending `##[error]The operation was
+canceled.`, and every one cleared by a plain `gh run rerun <id> --failed`
+completing the SAME job in 2-3 minutes.
 
-So the failure mode is a checkout **hang**, not the documented slowness, and
-the right response is re-run-and-verify rather than another timeout raise —
-raising the cap cannot fix a step that never progresses, and would only make
-each failure cost longer. Confirm before re-running by pulling the job log
-(`gh api repos/<owner>/<repo>/actions/jobs/<job_id>/logs`) and looking for that
-group/error pair; if the job actually got past checkout, it is a real failure
-and a re-run is the wrong move.
+Root cause is **not** our config and not the 7-minute slowness documented
+above: since **2026-05-19** `actions/checkout` has been stalling silently on
+**EU runners** — [actions/checkout#2441], open and unresolved, symptom
+described upstream as silent stalls of 15-25 minutes killed by
+`timeout-minutes`. That is our signature exactly.
+
+Consequences for how to react:
+
+* **Re-run; do not raise the cap.** A timeout cannot rescue a step that never
+  progresses — raising it only makes each failure cost longer. Confirm first
+  by pulling the job log
+  (`gh api repos/<owner>/<repo>/actions/jobs/<job_id>/logs`) and looking for
+  that group/error pair. If the job got PAST checkout, it is a real failure and
+  a re-run is the wrong move.
+* **Shrink what we ask for.** We cannot fix upstream, only reduce exposure.
+  This repo is a heavy ask: **1.70 GiB pack**, and `content/` alone is
+  **625 MB across 1,576 images**, downloaded by every job regardless of depth.
+  `_hugo.yml` needs `fetch-depth: 0` (enableGitInfo → `.Lastmod` →
+  `article:modified_time` + schema `dateModified`), so it now also sets
+  **`filter: blob:none`** — commits and trees in full, historical blobs
+  skipped. Measured: bare blobless clone **4.7 MB in 1.1s** vs the 1.70 GiB
+  pack, and `git log -1 -- content/blog/<post>/index.md` still returned the
+  correct date in **0.02s with zero blobs fetched**, so GitInfo is unaffected.
+* **The deeper fix is the content weight**, not the checkout flags: 625 MB of
+  images in git is the floor every job pays. Moving them to LFS or
+  CDN-only would be a separate, larger decision.
+
+[actions/checkout#2441]: https://github.com/actions/checkout/issues/2441
 
 Two things to preserve when touching either:
 - **`test:links` and `test:html_proofer` share ONE rake invocation**

--- a/.okf/build/ci-gates.md
+++ b/.okf/build/ci-gates.md
@@ -49,6 +49,22 @@ now 15 and 25. Do not trim them back toward the observed average: a gate that
 flakes on timeout teaches people to ignore red, which costs more than the
 runner minutes.
 
+**Slow is not the same as stalled — check which before raising a timeout**
+(2026-08-20, three occurrences in one session). `Unit Tests` failed at exactly
+10m twice and `build_and_deploy / build` at 15m1s, every one of them inside
+`##[group]Fetching the repository` and ending `##[error]The operation was
+canceled.` — i.e. they hit the cap, they did not run long and finish. Each
+plain `gh run rerun <id> --failed` then completed the SAME job in **2-3
+minutes**.
+
+So the failure mode is a checkout **hang**, not the documented slowness, and
+the right response is re-run-and-verify rather than another timeout raise —
+raising the cap cannot fix a step that never progresses, and would only make
+each failure cost longer. Confirm before re-running by pulling the job log
+(`gh api repos/<owner>/<repo>/actions/jobs/<job_id>/logs`) and looking for that
+group/error pair; if the job actually got past checkout, it is a real failure
+and a re-run is the wrong move.
+
 Two things to preserve when touching either:
 - **`test:links` and `test:html_proofer` share ONE rake invocation**
   (`rake test:links test:html_proofer`). Both default to the same `OUTPUT_DIR`

--- a/.okf/design/index.md
+++ b/.okf/design/index.md
@@ -1,5 +1,6 @@
 # Design
 
+* [Site chrome palette](site-palette.md) - LIGHT resolved (ADR-0003), the ruby/ink/surface tokens, and the three places dark is still deliberate
 * [Mermaid theme](mermaid-theme.md) - the Caveat webfont root-cause fix and the theming gotchas
 * [House visual spec](house-visual-spec.md) - paper tones, semantic colors, hand-drawn identity
 * [Cover pipeline](cover-pipeline.md) - rebuilding course covers from the design spec

--- a/.okf/design/site-palette.md
+++ b/.okf/design/site-palette.md
@@ -1,0 +1,77 @@
+---
+type: Design System
+title: Site chrome palette (light, "Rescue Room")
+description: The resolved site-wide palette - light default, ruby accent, purple secondary - and the three surfaces where dark is still deliberate.
+resource: themes/beaver/assets/css/foundations/css-variables.css
+tags: [design, palette, css, tokens, adr]
+generated:
+  by: claude/opus-5
+  at: 2026-08-20T00:00:00Z
+timestamp: 2026-08-20T00:00:00Z
+---
+
+# Resolved: LIGHT (ADR-0003, 2026-08-20)
+
+Site chrome is light. Not a default anyone drifted into — decided on a
+lightning demo of the peer set, and the reasoning is worth keeping because it
+predicts future calls:
+
+**The light/dark split is audience-shaped, not taste-shaped.** Dark marketing
+belongs to products bought by *developers evaluating a tool*; light belongs to
+services bought on *trust*. Every services peer reviewed ships light —
+thoughtbot, Test Double (a Rails consultancy selling to technical buyers),
+Basecamp (dark is a user preference, not the brand) — and the decisive signal
+was **Linear**, the poster child for dark product aesthetics, shipping a
+*light* marketing site. Light also holds a comprehension edge at **small font
+sizes**, which is our case: our humans are on phones (28% of GSC clicks from
+6% of impressions).
+
+**Why the dark case lost, stated so it isn't re-litigated:**
+`/services/vibe-code-rescue/` is the strongest page on the site and it is
+obsidian — but its quality is **structural, not chromatic** (proof chips in
+fold one, one repeated CTA, artifact cards instead of stock photography,
+~4,300px). Every one of those is palette-independent and every one already
+ships in the *light* blog.
+
+# The palette
+
+Defined in `foundations/css-variables.css`, which loads inline site-wide — see
+[css-pipeline](/architecture/css-pipeline.md) for the token-layer mechanics and
+the zero-delta promotion pattern.
+
+| Role | Token | Value |
+|---|---|---|
+| Primary accent | `--color-ruby` | `#cc342d` (5.1:1 on white — AA both directions) |
+| Accent pressed | `--ruby-700` | `#9e2620` |
+| Accent tints | `--ruby-100` / `--ruby-050` | `#fbeae8` / `#fdf5f4` (hero blush) |
+| Secondary accent | `--color-neon-purple` | `#a855f7` — gradient partner and small marks only, never a standalone brand colour or a section background |
+| Ink ramp (warm) | `--ink-900/700/500/300` | `#14110f` / `#3d3733` / `#6b625c` / `#a49b94` |
+| Hairlines | `--line` | `#e7e1d9` — the only border colour |
+| Surfaces | `--surface{,-raised,-sunken}` | `#ffffff` / `#faf7f3` / `#f2ece4` |
+| Dark surface | `--surface-ink`, `--color-obsidian*` | `#14110f`, JetVelocity obsidian family |
+
+# Where dark is still deliberate
+
+Light is the default, not a monopoly. Three surfaces keep dark **by design** —
+anything else going dark is a defect:
+
+1. **Blog cover art** — obsidian, unchanged. It reads precisely *because* it is
+   the only dark thing on the page.
+2. **One dark band per page**, spent on the single strongest proof.
+3. **`/services/vibe-code-rescue/`** — a dark *variant* of these same tokens and
+   components as a campaign landing page, not a second design system.
+
+# Deprecations in progress
+
+`--color-primary` (`#1a8cff`) is named "primary" and appears in no brand
+definition; it and the late-cascade `#0066d6` anchor rule die in 2608 Phase
+1a.2/1a.3. Until then several page files carry scoped `!important` workarounds
+against that rule — **retiring all of them is the phase's success signal**: if
+they cannot all go, the replacement link colours are wrong, not the
+workarounds.
+
+# Citations
+
+[1] `docs/adr/0003-site-design-system.md` — the decision and its alternatives
+[2] `docs/projects/2608-site-design-system/20-29-strategy/20.02-phase-1a-plan.md`
+[3] `.stitch/design.md` — the cover-image system (separate surface, stays dark)

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1027,7 +1027,7 @@ predicts future calls, the token table, and - importantly - the three surfaces
 where dark stays deliberate, so a future session doesn't "fix" the blog covers
 or the vibe-code-rescue campaign page into light.
 
-## 2026-08-20 - CI checkout STALLS (three times); re-run, don't raise the cap
+## 2026-08-20 - CI checkout stalls: UPSTREAM (checkout#2441), mitigated with blob:none
 
 Three CI failures in one session - Unit Tests at exactly 10m twice,
 build_and_deploy/build at 15m1s - every one inside
@@ -1039,3 +1039,15 @@ HANG, not slowness. A cap cannot rescue a step that never progresses, so the
 response is re-run-and-verify, and raising the timeout again would only make
 each failure cost longer. Rule added with the log-check to confirm it before
 re-running, so nobody re-runs a job that actually failed for real.
+
+ROOT CAUSE FOUND (same day, on Paul's hunch that a checkout upgrade was at
+fault - he was right that it was the action, wrong about it being our
+version): actions/checkout#2441, open since 2026-05-19, silent stalls of
+15-25 min on EU runners killed by timeout-minutes. Not our config, not
+fixable by us. What IS ours is how much we ask for: a 1.70 GiB pack and a
+625 MB content/ tree (1,576 images) downloaded by every job. _hugo.yml needs
+fetch-depth: 0 for enableGitInfo, so it now also sets filter: blob:none -
+measured 4.7 MB / 1.1s bare blobless vs 1.70 GiB, with
+`git log -1 -- <post>/index.md` still returning the right date in 0.02s and
+zero blobs fetched, so GitInfo is unaffected. Mitigation, not cure; the real
+floor is 625 MB of images in git, which is a separate LFS/CDN decision.

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1008,3 +1008,21 @@ GA4 deliberately not pulled - §5 establishes ~85-90% bot traffic and
 
 * Update: taste anchor established at `.stitch/course-taste-design.md` - Stitch-skill DESIGN.md encoding the cou...
 
+
+## 2026-08-20 - Site palette concept added; compaction verified non-lossy
+
+Checked today's knowledge against the #504 bundle compaction (359KB -> 191KB)
+before adding anything: the token layer, the img-cropped mobileWidth params,
+the blog-list traps, record-baselines and the GA browser-channel distinction
+all survived IN CONCEPTS rather than only in the log, which is the outcome the
+compaction was aiming for.
+
+One real gap remained, and it was in the section a cold session reads first
+for visual questions: `design/` had NO site-palette concept. house-visual-spec
+is in-post SVG artwork and cover-pipeline is covers, so "what palette does the
+site use?" resolved to nothing there - the LIGHT decision lived only in
+docs/adr/0003 and, since the previous pass, architecture/css-pipeline. Added
+design/site-palette.md with the decision, the audience-shaped reasoning that
+predicts future calls, the token table, and - importantly - the three surfaces
+where dark stays deliberate, so a future session doesn't "fix" the blog covers
+or the vibe-code-rescue campaign page into light.

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1026,3 +1026,16 @@ design/site-palette.md with the decision, the audience-shaped reasoning that
 predicts future calls, the token table, and - importantly - the three surfaces
 where dark stays deliberate, so a future session doesn't "fix" the blog covers
 or the vibe-code-rescue campaign page into light.
+
+## 2026-08-20 - CI checkout STALLS (three times); re-run, don't raise the cap
+
+Three CI failures in one session - Unit Tests at exactly 10m twice,
+build_and_deploy/build at 15m1s - every one inside
+`##[group]Fetching the repository` ending `The operation was canceled.` Each
+plain re-run completed the same job in 2-3 minutes. ci-gates already documented
+checkout being SLOW (7 min observed) and the timeouts raised to 15/25 because
+of it; what it lacked is the distinction that matters operationally: this is a
+HANG, not slowness. A cap cannot rescue a step that never progresses, so the
+response is re-run-and-verify, and raising the timeout again would only make
+each failure cost longer. Rule added with the log-check to confirm it before
+re-running, so nobody re-runs a job that actually failed for real.


### PR DESCRIPTION
Paul's hunch — "looks like there is a bug with the latest action upgrade" —
was right that the action is at fault, though not our version of it.

## Root cause: upstream, open, not ours

[actions/checkout#2441](https://github.com/actions/checkout/issues/2441) —
open since **2026-05-19**, silent stalls of 15–25 min on **EU runners**, killed
by `timeout-minutes`. That is our signature exactly:

| Job | Died at | Where | Re-run |
|---|---|---|---|
| Unit Tests | exactly 10m | `Fetching the repository` | 2m6s ✓ |
| Unit Tests | exactly 10m | `Fetching the repository` | 2m10s ✓ |
| build_and_deploy / build | 15m1s | `Fetching the repository` | ✓ |

We can't fix it. **Raising the cap can't either** — a timeout cannot rescue a
step that never progresses; it only makes each failure cost longer.

## What we *can* fix: how much we ask for

This repo is a heavy ask — **1.70 GiB pack**, and `content/` alone is
**625 MB across 1,576 images** that every job pulls regardless of depth.

`_hugo.yml` must keep `fetch-depth: 0`, because `enableGitInfo` feeds
`.Lastmod` into `article:modified_time` and schema `dateModified` — real SEO
surface, not decoration. So it now also sets **`filter: blob:none`**: commits
and trees in full, *historical* blobs skipped, working-tree blobs fetched once
at checkout.

**Verified rather than assumed**, since the whole point is that GitInfo must
keep working:

- bare blobless clone: **4.7 MB in 1.1s** vs the 1.70 GiB pack (**370×**)
- `git log -1 -- content/blog/<post>/index.md` → correct commit date in
  **0.02s**, clone still 4.7 MB — **zero blobs fetched**

## Also: corrects an entry I wrote earlier today

`ci-gates` said "it's a hang, re-run it" without knowing *why*. It now carries
the upstream cause, the log check that distinguishes a stall from a genuine
failure (so nobody re-runs red that deserved to stay red), and the honest
limit: **this is a mitigation, not a cure.** The real floor is 625 MB of images
in git — an LFS/CDN decision, not a checkout flag.

Bundle + one workflow file. `bin/hugo-build` green; OKF conformant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)