### PR TITLE
Sprint C4: vendor-price verification card + eight ideas relabelled blocked-on-arrival

### DIFF
--- a/docs/projects/2605-tech-for-non-technical-founders/50-59-execution/50.03-course-sprints-2026-08-groomed.md
+++ b/docs/projects/2605-tech-for-non-technical-founders/50-59-execution/50.03-course-sprints-2026-08-groomed.md
@@ -366,6 +366,67 @@ this entry closes off.
 
 ---
 
+## Sprint C4 - Vendor-price verification (scheduled 2026-08-21, cold-session executable)
+
+**Why this and nothing else from the roadmap.** With C0-C3 closed, a roadmap
+audit on 2026-08-21 found the rest of the course backlog splits into
+opportunistic (the 31 SVG floor candidates) and blocked-on-arrival (eight items
+gated on reader data that 5 `start_course` events per 28 days cannot produce -
+see the ideas bank). **This is the only remaining item that degrades on its
+own.** 40.04 already flagged it - *"Lovable price drift survived two previous
+sweeps"* - and recommended an annual refresh cadence "to add to TASK-TRACKER"
+that never got added. A stale price is the same defect class as an unsourced
+stat, and for an ICP burned by a devshop it reads as carelessness.
+
+**THE DISTINCTION THAT MAKES THIS SAFE - read before editing anything.** Two
+kinds of dollar figure live in the course and they are mixed *inside the same
+files*:
+
+- **Vendor prices** - what a named tool actually charges. Verify against the
+  vendor's live pricing page. Example: `validation-tools-field-guide` L86
+  "VenturusAI ... Pro from $10/mo", L233 "Radar | $9/mo".
+- **Narrative / teaching figures** - a scenario, Mia's business, an
+  illustrative unit economic. **Do NOT touch these.** Example: same file L111
+  "Subscription model at $200/mo" (Mia's fictional clinic app), L74 "$50/mo
+  pricing when the market pays $15" (a worked example).
+
+Changing a narrative figure breaks a teaching example and, where the number
+recurs across chapters, breaks the walkthrough's internal consistency. When
+unsure which kind a figure is, leave it and list it in the PR.
+
+**Scope.** 28 files carry `$X/mo`-shaped figures; 55 name a vendor
+(Lovable, Supabase, Mixo, Carrd, Bubble, Stripe). Inventory:
+`grep -rlE '\$[0-9]+(/mo|/month| per month)' content/course/tech-for-non-technical-founders-2026/`
+
+**Two of those 28 are SVGs, not markdown** -
+`mom-test-ask-about-past-not-future/mom-test-script.svg` and
+`reference/mom-test-full/good-vs-bad-answers.svg`. Prices inside artwork are
+invisible to every text ratchet we run; this is the third instance of the
+exhibit-blindness trap in a month (see `.okf/log.md` 2026-08-20 and the
+`paid-pilot` bar chart on 2026-08-20). If an SVG figure changes, re-export the
+PNG too where one exists.
+
+**Steps.** (1) Build the vendor list from the inventory grep and separate the
+two figure kinds. (2) Verify each vendor price against its live pricing page,
+recording the URL and the date checked. (3) Fix only what actually drifted.
+(4) Record the verified list somewhere durable so the next refresh is a diff,
+not a re-derivation - 40.04's own conclusion was *"tool-pricing canonical list
+belongs in ADR + annual refresh task, not chapter content"*, so a canonical
+table with per-row source + checked-date is the deliverable, not just edits.
+(5) Set the next refresh trigger a year out.
+
+**Gates.** Content-only class unless an SVG changes: `bin/hugo-build` + the
+rendered scroll gate on edited pages. An edited exhibit takes the full
+new-media visual gate at both viewports. Quote the source URL and check-date
+for every changed figure in the PR - a price with no in-repo source is the
+defect this card exists to remove, so do not replace one unsourced number with
+another.
+
+**Out of scope.** Narrative figures, canon company numbers
+(`.okf/content/claims-canon.md` owns those), and anything about course SEO.
+
+---
+
 ## Not scheduled (explicitly, so nobody re-litigates)
 
 - **Item 7** Wave G Batch 2 publish - BLOCKED on the blog->course bridge gate.

--- a/docs/projects/2605-tech-for-non-technical-founders/LOW-IMPACT-IDEAS-BANK.md
+++ b/docs/projects/2605-tech-for-non-technical-founders/LOW-IMPACT-IDEAS-BANK.md
@@ -8,6 +8,46 @@
 
 ---
 
+## ⛔ BLOCKED ON ARRIVAL, not "deferred" (relabelled 2026-08-21)
+
+**Read this before picking anything below.** A roadmap audit on 2026-08-21 found
+that eight items in this bank are gated on reader/GA4 data, and at current
+traffic **that data cannot be produced**. The 28-day funnel is
+`start_course` **5**, checkpoint-reveal **4**, branch-click **2**, glossary
+**1**. You cannot derive a Carrd-fallback rate, a finisher cohort, or
+"demonstrated GA4 demand" from five course starts.
+
+They had been carried as "deferred" across multiple sessions, which reads as
+*ready when we get to it*. They are not. They are **waiting on course arrival**,
+and course arrival is a distribution problem being tested on one channel
+(LinkedIn, cards LI-0..LI-D in `linkedin-posts/content-plan.md`). Google and AEO
+were both closed for the course on 2026-08-21 - see
+[`50-59-execution/50.05-course-discovery-diagnosis-2026-08-21.md`](50-59-execution/50.05-course-discovery-diagnosis-2026-08-21.md).
+
+| Item | Its trigger | Reachable today? |
+|---|---|---|
+| Ch 2.2 AI Personas → optional sidebar | "revisit after reader data" | No |
+| Ch 2.4 silent-observation resistance | "needs user testing data" | No |
+| Lesson 1.2a split by builder path | Carrd-fallback rate from analytics | No |
+| Template "when you need this" timing guide | reader data (structural change) | No |
+| Deferred briefs + Operating-Kit templates | "demonstrated GA4 demand" | No |
+| Option 2 services bridge | GA4 shows "a real finisher cohort" | No |
+| Post-ship retrospective (40.02) | 2+ weeks of live data | No |
+| Pilot → testimonials | 3-5 real completions | No |
+
+**Do not attempt to unblock these by lowering the bar** - shipping a structural
+change on 5 sessions of data is guessing with extra steps, and the original
+deferrals were right to demand evidence. Revisit when a channel puts sustained
+readers into Modules 1-3.
+
+**Still genuinely actionable** (needs no reader data): the vendor-pricing
+verification pass, now scheduled as **Sprint C4** in
+[`50-59-execution/50.03`](50-59-execution/50.03-course-sprints-2026-08-groomed.md),
+and the 31 SVG floor candidates (opportunistic, render-gate per image, never
+batch).
+
+---
+
 ## Applied (moved to course chapters)
 
 | Idea | Where Applied | Date |


### PR DESCRIPTION
Follow-up to #508. Docs-only. Answers "what else is left from the roadmap to improve the course" by scheduling the one item worth scheduling and correcting the status of eight that were mislabelled.

I made this call rather than waiting on an answer — both changes are docs-only and reversible. Close this PR if you disagree.

## Sprint C4 — vendor-price verification

**The only remaining roadmap item that degrades on its own.** 28 course files carry `$X/mo`-shaped figures; 55 name a vendor (Lovable, Supabase, Mixo, Carrd, Bubble, Stripe). 40.04 already flagged it — *"Lovable price drift survived two previous sweeps"* — and asked for an annual refresh cadence that was never added to any tracker.

**The card leads with the distinction that makes it safe to hand off.** The two kinds of dollar figure are mixed *inside single files*:

| Kind | Example | Action |
|---|---|---|
| Vendor price | `validation-tools-field-guide` L86 — "VenturusAI … Pro from $10/mo" | Verify against live pricing page |
| Narrative / teaching | same file L111 — "Subscription model at $200/mo" (Mia's fictional clinic app) | **Do not touch** |

A naive "refresh the prices" pass would corrupt teaching examples and break walkthrough consistency wherever a narrative number recurs across chapters.

**Two of the 28 are SVGs, not markdown** — `mom-test-script.svg` and `good-vs-bad-answers.svg`. Prices inside artwork are invisible to every text ratchet we run. That is the third instance of the exhibit-blindness trap in a month (the `paid-pilot` bar chart yesterday, the LI asset before it), so the card carries the re-export requirement explicitly.

Deliverable is a canonical table with per-row source URL and checked-date, not just edits — that was 40.04's own conclusion, and it makes the next refresh a diff rather than a re-derivation.

## Eight ideas relabelled: "deferred" → BLOCKED ON ARRIVAL

Ch 2.2 sidebar · Ch 2.4 resistance · 1.2a builder-path split · template timing guide · deferred briefs · Option 2 bridge · post-ship retro · pilot testimonials.

Every one is gated on reader/GA4 data. The 28-day funnel is `start_course` **5**, checkpoint-reveal **4**, branch-click **2**, glossary **1**. You cannot derive a Carrd-fallback rate, a finisher cohort, or "demonstrated GA4 demand" from five course starts.

"Deferred" reads as *ready when we get to it*, and they have been carried that way across several sessions as if a clock were running. They are waiting on distribution — the same constraint the LinkedIn cards test. The note explicitly forbids the tempting workaround: shipping a structural change on 5 sessions of data is guessing with extra steps, and the original deferrals were right to demand evidence.

## Net effect on the course roadmap

- **Scheduled:** C4 (this).
- **Opportunistic:** 31 SVG floor candidates, render-gate per image, never batch.
- **Blocked on arrival:** the eight above.
- **Closed:** course SEO/AEO (#508), certificate, video, mail list.

Gates: docs-only, `bin/hugo-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
