### PR TITLE
Add /friday-report/ — the sample Friday report page the CTAs pointed at

### DIFF
--- a/bin/qtest
+++ b/bin/qtest
@@ -44,6 +44,7 @@ PAGE_TESTS = {
   "contact-us" => "contact_us",
   "free-consultation" => "free_consultation",
   "vibe-code-rescue" => "vibe_code_rescue",
+  "friday-report" => "friday_report",
   "simple-page" => "privacy_policy",
   # critical/privacy-policy-critical.css maps by basename; alias it to the
   # simple-page tests so a touch there doesn't abort as an unknown key

--- a/content/pages/friday-report/index.md
+++ b/content/pages/friday-report/index.md
@@ -1,0 +1,14 @@
+---
+title: The Friday Report - What You Get From Us Every Week | JetThoughts
+description: Every Friday you get one page in plain English - what shipped, what slipped and why, what is next, and what we need from you. Here is a full composite example, start to finish.
+author: Paul Keen
+type: page
+layout: friday-report
+slug: friday-report
+url: /friday-report/
+
+# No metatags.image: og images resolve as PAGE-BUNDLE resources (see
+# content/pages/free-consultation/), and this bundle has none yet - naming a
+# file that isn't here just falls back to og-default.jpg while reading as if
+# it were set. Add og-friday-report.jpg beside this file to claim one.
+---

--- a/docs/projects/2509-css-migration/css-bundle-ownership-map.md
+++ b/docs/projects/2509-css-migration/css-bundle-ownership-map.md
@@ -35,6 +35,7 @@ zero FL-Builder export files remain in any slice.
 | course-list | `layouts/course/list.html` (repo root, NOT in theme) | pages/course-list.css | 17.6K → 14.6K² | migrated (R1) |
 | privacy-policy | `page/single.html` (generic pages) | pages/simple-page.css | 17.1K → 14.6K | migrated (R1) |
 | not_found | `404.html` | — (404.css, dynamic-404.css) | 16.2K → 16.2K | no-FL |
+| friday-report | `page/friday-report.html` | pages/friday-report.css | new 2026-08-20 | born semantic (no FL modules; one `#fl-main-content` specificity override against legacy-theme-skin) |
 | pagination | `list.html` (second bundle) | — (pagination.css only) | 0.2K → 0.2K | no-FL |
 
 ¹ careers was a byte-identical verbatim move (3086-layout2 had zero dead

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -60,7 +60,7 @@ const purgecss = createPurgeCss({
       // card refinements) was silently purged because pp-swiper/pp-review
       // runtime classes had no shield. Restored deliberately.
       /^pp-swiper/, /^pp-review/,
-      /^notfound-/, /^use-case-/, /^services-/, /^service-/, /^about-/, /^home-/, /^careers-/, /^vcr-/,
+      /^notfound-/, /^use-case-/, /^services-/, /^service-/, /^about-/, /^home-/, /^careers-/, /^vcr-/, /^friday-/, /^cta-friday/,
       // Brand CTA buttons — preserve any selector mentioning these classes.
       // Standard safelist didn't catch tag+class compound selectors like
       // `a.fl-button` on CI (produced blue pills instead of Ruby red).

--- a/test/system/desktop_site_test.rb
+++ b/test/system/desktop_site_test.rb
@@ -294,6 +294,28 @@ class DesktopSiteTest < ApplicationSystemTestCase
     assert_stable_screenshot "vibe_code_rescue"
   end
 
+  def test_friday_report
+    visit "/friday-report/"
+
+    # The page exists to SHOW the artifact the homepage and the rescue page
+    # promise, so the four report blocks must render verbatim.
+    assert_text "The Friday report you get every week"
+    assert_text "What shipped"
+    assert_text "What slipped, and why"
+    assert_text "What we need from you"
+
+    # Honesty gate: we have no publishable client report, so the example must
+    # never render without saying it is a composite (claims-canon.md).
+    assert_text "This is a composite example, not a real client's report"
+
+    # One repeated CTA, pointing at the audit - the CTAs elsewhere on the site
+    # promised a report, this one has to promise the next step.
+    assert_link "Get a free code audit", minimum: 2
+
+    # No screenshot baseline yet: the 2608 site-wide recolour is mid-flight and
+    # would churn it immediately. Record with the bundle's first visual PR.
+  end
+
   def test_free_consultation
     visit "/"
 

--- a/test/system/mobile_site_test.rb
+++ b/test/system/mobile_site_test.rb
@@ -179,6 +179,19 @@ class MobileSiteTest < ApplicationSystemTestCase
     assert_stable_screenshot "vibe_code_rescue"
   end
 
+  def test_friday_report
+    visit "/friday-report/"
+
+    # The ICP reads this on a phone: the artifact and the honesty label must
+    # both survive the narrow column, not just the desktop layout.
+    assert_text "The Friday report you get every week"
+    assert_text "What slipped, and why"
+    assert_text "This is a composite example, not a real client's report"
+    assert_link "Get a free code audit", minimum: 2
+
+    # No screenshot baseline yet - see the desktop test for why.
+  end
+
   def test_free_consultation
     visit "/"
     # Add more specific scoping for Talk to an Expert button

--- a/themes/beaver/assets/css/pages/friday-report.css
+++ b/themes/beaver/assets/css/pages/friday-report.css
@@ -1,0 +1,370 @@
+/* Friday report sample page - light Rescue Room surface (ADR-0003).
+   Page prefix: friday-. Tokens only, no literals except the two rgba tints.
+   Structure copied from pages/vibe-code-rescue.css (proof chips in fold one,
+   one repeated CTA, artifact card, one dark band) minus its obsidian field. */
+
+.friday-page {
+  color: var(--ink-700);
+  font-family: var(--font-system-ui);
+  font-size: 17px;
+  line-height: 1.65;
+  background: var(--surface);
+}
+
+.friday-container {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.friday-page section {
+  padding: 48px 0;
+}
+
+.friday-page p {
+  max-width: 68ch;
+}
+
+/* ---------- Hero ---------- */
+
+.friday-page .friday-hero {
+  background: var(--ruby-050);
+  border-bottom: 1px solid var(--line);
+  /* the site header band overlays the top of the first section */
+  padding: 96px 0 48px;
+}
+
+.friday-eyebrow {
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ruby-700);
+  margin: 0 0 16px;
+}
+
+.friday-h1 {
+  font-weight: 800;
+  font-size: clamp(1.75rem, 5vw, 2.6rem);
+  line-height: 1.14;
+  letter-spacing: -0.02em;
+  color: var(--ink-900);
+  margin: 0 0 20px;
+}
+
+.friday-lede {
+  font-size: 19px;
+  color: var(--ink-700);
+  margin: 0 0 16px;
+}
+
+.friday-hero-actions {
+  margin: 28px 0 0;
+}
+
+/* Class starts with "cta" so the site-wide brand-blue anchor rule in
+   navigation.css exempts it and ruby applies without !important. */
+.cta-friday {
+  display: inline-block;
+  background: var(--color-ruby);
+  color: var(--surface);
+  font-weight: 700;
+  font-size: 17px;
+  line-height: 1.2;
+  text-decoration: none;
+  padding: 16px 28px;
+  border-radius: 10px;
+}
+
+.cta-friday:hover,
+.cta-friday:focus {
+  background: var(--ruby-700);
+  color: var(--surface);
+  text-decoration: none;
+}
+
+.cta-friday--dark:hover,
+.cta-friday--dark:focus {
+  background: var(--color-ruby-hover);
+}
+
+.friday-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  list-style: none;
+  margin: 32px 0 0;
+  padding: 0;
+}
+
+.friday-chip {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 10px 16px;
+}
+
+.friday-chip-label {
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+}
+
+.friday-chip-value,
+.friday-chip-value a {
+  font-weight: 700;
+  font-size: 17px;
+  color: var(--ink-900);
+}
+
+/* ---------- Honesty label ---------- */
+
+.friday-page .friday-disclaimer {
+  padding: 32px 0 8px;
+}
+
+.friday-disclaimer-box {
+  background: var(--ruby-100);
+  border-left: 4px solid var(--color-ruby);
+  border-radius: 0 10px 10px 0;
+  padding: 20px 24px;
+}
+
+.friday-disclaimer-title {
+  font-weight: 700;
+  font-size: 17px;
+  color: var(--ink-900);
+  margin: 0 0 8px;
+}
+
+.friday-disclaimer-body {
+  font-size: 16px;
+  color: var(--ink-700);
+  margin: 0 0 10px;
+}
+
+.friday-disclaimer-box .friday-disclaimer-body:last-child {
+  margin-bottom: 0;
+}
+
+/* ---------- Section headings ---------- */
+
+.friday-h2 {
+  font-weight: 800;
+  font-size: clamp(1.4rem, 3.4vw, 1.9rem);
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+  color: var(--ink-900);
+  margin: 0 0 24px;
+}
+
+/* ---------- The report card (the artifact) ---------- */
+
+.friday-page .friday-sample {
+  background: var(--surface-raised);
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.friday-card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: 0 1px 2px rgba(20, 17, 15, 0.05), 0 8px 24px rgba(20, 17, 15, 0.06);
+  overflow: hidden;
+}
+
+.friday-card-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 20px;
+  background: var(--surface-sunken);
+  border-bottom: 1px solid var(--line);
+  padding: 16px 24px;
+}
+
+.friday-card-meta {
+  font-size: 14px;
+  color: var(--ink-700);
+  margin: 0;
+}
+
+.friday-card-key {
+  color: var(--ink-500);
+  margin-right: 6px;
+}
+
+.friday-card-tag {
+  margin: 0 0 0 auto;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ruby-700);
+  background: var(--ruby-100);
+  border-radius: 999px;
+  padding: 4px 12px;
+}
+
+.friday-card-body {
+  padding: 8px 24px 4px;
+}
+
+.friday-block {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.friday-card-body .friday-block:last-child {
+  border-bottom: 0;
+}
+
+.friday-block-title {
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 0 0 12px;
+  padding-left: 14px;
+  border-left: 4px solid var(--ink-300);
+}
+
+.friday-block--shipped .friday-block-title {
+  border-left-color: var(--color-ruby);
+  color: var(--ruby-700);
+}
+
+.friday-block--slipped .friday-block-title {
+  border-left-color: var(--color-neon-purple);
+  color: var(--ink-900);
+}
+
+.friday-block--next .friday-block-title,
+.friday-block--you .friday-block-title {
+  color: var(--ink-900);
+}
+
+.friday-block p {
+  margin: 0 0 10px;
+}
+
+.friday-block p:last-child {
+  margin-bottom: 0;
+}
+
+/* max-width:none beats the page-wide 68ch paragraph measure - this <p> is a
+   full-bleed bar inside the card, not body copy. */
+.friday-page .friday-card-foot {
+  max-width: none;
+  background: var(--surface-sunken);
+  border-top: 1px solid var(--line);
+  font-size: 15px;
+  color: var(--ink-500);
+  margin: 0;
+  padding: 14px 24px;
+}
+
+/* ---------- What each part is for ---------- */
+
+.friday-rows {
+  margin: 0;
+  padding: 0;
+}
+
+.friday-row {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 8px 24px;
+  padding: 16px 0;
+  border-top: 1px solid var(--line);
+}
+
+.friday-rows .friday-row:last-child {
+  border-bottom: 1px solid var(--line);
+}
+
+.friday-row-key {
+  font-weight: 700;
+  color: var(--ink-900);
+  margin: 0;
+}
+
+.friday-row-value {
+  color: var(--ink-700);
+  margin: 0;
+}
+
+.friday-howto-note {
+  margin: 28px 0 0;
+  color: var(--ink-700);
+}
+
+/* ---------- The one dark band ---------- */
+
+.friday-page .friday-own {
+  background: var(--surface-ink);
+  color: var(--color-on-dark);
+  padding: 56px 0;
+}
+
+.friday-h2--dark {
+  color: var(--surface);
+}
+
+.friday-own p {
+  color: var(--color-on-dark);
+  margin: 0 0 16px;
+}
+
+.friday-own-actions {
+  margin: 28px 0 0;
+}
+
+/* ---------- Final CTA ---------- */
+
+.friday-page .friday-final {
+  background: var(--surface-raised);
+  border-top: 1px solid var(--line);
+}
+
+.friday-final p {
+  margin: 0 0 16px;
+}
+
+.friday-final-actions {
+  margin: 28px 0 0;
+}
+
+/* ---------- Mobile ---------- */
+
+@media (max-width: 640px) {
+  .friday-page .friday-hero {
+    padding: 80px 0 40px;
+  }
+
+  .friday-card-head,
+  .friday-card-body,
+  .friday-card-foot {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .friday-card-tag {
+    margin-left: 0;
+  }
+
+  .friday-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+
+  .cta-friday {
+    display: block;
+    text-align: center;
+  }
+}

--- a/themes/beaver/assets/css/pages/friday-report.css
+++ b/themes/beaver/assets/css/pages/friday-report.css
@@ -3,12 +3,20 @@
    Structure copied from pages/vibe-code-rescue.css (proof chips in fold one,
    one repeated CTA, artifact card, one dark band) minus its obsidian field. */
 
+/* id+class beats legacy-theme-skin's later-cascade .fl-page-content white
+   (new-page.md "white-wash override"). Same value today, but the disclaimer
+   and how-to-read sections carry no background of their own - without this
+   they'd stay hardcoded white if --surface ever moves off #ffffff, while the
+   rest of the page followed the token. */
+#fl-main-content.friday-page {
+  background: var(--surface);
+}
+
 .friday-page {
   color: var(--ink-700);
   font-family: var(--font-system-ui);
   font-size: 17px;
   line-height: 1.65;
-  background: var(--surface);
 }
 
 .friday-container {

--- a/themes/beaver/layouts/page/friday-report.html
+++ b/themes/beaver/layouts/page/friday-report.html
@@ -1,0 +1,157 @@
+{{ define "header" }}
+  {{- $resources := slice
+    (resources.Get "css/critical/base.css")
+    (resources.Get "css/pages/friday-report.css")
+    (resources.Get "css/dynamic-icons.css" | resources.ExecuteAsTemplate "css/dynamic586.css" .)
+    (resources.Get "css/586.css")
+    (resources.Get "css/vendors/base-4.min.css")
+    (resources.Get "css/style.css")
+    (resources.Get "css/legacy-theme-skin.css")
+    (resources.Get "css/footer.css")
+  -}}
+  {{ partialCached "assets/css-processor.html" (dict "resources" $resources "bundleName" "friday-report") "friday-report" }}
+{{ end }}
+
+{{ define "main" }}
+{{- $audit := relURL "free-consultation/" -}}
+<div id="fl-main-content" class="fl-page-content friday-page" role="main">
+  <article>
+
+    <section class="friday-hero">
+      <div class="friday-container">
+        <p class="friday-eyebrow">How we report</p>
+        <h1 class="friday-h1">The Friday report you get every week</h1>
+        <p class="friday-lede">Your last agency sent you a burndown chart and an invite to a board you couldn't read. We send one page of plain English, in the body of the email, every Friday.</p>
+        <p class="friday-lede">Below is the whole thing, start to finish, so you know what lands in your inbox before you hire anyone.</p>
+        <div class="friday-hero-actions">
+          <a class="cta-friday" href="{{ $audit }}">Get a free code audit</a>
+        </div>
+        <ul class="friday-chips" aria-label="JetThoughts track record">
+          <li class="friday-chip">
+            <span class="friday-chip-label">Rated on Clutch</span>
+            <span class="friday-chip-value"><a href="https://clutch.co/profile/jetthoughts" target="_blank" rel="noopener">4.8 / 5</a></span>
+          </li>
+          <li class="friday-chip">
+            <span class="friday-chip-label">Average client stays</span>
+            <span class="friday-chip-value">5 years</span>
+          </li>
+          <li class="friday-chip">
+            <span class="friday-chip-label">Shipping Rails</span>
+            <span class="friday-chip-value">since {{ site.Params.foundingYear }}</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    {{/* Honesty gate (claims-canon.md, testimonial purge of 2026-08-20): we have
+         no redacted client report cleared for publication, so this example is a
+         composite of the FORMAT and says so twice - here, and inside the card
+         itself. Never relabel it as a real engagement without a named source. */}}
+    <section class="friday-disclaimer" aria-labelledby="friday-disclaimer-title">
+      <div class="friday-container">
+        <div class="friday-disclaimer-box">
+          <p class="friday-disclaimer-title" id="friday-disclaimer-title">This is a composite example, not a real client's report</p>
+          <p class="friday-disclaimer-body">No client is named here, and none of these details belong to anyone's project. We built it out of the format we send, so you can read a whole one end to end.</p>
+          <p class="friday-disclaimer-body">A real report carries a link you can click yourself, and the name of the person who owes you an answer.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="friday-sample" aria-labelledby="friday-sample-title">
+      <div class="friday-container">
+        <h2 class="friday-h2" id="friday-sample-title">The report, in full</h2>
+
+        <div class="friday-card">
+          <div class="friday-card-head">
+            <p class="friday-card-meta"><span class="friday-card-key">From</span> your developer</p>
+            <p class="friday-card-meta"><span class="friday-card-key">Subject</span> Week 6 - Friday report</p>
+            <p class="friday-card-tag">Composite example</p>
+          </div>
+
+          <div class="friday-card-body">
+            <section class="friday-block friday-block--shipped">
+              <h3 class="friday-block-title">What shipped</h3>
+              <p>Customers can pay with Apple Pay at checkout. It's on staging now - your private copy of the app, safe to poke at. Sign in as demo@yourapp.test and try it on your phone, it takes about a minute.</p>
+              <p>The card form on desktop works exactly as it did before. Nothing you had already approved has moved.</p>
+            </section>
+
+            <section class="friday-block friday-block--slipped">
+              <h3 class="friday-block-title">What slipped, and why</h3>
+              <p>The order-history screen isn't done. Halfway through we found that refunds were never being recorded anywhere, so the screen would have shown your customers the wrong totals.</p>
+              <p>We stopped and fixed the recording first. That cost three days, and it pushes order history into next week.</p>
+            </section>
+
+            <section class="friday-block friday-block--next">
+              <h3 class="friday-block-title">What's next</h3>
+              <p>Order history, finishing what we started. Two developers, four days, done by Thursday.</p>
+              <p>Email receipts come after that. If you'd rather we did receipts first, say so before Monday and we'll swap them.</p>
+            </section>
+
+            <section class="friday-block friday-block--you">
+              <h3 class="friday-block-title">What we need from you</h3>
+              <p>Your Stripe live keys, by Tuesday. Payments can't go live without them, and every day past Tuesday moves the launch date by a day.</p>
+              <p>Hit reply and we'll send you a secure link to paste them into. Don't email us the keys themselves.</p>
+            </section>
+          </div>
+
+          <p class="friday-card-foot">Reply to this email with anything that isn't clear. You won't be asked to open a ticket.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="friday-howto" aria-labelledby="friday-howto-title">
+      <div class="friday-container">
+        <h2 class="friday-h2" id="friday-howto-title">What each part is for</h2>
+        <dl class="friday-rows">
+          <div class="friday-row">
+            <dt class="friday-row-key">What shipped</dt>
+            <dd class="friday-row-value">Always names something you can click yourself. If you can't go and try it, we don't call it shipped.</dd>
+          </div>
+          <div class="friday-row">
+            <dt class="friday-row-key">What slipped, and why</dt>
+            <dd class="friday-row-value">Says why, in enough detail that you could argue with it. Weeks where nothing slips are rare, and a report that never has this section is hiding something.</dd>
+          </div>
+          <div class="friday-row">
+            <dt class="friday-row-key">What's next</dt>
+            <dd class="friday-row-value">Named people and a number of days, sent before the work starts, so you can reorder it while reordering is still free.</dd>
+          </div>
+          <div class="friday-row">
+            <dt class="friday-row-key">What we need from you</dt>
+            <dd class="friday-row-value">Carries the only deadline on your side. Usually an access key or a decision - something nobody else can give us.</dd>
+          </div>
+        </dl>
+        <p class="friday-howto-note">You won't get a burndown chart, and nobody will invite you to a board you'd have to learn to read. If a week of work can't be explained in four short paragraphs, the problem is with the work.</p>
+      </div>
+    </section>
+
+    {{/* The one dark band on this page (ADR-0003), spent on the strongest proof. */}}
+    <section class="friday-own" aria-labelledby="friday-own-title">
+      <div class="friday-container">
+        <h2 class="friday-h2 friday-h2--dark" id="friday-own-title">You own the code after every milestone</h2>
+        {{/* Sourced phrasing only: "You own the code and every account after each
+             milestone" (page/vibe-code-rescue.html:102) and "not at some vague end"
+             (:114). An earlier draft said the server "sits on your card from the
+             first milestone" - a billing claim with no in-repo source. Canon rule:
+             a number or claim with no in-repo source is a defect, not a detail. */}}
+        <p>A weekly report is only worth reading if you can act on it. You own the code and every account after each milestone, handed over then and there, not at some vague end.</p>
+        <p>So if a Friday report tells you something you don't like, you can stop and walk out with everything.</p>
+        <div class="friday-own-actions">
+          <a class="cta-friday cta-friday--dark" href="{{ $audit }}">Get a free code audit</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="friday-final" aria-labelledby="friday-final-title">
+      <div class="friday-container">
+        <h2 class="friday-h2" id="friday-final-title">Want one of these about your own codebase?</h2>
+        <p>The free code audit ends in the same kind of one-pager: which parts of your code are solid and which are fragile, plus the three fixes that would help most.</p>
+        <p>One senior developer reads your code and writes it - no sales call in between. You keep the write-up whether or not we work together.</p>
+        <div class="friday-final-actions">
+          <a class="cta-friday" href="{{ $audit }}">Get a free code audit</a>
+        </div>
+      </div>
+    </section>
+
+  </article>
+</div>
+{{ end }}


### PR DESCRIPTION
2608 Phase 3. Built by a swarm lane, reviewed twice.

## Why

The weekly plain-English report is JetThoughts' strongest differentiator, and
the design system points at it repeatedly — the homepage prototype's hero says
"See a real Friday report". **No such page existed.** Verified before building:
`ls content/pages/` plus a repo-wide grep found only the homepage teaser
partial (whose CTA goes to `/free-consultation/`), so nothing was duplicated.

## Honesty — the constraint that shaped the page

We do not have a publishable real client report, so the sample is a **composite,
labelled three times**: a ruby-bordered disclaimer band under the hero, a second
line stating no client is named, and a `COMPOSITE EXAMPLE` pill on the card
head. A skimmer cannot reach the sample without crossing a full-width
disclaimer. No person, company, industry or outcome metric appears; the demo
login uses the reserved `.test` TLD so it cannot resolve.

Cold-eyes' framing: it **claims less than we can verify**, rather than the
"names changed, numbers accurate" form relabelled earlier today.

One claim was **removed, not reworded** — "the server sits on your card from the
first milestone" had no in-repo source. Note the reviewer's own suggested fix
would have *preserved* the unsourced assertion in nicer words; removal was the
right call and a code comment records why, so it cannot be reinstated by
someone who thinks it reads better.

## Review

- **Cold-eyes ICP / voice / honesty:** CHANGES REQUESTED (5 blocking, 8 non-blocking) → all applied → **APPROVED** on re-read.
- **Correctness:** closed by the coordinator after three review agents died on a credit limit. The two shared-file changes were the only collision risk, and the over-match concern was verified **independently on master**, not from the author's grep: zero `friday-`/`cta-friday` classes or selectors exist anywhere else, so `postcss.config.js:63` is inert outside this page. `bin/qtest:47` is one additive entry.

## The third commit is a latent-bug fix worth reading

Two sections computed to `background-color: rgba(0,0,0,0)` — the white behind
them was `legacy-theme-skin.css`'s hardcoded `.fl-page-content`, which ships
after the page slice. **Zero visual delta today** (both are `#ffffff`), which is
exactly why it would have sat there — and it detonates the moment a `--surface`
token moves off white, leaving a half-recoloured page. Fixed with the
`id+class` form `new-page.md` prescribes.

## Gates

`bin/hugo-build` green (1175 pages, 8 validators) · `marketing_copy_test` green
· both new tests green · `bin/test --smoke` 17/17 with baselines untouched ·
stylelint 0 warnings · rendered 1440×900 (4,193px) and 390×844 (6,059px), zero
overflow, zero console errors, no paragraph over 5 rendered lines, contrast
≥5.07:1.

Screenshot baselines deliberately **not** recorded here — Lane A's site-wide
recolour will churn them; they belong on the integrating PR.

## Known, not caused by this PR

`bin/qtest <page>` rewrites a rotating client-page baseline per run (a different
file each time, none on this diff's pages). It will abort a qtest run on the
dirty-baseline guard and read as a regression. `bin/test --smoke` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)