### PR TITLE
OKF: three publishing gates learned from claims we shipped wrong

### DIFF
--- a/.okf/log.md
+++ b/.okf/log.md
@@ -51,6 +51,38 @@ two artifacts each. Verified against each walkthrough's own lesson links before
 "fixing" anything.
 
 
+## 2026-08-20 - Three publishing gates, all learned from claims we shipped wrong
+
+Added to [blog-pipeline](workflows/blog-pipeline.md), because all three are
+gates rather than background:
+
+1. **Technical claims must be executed, not read.** Every wrong technical
+   claim shipped this day came from reading source and inferring behaviour.
+   The Kamal 2 guide (#506) opened by asserting a stale `traefik:` key sits
+   in `deploy.yml` doing nothing; `kamal config` answers
+   `ERROR (Kamal::ConfigurationError): unknown key: traefik`. The bad
+   inference came from `Validator::Configuration#allow_extensions? => true`,
+   which governs YAML extension keys and not arbitrary config keys. Same
+   post told readers to find a mistyped secret with `kamal config`, but
+   `Configuration#to_h` emits no `env` and no `proxy`, so it exits 0
+   unchanged - the gem's own stale `desc` string was inherited untested.
+   A reviewer who ran the command falsified an opening thesis that
+   source-reading passes had approved.
+
+2. **Frontmatter is published copy.** #509 shipped live: the body was
+   softened to "whether the model was being retired or quietly
+   substituted" while `twitter_description` still asserted "a retired
+   model took out five features at once". The softening reached the prose
+   and not the metatags, so the page kept the claim the edit existed to
+   remove. Diff meta against body before merge.
+
+3. **Citation lists use `## Sources`.** 4 posts already used it; 16 had
+   drifted across `## Further reading`, a bare `Further reading:`
+   paragraph, and a bold `**Further reading:**` line (#510). The bold
+   variant survived the first survey because the grep only matched the
+   other two - a partial sweep reads as a finished one. Internal links
+   belong in body prose or the theme's `Read next`, not in this list.
+
 ## 2026-08-20 - Bundle compaction: the log was 37% of the bundle, and two concepts were copies
 
 Re-reviewed every file for size. The bundle was 359KB; 52% of it was two

--- a/.okf/workflows/blog-pipeline.md
+++ b/.okf/workflows/blog-pipeline.md
@@ -4,9 +4,13 @@ title: Blog Post Pipeline (Idea to Published)
 description: Canonical end-to-end workflow for drafting, reviewing, and publishing a JetThoughts blog post — mandatory for any write/draft/schedule/publish request.
 resource: docs/workflows/blog-pipeline.md
 tags: [content, blog, workflow]
+timestamp: 2026-08-20T00:00:00Z
 generated:
   by: process:okf-migrate
   at: 2026-07-19T00:00:00Z
+verified:
+  - by: claude/opus-5
+    at: 2026-08-20T00:00:00Z
 ---
 
 # Overview
@@ -48,6 +52,64 @@ closings, therapist voice, staccato fragment stacking, noun stacking
 without a human subject, telling instead of showing, apologetic
 caveats, fabricated timelines/stats. Full list + fixes in the
 [voice-guide](/content-strategy/voice-guide.md).
+
+# Technical claims must be executed, not read (blocking)
+
+A claim about how an external tool behaves is verified by RUNNING the
+tool, never by reading its source and inferring. Reading source and
+asserting behaviour produced every wrong technical claim we shipped on
+2026-08-20.
+
+Worked example, same day, twice on the same page. The Kamal 2 guide
+opened by saying a stale `traefik:` key sits in `config/deploy.yml`
+doing nothing. One command falsified it:
+
+```bash
+kamal config
+# ERROR (Kamal::ConfigurationError): unknown key: traefik
+```
+
+Kamal validates every top-level key and refuses. The wrong inference
+came from reading `Validator::Configuration#allow_extensions? => true`
+and concluding unknown keys pass — that flag governs YAML extension
+keys, not arbitrary config keys. The same post told readers to run
+`kamal config` to find a mistyped secret name; `Configuration#to_h`
+emits roles/hosts/image/builder/accessories and neither `env` nor
+`proxy`, so the command exits 0 with byte-identical output and cannot
+show what was claimed. Its own `desc` string ("including secrets!") is
+stale, and the draft inherited that instead of testing it.
+
+Rule: if a claim is executable, execute it before publishing. A
+reviewer who runs the command outranks one who reads the file — on
+2026-08-20 the runner falsified an article's opening thesis that four
+source-reading passes had approved.
+
+# Frontmatter is published copy (blocking)
+
+`description`, `og_description`, `twitter_description` and
+`cover_image_alt` ship to readers, so they get the same claims check as
+prose. Diff them against the body before merge.
+
+Caught 2026-08-20 (#509, live on the site): a post's body was softened
+to "whether the model was being retired or quietly substituted", while
+`twitter_description` still asserted "a retired model took out five
+features at once". The softening landed in the prose and not in the
+metatags, so the page kept making the exact claim the edit existed to
+remove.
+
+# Citation lists use `## Sources`
+
+The heading for a post's external-citation list is `## Sources` — a
+real heading, not a bare `Further reading:` paragraph and not a bold
+`**Further reading:**` line. Plain-text markers get no table-of-contents
+entry, no screen-reader landmark, and no visual separation from the body.
+
+Convention count on 2026-08-20 before normalization: 4 posts already
+used `## Sources`; 16 had drifted across three other forms and were
+converted (#510). Internal JT links do NOT belong in this list — they go
+in body prose or the theme's auto-generated `Read next`
+(`themes/beaver/layouts/partials/blog/related-posts.html`, opt out with
+`related_posts: false`).
 
 # Cross-post repetition gates (blocking for cluster posts)
 

--- a/.okf/workflows/index.md
+++ b/.okf/workflows/index.md
@@ -3,7 +3,7 @@
 * [Company-layer ownership](company-layer-ownership.md) - vault owns ALL operations (loop, pipeline, runbook; re-settled 2026-08-20), repo owns growth/marketing campaigns, claims canon owns the facts
 * [Render verification](render-verification.md) - headless Chrome + slicing recipes for the visual scroll gate
 * [Review swarm](review-swarm.md) - the two-critic review pattern and its failure modes
-* [Blog Post Pipeline](blog-pipeline.md) - mandatory end-to-end workflow for writing/publishing blog posts
+* [Blog Post Pipeline](blog-pipeline.md) - mandatory end-to-end workflow for writing/publishing blog posts, plus the execute-don't-read claims gate, the frontmatter claims check, and the `## Sources` citation convention
 * [LinkedIn Post Pipeline](linkedin-post-pipeline.md) - Paul Keen voice rules and posting workflow
 * [CSS Maintainability Redesign](css-maintainability-plan.md) - approved plan for hand-editable CSS + FL-Builder retirement
 * [Visual Scroll Gate](visual-scroll-gate.md) - blocking pre-handback visual walk for content/visual changes


### PR DESCRIPTION
## What

OKF sync for today's merged work (#499, #501, #506, #509, #510). Three durable learnings, all captured as **gates** in `workflows/blog-pipeline.md` rather than as log entries — following the bundle's own rule that a lesson still mattering six weeks later belongs in a concept.

## The three gates

**1. Technical claims must be executed, not read.**

Every wrong technical claim shipped today came from reading source and inferring runtime behaviour. The Kamal guide (#506) opened by asserting a stale `traefik:` key sits in `deploy.yml` doing nothing. One command:

```
ERROR (Kamal::ConfigurationError): unknown key: traefik
```

Kamal validates every top-level key and refuses. The bad inference came from reading `Validator::Configuration#allow_extensions? => true` and concluding unknown keys pass — that flag governs YAML *extension* keys, not arbitrary config keys. The same post told readers to find a mistyped secret with `kamal config`, but `Configuration#to_h` emits neither `env` nor `proxy`, so it exits 0 with byte-identical output; the gem's own stale `desc` string ("including secrets!") was inherited untested.

A reviewer who **ran** the command falsified an article's opening thesis that source-reading passes had approved.

**2. Frontmatter is published copy.**

#509 shipped live: the body was softened to "whether the model was being retired or quietly substituted" while `twitter_description` still asserted "a retired model took out five features at once". The softening reached the prose and not the metatags, so the page kept making the exact claim the edit existed to remove. `description` / `og_description` / `twitter_description` / `cover_image_alt` now get the same claims check as prose.

**3. Citation lists use `## Sources`.**

4 posts already used it; 16 had drifted across `## Further reading`, a bare `Further reading:` paragraph, and a bold `**Further reading:**` line (#510). The bold variant survived my first survey because the grep matched only the other two — a partial sweep reads exactly like a finished one. Internal links belong in body prose or the theme's `Read next`, not in this list.

## Bookkeeping

- `workflows/blog-pipeline.md`: three new sections, plus `timestamp` and an honest `verified` stamp (`claude/opus-5`, today) per the bundle's v0.2 provenance convention
- `workflows/index.md`: entry widened to name the three gates, so a cold session finds them without opening the file
- `log.md`: one dated entry, newest-first

No new concept files — all three fit existing ones, per the repo's consolidate-first rule.

## Validation

```
uv run okf_validate.py .okf --strict  ->  ✓ conformant (64 warnings)
```

Zero errors. **Warning count measured against a clean tree first**, so 64 is a verified baseline rather than an assumption — this change adds none. Remaining warnings are pre-existing: log headings that carry a title after the ISO date, and `timestamp` absent on seven other workflow concepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
