### PR TITLE
Phase 2 specs + pre-ship baseline: both blog phases already shipped

### DIFF
--- a/.okf/architecture/blog-list-page.md
+++ b/.okf/architecture/blog-list-page.md
@@ -10,7 +10,7 @@ generated:
 verified:
   - by: claude/opus-5
     at: 2026-08-20T00:00:00Z
-timestamp: 2026-08-20T00:00:00Z
+timestamp: 2026-08-21T01:20:00Z
 ---
 
 # Overview
@@ -37,6 +37,17 @@ Tag pages render from a SEPARATE template — `themes/beaver/layouts/list.html`
 (kind `term`) — which drifted from the index for months (hashtag tags,
 `target="_blank"` cards, no reading time) because both carried their own copy
 of the row markup. Three partials are now the single source for both:
+
+**The drift has a second, quieter form: template CONDITIONS.** Those tag pages
+have `.Section == "tags"`, not `"blog"`, despite their `/blog/tags/` URL — see
+[hugo-site](/architecture/hugo-site.md). So a `eq .Section "blog"` guard added
+anywhere (analytics, meta tags, CSS class hooks) silently covers the index and
+skips the term pages. Unifying the markup did not unify the predicates; check
+both kinds in rendered output whenever you add one.
+
+Still outstanding on this template: `list.html:51` and `:70` carry inline
+`style="margin: 0!important;padding: 0!important"` on both taxonomy H1
+variants, which no stylesheet rule can override.
 
 | Partial | Renders |
 |---|---|

--- a/.okf/architecture/hugo-site.md
+++ b/.okf/architecture/hugo-site.md
@@ -4,6 +4,9 @@ title: JetThoughts Hugo Site
 description: Hugo static site generator setup for the JetThoughts marketing site and blog (JTWay).
 resource: config/_default/hugo.toml
 tags: [hugo, build, config]
+timestamp: 2026-08-21T01:20:00Z
+verified:
+  - { by: claude/opus-5, at: 2026-08-21T01:20:00Z }
 generated:
   by: process:okf-migrate
   at: 2026-07-12T00:00:00Z
@@ -21,6 +24,19 @@ Key config choices (`config/_default/hugo.toml`):
 - `baseURL = "https://jetthoughts.com/"`, `theme = "beaver"`.
 - Permalinks: pages at `/:slug/`, blog posts at `/blog/:slug/`, tag
   taxonomy at `/blog/tags/:slug/`.
+
+  **A permalink rewrite does NOT change `.Section` or `.Kind`** (2026-08-21,
+  caught in review before it shipped). The taxonomy is declared
+  `tag = "tags"` and only `[permalinks.term]` rewrites the URL, so a page
+  served at `/blog/tags/rails/` still has `.Section == "tags"` and
+  `.Kind == "term"`. Any template condition of the form
+  `eq .Section "blog"` therefore MISSES every tag page while looking like it
+  covers them - the URL says blog, the page object does not. A proposed
+  analytics gate was written this way and would have shipped instrumentation
+  that silently skipped the pages it named. Gate on `.Kind`
+  (`term`/`taxonomy`) or on the section the taxonomy actually belongs to, and
+  verify BOTH page kinds in the rendered output rather than reasoning from
+  the URL.
 - `[build] writeStats = true` — Hugo writes `hugo_stats.json`, which
   PostCSS/PurgeCSS reads to know which CSS classes are actually used
   on the page (see [css-pipeline](/architecture/css-pipeline.md)).

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -6,11 +6,12 @@ tags: [testing, visual-regression, gates]
 status: stable
 generated: { by: claude/opus-4-8, at: 2026-08-12T20:20:00Z }
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T00:50:00Z }
   - { by: claude/fable-5, at: 2026-08-01T11:30:00Z }
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T23:45:00Z }
   - { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
-timestamp: 2026-08-21T00:00:00Z
+timestamp: 2026-08-21T00:50:00Z
 ---
 
 # The suites
@@ -237,6 +238,44 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
   `_dest/public-test-local`. Clear the dest dir before trusting a RED, the
   same way a screenshot baseline must be COMMITTED before trusting a
   re-record (both are "the assertion is right, the input is stale").
+
+- **A `skip_area` mask can blind a gate completely, at any tolerance**
+  (2026-08-21). All four blog-index screenshots mask BOTH `.blog-post` and
+  `.post-feature` (`test/system/desktop_site_test.rb:34,42`,
+  `test/system/mobile_site_test.rb:25,33`) - and `.post-feature` IS the
+  feature slot the blog index was rebuilt around. The index's entire content
+  area has never been visually gated. Phase 2.1 and 2.2 shipped through that
+  hole on 2026-08-20 and nobody noticed for a day.
+
+  This is strictly worse than the 2% tolerance trap above: tolerance is a
+  STATISTICAL blindness that a big enough change defeats, a mask is a
+  STRUCTURAL one that no change defeats. Masks are usually added for a good
+  reason (post content churns as posts are added, so unmasked baselines would
+  never settle) - but a mask over a COMPONENT rather than over dynamic TEXT
+  silently removes it from coverage forever. When adding one, mask the
+  smallest volatile region, and grep the mask list before trusting a green
+  run on a component you just changed.
+
+- **Local gates are the merge authority while CI is unreliable** (Paul,
+  2026-08-21: "use local tests for now, CI is under attack is not reliable").
+  CI checks become informational; gate on `bin/rake test:unit` +
+  `bin/hugo-build` + `bin/qtest --changed`, plus the macOS `bin/test` leg for
+  visual work, and quote those results in the PR. **macOS only** - never cite
+  `dtest` from a worktree (vacuous-green, above).
+
+  The consequence must be stated, not hidden: work that moves Linux baselines
+  ships on macOS evidence, so **master's Linux screenshot job goes red and
+  stays red** until one batched CI dispatch re-records. That is accepted,
+  written-down debt - PR #518 carries it - and it is cleared by CI, never by
+  recording locally. Say so in the PR rather than letting a reader assume
+  both legs were run.
+
+- **Quote the compared COUNT, not just "0 failures"** (2026-08-21). A suite
+  that compared nothing and a suite that compared everything both print
+  `0 failures`. The distinguishing line is
+  `[snap_diff] N screenshots compared, no failures.` - cite the N. #518 cites
+  `53 screenshots compared`, which is what makes its green legible as
+  evidence rather than as an absence of errors.
 
 - **A rendered-output sweep can look thorough and check almost nothing**
   (2026-08-20). Count the DISTINCT values a sweep actually resolves before

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -243,9 +243,14 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
   (2026-08-21). All four blog-index screenshots mask BOTH `.blog-post` and
   `.post-feature` (`test/system/desktop_site_test.rb:34,42`,
   `test/system/mobile_site_test.rb:25,33`) - and `.post-feature` IS the
-  feature slot the blog index was rebuilt around. The index's entire content
-  area has never been visually gated. Phase 2.1 and 2.2 shipped through that
-  hole on 2026-08-20 and nobody noticed for a day.
+  feature slot the blog index was rebuilt around.
+
+  **Scope it precisely** (narrowed 2026-08-21 after review - the first draft
+  said "the entire content area" and "2.1 and 2.2 shipped through that hole",
+  both overstated). The masks hide the LISTING ROWS and the FEATURE SLOT only;
+  the lead, filters, CTA band and pagination on that page remain covered. And
+  the POST template has 24 dedicated baselines of its own, so Phase 2.2 was
+  never unguarded. What went unseen is Phase 2.1's rows and feature slot.
 
   This is strictly worse than the 2% tolerance trap above: tolerance is a
   STATISTICAL blindness that a big enough change defeats, a mask is a

--- a/.okf/design/site-palette.md
+++ b/.okf/design/site-palette.md
@@ -7,7 +7,7 @@ tags: [design, palette, css, tokens, adr]
 generated:
   by: claude/opus-5
   at: 2026-08-20T00:00:00Z
-timestamp: 2026-08-20T00:00:00Z
+timestamp: 2026-08-21T01:20:00Z
 ---
 
 # Resolved: LIGHT (ADR-0003, 2026-08-20)
@@ -85,11 +85,29 @@ anything else going dark is a defect:
 
 # Deprecations in progress
 
-`--color-primary` (`#1a8cff`) is named "primary" and dies in 2608 Phase 1a.2,
-along with the late-cascade `#0066d6` anchor rule in 1a.3. WHEN those phases
-run relative to everything else is a separate decision - see the
-[rollout sequence](/workflows/site-redesign-rollout.md); the blog bundles ship
-before the site-wide chrome, so tokens land in blog CSS first.
+`--color-primary` (`#1a8cff`) **is gone as of 2026-08-21** — deleted in Phase
+1a.2 along with the late-cascade `#0066d6` anchor rule in 1a.3, both shipped
+in PR #518. The only surviving matches in `themes/beaver/assets/css/` are
+seven COMMENTS recording what each rule replaced (`/* was
+var(--color-primary) */`); a grep that counts them reads as if the token
+survived. Grep for `var(--color-primary` with the opening paren and read the
+hits before concluding a token is still live.
+
+## The `--rr-*` aliases die next, in 1a.4 — verify by grep, never by list
+
+Phase 1a.1 promoted the Rescue Room tokens into
+`foundations/css-variables.css:110-116` as `--rr-*` aliases marked
+DELETE-in-1a.4. They are consumed in three files as of 2026-08-21:
+`pages/blog-list.css`, `single-post.css`, and `pages/blog-single.css`.
+
+**Do not delete the alias block against a written inventory.** A spec's list
+of consumers was wrong twice in one review (2026-08-21): it omitted a live
+line and named a file carrying zero references. `single-post.css` is the one
+that makes this dangerous — its `--rr-*` declarations set CTA and tag colour
+and background, and that file is a member of the COURSE bundle too, so
+deleting the aliases early breaks styling on blog AND course. Re-run
+`grep -rn 'var(--rr-' themes/beaver/assets/css/` at the moment of deletion and
+believe the output, not the doc.
 
 **It is the logo's colour, and that is the point, not a reason to keep it.**
 `themes/beaver/assets/img/icons/logo-dark.svg` contains exactly one hex value:

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -3,6 +3,45 @@
 Newest first. Entries before 2026-08-19 are squashed to one line each
 (compacted 2026-08-20); their full text is in this file's git history.
 
+## 2026-08-21 - the deferred pass, and two of my own claims corrected
+
+Ran the pass queued on #516 once that PR merged (it could not run earlier: the
+session was checked out on #518, where this bundle state did not exist).
+
+**Corrections to `workflows/site-redesign-rollout.md`, written four passes ago:**
+
+* The engagement figure. The concept repeated the plan's "25.2% scroll / 26.3s
+  vs a 32.9-40.3% site average". Measured: that is ONE 3-day Clarity window of
+  five and the lowest, the windows swing 2.9x, and session-weighted across 743
+  sessions the blog is at **44.31% / 34.97s** - at or above the average it was
+  said to trail. It also straddles the 08-20 deploy; the clean pre-ship figure
+  is 08-06->08-17, 451 sessions, 56.4% / 40.1s. Blog-first still holds, on a
+  better fact: GSC puts the blog at 77% of the site's Google traffic.
+* The course coupling. The concept repeated 20.01's "2.2 couples the course
+  page". True of the FILE, false of the SELECTORS: `course/single.html:55` has
+  no `.post-article` and all 15 styled rules are `.post-article`-prefixed.
+  DECOUPLED - 2.3 need not follow 2.2. The genuinely shared file is
+  `single-post.css`, which also drives `bin/generate-template-pdfs`.
+
+Both were inherited from the plan doc without independent verification, which
+is the same failure the new "check phase status against GIT, not the plan
+table" rule now names: Phase 2.1 and 2.2 had ALREADY SHIPPED (#487, #494, both
+2026-08-20) while the plan still listed them pending, and a status answer was
+given from the table.
+
+**Added:**
+
+* `build/test-gates.md` - a `skip_area` mask blinds a gate STRUCTURALLY where
+  tolerance blinds it statistically: all four blog-index screenshots mask
+  `.post-feature`, which IS the feature slot, so the index content area has
+  never been gated. Plus the local-gates-are-authority policy with its stated
+  Linux debt, and "quote the compared COUNT, not just 0 failures".
+* `workflows/analytics-access.md` - `/blog/` fires no `scroll_depth` at all
+  (`page/analytics.html:72` gates on `.IsPage`), and the 3-day-window trap with
+  the session-weighting and straddles-a-deploy rules.
+* `workflows/review-swarm.md` - non-colliding agents can still collide with an
+  unmerged branch, and never switch branches under a running agent.
+
 ## 2026-08-21 - new concept: the rollout SEQUENCE was undiscoverable
 
 `design/site-palette.md` carried the palette decision, but nothing in the

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -3,6 +3,41 @@
 Newest first. Entries before 2026-08-19 are squashed to one line each
 (compacted 2026-08-20); their full text is in this file's git history.
 
+## 2026-08-21 - Codex review killed a claim I had already published
+
+All eight findings verified against the tree; all eight valid. The one that
+matters reached the bundle before review caught it.
+
+**`workflows/analytics-access.md` corrected - the "Clarity disagrees with
+itself" claim was a denominator mismatch.** The write-up said per-page numbers
+contradict the aggregate "for an identical window and page-set" (~9% vs 25.56%,
+"~3x"). They are NOT the same page-set: ~9% was session-weighted over the TOP
+TEN pages, 25.56% covers EVERY `/blog/` page. The omitted long tail can account
+for the whole gap. Nothing was demonstrated, and per-post analysis was never
+ruled out - it needs the full page rows retrieved.
+
+The violation is that the section states "state the denominator" as its rule,
+and the mismatch was written INTO it. Recorded in the concept as a worked
+near-miss rather than deleted, because the shape recurs: the API returns a
+top-N subset by default and the aggregate on request, so comparing them is the
+most available thing to do.
+
+Other findings fixed in the 2608 specs (not bundle concepts): a `--rr-*` alias
+inventory that omitted a live consumer and named a file with zero references -
+deleting the aliases on it would have broken CTA/tag styling on blog AND course;
+an analytics gate using `eq .Section "blog"` that cannot match tag pages
+(`config/_default/hugo.toml:37-41` rewrites the term PERMALINK but the taxonomy
+is `tag = "tags"`, so `.Section` is `tags`); inline `!important` H1 styles left
+in `themes/beaver/layouts/list.html:51,70`; and advice to probe three
+`!important`s for removal that fight legacy heading-margin rules, not the
+retired anchor rule - `20.02:69-81` records that distinction and removing them
+would restore a title-alignment regression.
+
+Also recorded, not silently ignored: the macOS-only gate KNOWINGLY departs from
+`CLAUDE.md:148`. The override is Paul's (CI unreliable, 2026-08-21) and its cost
+- master's Linux job red until one batched dispatch - is now stated in the spec
+rather than left for a reader to discover.
+
 ## 2026-08-21 - the deferred pass, and two of my own claims corrected
 
 Ran the pass queued on #516 once that PR merged (it could not run earlier: the

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -3,6 +3,33 @@
 Newest first. Entries before 2026-08-19 are squashed to one line each
 (compacted 2026-08-20); their full text is in this file's git history.
 
+## 2026-08-21 - the Hugo trap behind the analytics finding, lifted from spec to bundle
+
+The Codex round fixed the 2608 specs. One of its findings was a durable CODE
+fact that was left sitting in a project doc where template work would never
+find it.
+
+* `architecture/hugo-site.md` - **a permalink rewrite does NOT change
+  `.Section` or `.Kind`.** The taxonomy is declared `tag = "tags"` and only
+  `[permalinks.term]` rewrites the URL, so a page served at
+  `/blog/tags/rails/` still has `.Section == "tags"`. Every
+  `eq .Section "blog"` condition therefore MISSES tag pages while reading as
+  though it covers them - the URL says blog, the page object does not. A
+  proposed analytics gate was written exactly this way.
+* `architecture/blog-list-page.md` - the same drift in a second form. That
+  concept already records the index and tag templates drifting apart in MARKUP
+  and being unified by shared partials. Unifying markup did NOT unify
+  PREDICATES: a `.Section` guard added anywhere still covers one and skips the
+  other. Also noted the inline `!important` H1 styles still at `list.html:51,70`.
+* `design/site-palette.md` - two fixes. `--color-primary` no longer "dies in
+  1a.2"; it is GONE as of #518, and the seven surviving matches are comments
+  recording what each rule replaced, which a careless grep reads as survival.
+  And the `--rr-*` alias deprecation was missing entirely: it now names the
+  three live consumers and the rule that matters - **verify by grep at deletion
+  time, never against a written inventory.** That inventory was wrong twice in
+  one review, and `single-post.css` is in the COURSE bundle, so an early
+  deletion breaks blog and course together.
+
 ## 2026-08-21 - Codex review killed a claim I had already published
 
 All eight findings verified against the tree; all eight valid. The one that

--- a/.okf/workflows/analytics-access.md
+++ b/.okf/workflows/analytics-access.md
@@ -6,7 +6,9 @@ tags: [analytics, ga4, search-console, mcp, seo, tooling]
 generated:
   by: claude/opus-5
   at: 2026-08-13T00:00:00Z
+timestamp: 2026-08-21T00:50:00Z
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T00:50:00Z }
   - by: claude/opus-5
     at: 2026-08-13T00:00:00Z
   - by: claude/opus-5
@@ -136,6 +138,41 @@ that can never convert.
 Use `sc-domain:jetthoughts.com` for *coverage* questions (what exists, what is
 indexed); use the `https://jetthoughts.com/` prefix property, or a
 `page notContains elital` filter, for any *performance* question.
+
+## `/blog/` fires no `scroll_depth` - GA4 cannot see the blog index
+
+`themes/beaver/layouts/partials/page/analytics.html:72` gates the scroll
+milestones on `{{ if and .IsPage (eq .Section "blog") }}`. `.IsPage` is FALSE
+for list pages, so individual posts emit `scroll_depth` and `/blog/` emits
+nothing. Found 2026-08-21 while baselining the blog rebuild.
+
+Consequence: for the blog INDEX, Clarity is the only instrument that sees
+scroll at all - it measures client-side without site instrumentation, so it
+is unaffected. Never answer an index-engagement question from GA4; it has no
+data, which reads identically to zero engagement.
+
+## A 3-day window is not a baseline - recompute before quoting
+
+Clarity caps a query at 3 days, which quietly invites quoting one window as
+if it were the period. On 2026-08-21 the figure driving the whole blog-first
+strategy - "25.2% scroll / 26.3s vs a 32.9-40.3% site average" - turned out
+to be ONE window of five, and the lowest. The five windows over
+2026-08-06 -> 08-20 ran 29.89 / 51.13 / 75.11 / 50.91 / 25.56%: a **2.9x
+swing**. Session-weighted across all 743 sessions: **44.31% scroll /
+34.97s** - at or above the average it was said to trail.
+
+Two rules fall out. **Session-weight across every window** rather than
+averaging the windows or picking one. And **check whether a window straddles
+a deploy** - the low window contained the 08-20 rebuild ship (17:35 and
+20:16), so the honest pre-ship baseline is the clean 08-06 -> 08-17 stretch
+(451 sessions, 56.4% / 40.1s). Same family as the GA4-vs-GSC reconciliation
+above: a flattering or alarming number survives by being quoted rather than
+recomputed.
+
+Also unreliable: Clarity's PER-PAGE scroll numbers contradict its own
+aggregate for an identical window and page-set (0-2% on top posts vs 25.56%
+aggregate, ~3x). Per-post scroll comparison is not currently obtainable -
+record that as a gap rather than substituting an estimate.
 
 ## There is no conversion tracking
 

--- a/.okf/workflows/analytics-access.md
+++ b/.okf/workflows/analytics-access.md
@@ -169,10 +169,22 @@ a deploy** - the low window contained the 08-20 rebuild ship (17:35 and
 above: a flattering or alarming number survives by being quoted rather than
 recomputed.
 
-Also unreliable: Clarity's PER-PAGE scroll numbers contradict its own
-aggregate for an identical window and page-set (0-2% on top posts vs 25.56%
-aggregate, ~3x). Per-post scroll comparison is not currently obtainable -
-record that as a gap rather than substituting an estimate.
+**A near-miss worth keeping, because it is this same rule failing one step
+deeper.** The first write-up of this claimed Clarity's per-page numbers
+"contradict its own aggregate for an identical window and page-set" - 0-2% on
+top posts vs a 25.56% aggregate, "~3x". Review (Codex, 2026-08-21) killed it:
+the ~9% figure was session-weighted over the TOP TEN pages only, and the
+25.56% aggregate covers EVERY `/blog/` page. Two different populations. The
+omitted long tail can account for the whole gap, so no disagreement was
+demonstrated and per-post analysis was never ruled out - it just needs the
+full page set retrieved.
+
+The rule this section states is "state the denominator", and the violation
+was writing a denominator-mismatch INTO the section warning against it.
+Comparing a top-N subset against an all-rows aggregate is the most available
+way to do it, because the API returns the subset by default and the aggregate
+on request. Before concluding two figures disagree, confirm they cover the
+same rows.
 
 ## There is no conversion tracking
 

--- a/.okf/workflows/analytics-access.md
+++ b/.okf/workflows/analytics-access.md
@@ -146,10 +146,18 @@ milestones on `{{ if and .IsPage (eq .Section "blog") }}`. `.IsPage` is FALSE
 for list pages, so individual posts emit `scroll_depth` and `/blog/` emits
 nothing. Found 2026-08-21 while baselining the blog rebuild.
 
-Consequence: for the blog INDEX, Clarity is the only instrument that sees
-scroll at all - it measures client-side without site instrumentation, so it
-is unaffected. Never answer an index-engagement question from GA4; it has no
-data, which reads identically to zero engagement.
+Consequence, stated precisely (narrowed 2026-08-21 after review): what `/blog/`
+loses is the CUSTOM 25/50/75/90 milestone set. If GA4 enhanced measurement is
+enabled on the property, its BUILT-IN `scroll` event (fires once at 90%) is
+unaffected by this template gate and may still be available - **verify in the
+property before assuming either way; it was not verified here.** So the honest
+statement is "missing intermediate milestones", not "no scroll data": discarding
+a usable 90% signal because a doc said GA4 sees nothing would be its own error.
+
+Clarity is unaffected regardless - it measures client-side without site
+instrumentation - and remains the richer index-scroll source. What still holds:
+never answer an index-engagement question from the CUSTOM milestones; they have
+no data there, which reads identically to zero engagement.
 
 ## A 3-day window is not a baseline - recompute before quoting
 

--- a/.okf/workflows/index.md
+++ b/.okf/workflows/index.md
@@ -6,7 +6,7 @@
 * [Blog Post Pipeline](blog-pipeline.md) - mandatory end-to-end workflow for writing/publishing blog posts, plus the execute-don't-read claims gate, the frontmatter claims check, and the `## Sources` citation convention
 * [LinkedIn Post Pipeline](linkedin-post-pipeline.md) - Paul Keen voice rules and posting workflow
 * [CSS Maintainability Redesign](css-maintainability-plan.md) - approved plan for hand-editable CSS + FL-Builder retirement
-* [Rescue Room rollout sequence](site-redesign-rollout.md) - why phases are ordered by whether layout moves, why blog runs before site-wide chrome, and the gates that block regardless
+* [Rescue Room rollout sequence](site-redesign-rollout.md) - why phases are ordered by whether layout moves, why blog runs before site-wide chrome, why phase status must be checked against git rather than the plan table, and the gates that block regardless
 * [Visual Scroll Gate](visual-scroll-gate.md) - blocking pre-handback visual walk for content/visual changes
 * Test suites, rake tasks, and the visual-regression gate live in [test-gates](/build/test-gates.md) (`workflows/testing.md` was squashed into it 2026-08-20 - it duplicated the gate rules and still carried the superseded "run both suites per commit" instruction)
 * [Analytics Access](analytics-access.md) - live GA4 + Search Console MCP servers, correct property IDs, credential split, data-lag traps, and why GA4 sessions must be reconciled against GSC clicks before being quoted

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -7,8 +7,9 @@ generated:
   by: process:okf-migrate
   at: 2026-07-24T00:00:00Z
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T00:50:00Z }
   - { by: claude/opus-5, at: 2026-08-21T00:10:00Z }
-timestamp: 2026-08-21T00:10:00Z
+timestamp: 2026-08-21T00:50:00Z
 ---
 
 # The loop
@@ -104,6 +105,22 @@ verdict format, and the two or three specific things to attack.
 - Fixer geometry claims (SVG sizes, clipping fixed) must be re-verified by
   your own re-render - one wave shipped a wording truncation nobody saw.
 - Parallel sessions contend on .git/index.lock - wait-loop before git ops.
+- **Non-colliding agents can still collide with an UNMERGED BRANCH**
+  (2026-08-21). Fan-out safety is normally reasoned about between agents -
+  give each its own file and they cannot fight. That is necessary and not
+  sufficient. On 2026-08-21 three doc-writing agents were safe against each
+  other AND against PR #518, but CSS agents would not have been: #518 was
+  rewriting the very bundles a blog-rebuild lane would have edited, so every
+  line they wrote would have been rebased over a 194-file recolour. Before
+  fanning out, check what is IN FLIGHT, not just what the agents own.
+- **Brief agents with the branch state, not just the task** (2026-08-21).
+  Agents dispatched into a worktree inherit whatever is checked out. Two
+  correctly reported that a concept "does not exist in this worktree" because
+  it lived on an unmerged branch - right observation, and only harmless
+  because they flagged it instead of inventing around it. Tell an agent which
+  branch it is on and what is missing there, or it will reason confidently
+  from a partial tree. Do NOT switch branches under a running agent: it
+  silently changes the files it is mid-read of, and nothing errors.
 - **Brief critics to return MEASUREMENTS, not verdicts** (2026-08-20). Two
   consecutive reviewers on one small test each found a claim that passed
   self-review twice, and in both cases the decisive artifact was a COUNT:

--- a/.okf/workflows/site-redesign-rollout.md
+++ b/.okf/workflows/site-redesign-rollout.md
@@ -39,9 +39,11 @@ ORDER the decision ships in, which is a separate call and the one a session
 gets wrong. Reading only the palette concept, the obvious next move after
 Phase 1a.3 is 1a.4 - and that is the wrong order (see blog-first below).
 
-Live phase status lives in the plan doc under `resource:`, not here; a state
-snapshot in a concept rots within days. What is recorded here is the reasoning
-that outlives any particular phase.
+**Phase status comes from GIT, not from any document** - see the section below.
+Neither this concept nor the plan doc is a status source: the plan records what
+was DECIDED and went stale (it listed 2.1/2.2 pending after both shipped), and
+a state snapshot in a concept rots within days. What is recorded here is the
+reasoning that outlives any particular phase.
 
 # Three rules that decide sequence
 
@@ -62,7 +64,8 @@ are A (qualitative), B (guardrails with declared rollback thresholds), C
 whose case is coherence.
 
 **3. Blog before site-wide chrome** (Paul, 2026-08-20). That is where the
-humans already are - the ~145 GSC clicks/28d land overwhelmingly on posts - and
+humans already are - the 105 GSC clicks/28d (measured 2026-08-21; the plan's
+~145 was superseded) land overwhelmingly on posts - and
 the blog bundles do not touch the money pages. It also has the clearest
 engagement problem to move.
 

--- a/.okf/workflows/site-redesign-rollout.md
+++ b/.okf/workflows/site-redesign-rollout.md
@@ -8,10 +8,31 @@ status: stable
 generated:
   by: claude/opus-5
   at: 2026-08-21T00:30:00Z
-timestamp: 2026-08-21T00:30:00Z
+timestamp: 2026-08-21T00:50:00Z
 ---
 
 # Why this concept exists
+
+# Check phase status against GIT, not the plan table
+
+**The plan's Phase 2 table lists 2.1 and 2.2 as pending. Both shipped on
+2026-08-20** - #487 (17:35, blog index/tags/posts restyle) and #494 (20:16,
+whole-blog rebuild), confirmed with
+`git merge-base --is-ancestor e1fa5409 origin/master`. A status answer given
+from the plan on 2026-08-21 was wrong for exactly this reason.
+
+A plan doc records what was DECIDED; only the tree records what SHIPPED. Before
+reporting phase status or starting phase work, grep the artifact - the
+markup, the selector, the commit - not the table row. Two independent agents
+hit this within minutes of each other, which is how a stale row survives:
+everyone reads the plan because it is the obvious place to look.
+
+**Corollary - blog-first orders work NOT YET STARTED; it does not un-build
+finished work.** When a later-sequenced phase is already built and edits the
+same bundles an earlier-sequenced one rewrites, the built work lands first.
+1a.2/1a.3 landed before the Phase 2 punch-lists on 2026-08-20 for this reason:
+starting blog work on an unmerged 194-file recolour recreates precisely the
+merge pain the 1a/1b split exists to avoid.
 
 The palette DECISION is in [site-palette](/design/site-palette.md). This is the
 ORDER the decision ships in, which is a separate call and the one a session
@@ -43,9 +64,21 @@ whose case is coherence.
 **3. Blog before site-wide chrome** (Paul, 2026-08-20). That is where the
 humans already are - the ~145 GSC clicks/28d land overwhelmingly on posts - and
 the blog bundles do not touch the money pages. It also has the clearest
-engagement problem to move: blog pages sit at **25.2% average scroll depth /
-26.3s** against a site average of 32.9-40.3% / 28-34s (Clarity, bot-filtered,
-2026-08-20 baseline).
+engagement problem to move.
+
+**CORRECTED 2026-08-21 - the engagement figure did not survive recomputation.**
+The plan cites 25.2% scroll / 26.3s against a 32.9-40.3% site average. That is
+ONE 3-day Clarity window of five, and the lowest; the windows swing 2.9x
+(29.89 / 51.13 / 75.11 / 50.91 / 25.56%). Session-weighted over all 743
+bot-filtered sessions the blog sits at **44.31% scroll / 34.97s** - at or above
+the average it was said to trail. The low window also straddles the 08-20
+deploy, so the clean pre-ship baseline is 08-06 -> 08-17: 451 sessions,
+**56.4% / 40.1s**.
+
+Blog-first remains right, but on a different fact than the one written down:
+GSC shows the blog at **105 clicks / 28d, 77% of the entire site's Google
+traffic**. A 3-day window is not a baseline. Recompute a quoted metric over the
+full period before building a strategy on it.
 
 # The cost blog-first accepts, and why it is not a bug
 
@@ -68,9 +101,18 @@ learning whether the design engages anyone before the whole site commits to it.
   evening): "avoid measures, rebuild the whole blog, and we will use measure
   based on the whole blog." Nothing blog-scoped waits on a reading. The read
   still happens - once, over the whole rebuilt blog - and is informational.
-- **2.2 couples the course page.** `blog-single` shares
-  `pages/blog-single.css` with `course-single`; sequence 2.3 immediately after
-  or screenshot both.
+- **2.2 does NOT couple the course page - the plan pointed at the wrong file**
+  (measured 2026-08-21, correcting 20.01's "2.2 note"). The warning is true of
+  the FILE and false of the SELECTORS. Both templates load
+  `pages/blog-single.css`, but `course/single.html:55` renders
+  `class="single-content"` with **no `.post-article`**, and all 15 styled rules
+  in that file are `.post-article`-prefixed. Exactly two selectors reach
+  course: `.single-post-row` and the `h1.post-title` rule. **2.3 need not
+  follow 2.2.** The genuinely shared file is `single-post.css`, where
+  `.blog .post-tags a` and the print block hiding `.post-cover-figure` DO reach
+  course - and that file drives `bin/generate-template-pdfs`, so a change there
+  moves PDFs too. Scope tripwire: `macos/{desktop,mobile}/course/chapter.png`
+  must come out byte-identical.
 
 # Citations
 

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.01-rollout-plan.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.01-rollout-plan.md
@@ -177,11 +177,22 @@ before, which is a coherent state to sit in indefinitely.
 
 > **Re-sequenced 2026-08-20.** Paul: start with the blog to confirm engagement
 > before touching anything else. This is where the humans already are — the
-> 145 GSC clicks/28d land overwhelmingly on posts — and the blog bundles don't
-> touch the money pages. It also has the clearest engagement problem to move:
-> Clarity (bot-filtered, 3 days to 2026-08-20) shows **blog pages at 25.2%
-> average scroll depth / 26.3s engagement**, against a site average of
-> 32.9–40.3% / 28–34s. Visitors leave posts in the first quarter of the page.
+> ~~145~~ **105** GSC clicks/28d land overwhelmingly on posts — and the blog
+> bundles don't touch the money pages.
+>
+> **CORRECTED 2026-08-21 — the engagement half of this justification does not
+> hold.** The original text read "the clearest engagement problem to move:
+> Clarity shows blog pages at 25.2% scroll / 26.3s against a 32.9–40.3% site
+> average. Visitors leave posts in the first quarter." That 3-day reading is
+> ONE window of five and the lowest; session-weighted the blog is at 44.31%,
+> and the clean pre-ship window is **56.4% / 40.1s over 451 sessions**
+> ([40.01](../40-49-measurement/40.01-blog-engagement-baseline.md)). There is
+> no demonstrated engagement deficit and "visitors leave in the first quarter"
+> must not be repeated.
+>
+> **Blog-first still stands, on the traffic-share half:** those 105 clicks are
+> **77% of the site's entire Google traffic**. That is the durable reason, and
+> it was always the stronger one.
 >
 > **Consequence for Phase 1:** the blog phases run BEFORE the site-wide chrome
 > sprint. New tokens are therefore scoped into the blog bundles'

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.03-phase-2.1-blog-list-spec.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.03-phase-2.1-blog-list-spec.md
@@ -116,13 +116,27 @@ move one on mobile.
 | 3.1 | `themes/beaver/assets/css/pages/blog-list.css` | `:188-191`, `:226` | `.post-meta .post-tags` → `.post-meta .post-tags-card` (both places). Mobile hide starts working. |
 | 3.2 | same | `:150` | `background: #10141a` → `background: var(--surface-ink)` |
 | 3.3 | same | `:88` | `color: #fff` → `color: var(--surface)` |
-| 3.4 | same | `:27, 77, 98, 122, 140, 185, 196, 204` | `--rr-ink-900/700/500` → `--ink-900/700/500`; `--rr-line` → `--line`; `--rr-surface-raised` → `--surface-raised`. Values are identical by definition (`css-variables.css:112-116`), so this is a zero-delta rename. |
+| 3.4 | same | `:27, 77, 78, 98, 122, 140, 185, 196, 203` | `--rr-ink-900/700/500` → `--ink-900/700/500`; `--rr-line` → `--line`; `--rr-surface-raised` → `--surface-raised`. Values are identical by definition (`css-variables.css:112-116`), so this is a zero-delta rename. |
 | 3.5 | `themes/beaver/layouts/blog/list.html` | `:42-44` | Delete the inline `style` attribute; add `.blog-index h1 { margin: 0; padding: 0 }` to `blog-list.css` |
-| 3.6 | `themes/beaver/layouts/partials/page/analytics.html` | `:72` | Widen the gate so `/blog/` and tag pages emit `scroll_depth` too (e.g. `{{ if eq .Section "blog" }}`). Verify in DebugView per 20.01 Phase 0.1's gate. |
+| 3.6 | `themes/beaver/layouts/partials/page/analytics.html` | `:72` | Widen the gate so `/blog/` AND tag pages emit `scroll_depth`. **`eq .Section "blog"` is NOT sufficient**: `config/_default/hugo.toml:37-41` declares the taxonomy as `tag = "tags"` and only REWRITES the term permalink to `/blog/tags/:slug/`, so `.Section` on those pages is `tags`, not `blog`. The gate needs an explicit term/taxonomy predicate (e.g. `or (eq .Section "blog") (eq .Kind "term") (eq .Kind "taxonomy")`). Verify BOTH page kinds in DebugView per 20.01 Phase 0.1's gate. |
+| 3.7 | `themes/beaver/layouts/list.html` | `:51`, `:70` | Delete the inline `style="margin: 0!important;padding: 0!important"` on BOTH taxonomy H1 variants. 3.5 only clears `blog/list.html`; a stylesheet rule cannot override these, so tag pages would silently keep the old spacing when Phase 1b lands the shared scale. |
 
-**Do NOT delete the `--rr-*` aliases in this phase.** 3.4 removes blog-list.css
-as a consumer; `blog-single.css` and `vibe-code-rescue.css` are the others, and
-the alias block dies in 1a.4 when all three are clear.
+**Do NOT delete the `--rr-*` aliases in this phase.** Inventory corrected
+2026-08-21 after review - the first version omitted `blog-list.css:78` and
+named `vibe-code-rescue.css`, which has **zero** `var(--rr-*)` references.
+Verified live consumers (`grep -rn 'var(--rr-' themes/beaver/assets/css/`):
+
+| File | Lines |
+|---|---|
+| `pages/blog-list.css` | 27, 77, 78, 98, 122, 140, 185, 196, 203 |
+| `single-post.css` | 434, 448, 453, 474, 479, 491 |
+| `pages/blog-single.css` | 65, 73, 88 |
+
+3.4 clears only the first. **1a.4 must not delete the alias block until all
+three files are clear** - `single-post.css:434-491` carries CTA and tag colour
+and background declarations that reach the course bundle, so deleting the
+aliases early breaks live styling on blog AND course. Re-run the grep at the
+time of deletion rather than trusting this table.
 
 ### The token-definition rule this phase inherits
 
@@ -170,7 +184,26 @@ exist** — deleted in 1a.2; the eight remaining occurrences in
 
 ## 5. The gate
 
-**macOS local only.** In order:
+**macOS local only — this KNOWINGLY departs from `CLAUDE.md:148`**, which
+requires the full `bin/test` + `bin/dtest` pair with updated baselines before
+a PR opens. Standing override from Paul, 2026-08-21: *"use local tests for
+now, CI is under attack is not reliable."* Flagged in review (Codex) as a
+policy violation, which it is — recorded here rather than left as a silent
+contradiction, so an executor is not caught between two rules.
+
+**What the override costs, stated so it is not discovered later:** an
+implementing PR merges with STALE Linux baselines, so master's Linux
+screenshot job goes red and stays red until one batched CI dispatch
+(`gh workflow run test.yml --ref <branch> -f screenshots=true -f update-baselines=true`)
+re-records them. This is accepted debt, not an oversight — PR #518 already
+carries it. It cannot be paid locally: ARM Docker emulation plants false
+drift, and `bin/record-baselines --linux` refuses by design. **If CI is
+healthy when this phase runs, do the dispatch against the feature branch and
+commit the Linux baselines BEFORE merge, per Codex's finding and the
+unmodified CLAUDE.md rule.** The override is a response to CI being
+unavailable, not a preference.
+
+In order:
 
 1. `bin/qtest --changed` — this diff touches `themes/` CSS and a template, so the
    visual gate applies in full (not the content-only exemption).

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.03-phase-2.1-blog-list-spec.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.03-phase-2.1-blog-list-spec.md
@@ -19,10 +19,16 @@ invented here.
 
 ## 1. What the page has TODAY
 
-**The number this phase exists to move:** blog pages read **25.2% average scroll
-depth / 26.3s engagement** against a site average of 32.9–40.3% / 28–34s
-(Clarity, bot-filtered, 3 days to 2026-08-20; 219 sessions). Visitors leave in
-the first quarter of the page.
+**The number this phase was said to exist to move does not hold — corrected
+2026-08-21** against
+[40.01](../40-49-measurement/40.01-blog-engagement-baseline.md). The
+25.2% / 26.3s / 219-session reading is ONE 3-day Clarity window of five, the
+lowest, and it straddles the 2026-08-20 deploy. Clean pre-ship (08-06 →
+08-17): **56.4% scroll / 40.1s over 451 sessions**. Do not repeat "visitors
+leave in the first quarter" - it is unsupported.
+
+The durable reason to care about this page: the blog carries **77% of the
+site's entire Google traffic** (105 GSC clicks / 28d).
 
 ### 1a. The 2.1 scope row, verified present
 
@@ -53,12 +59,19 @@ same three partials.
    is in no token file.
 3. **Second literal, active filter pill.** `blog-list.css:88` — `color: #fff`
    where `--surface` is `#ffffff`.
-4. **`--rr-*` aliases are on death row and blog-list.css is their last
-   consumer.** `foundations/css-variables.css:110-116` defines
-   `--rr-ink-900/700/500`, `--rr-line`, `--rr-surface-raised` as aliases of the
-   canonical `--ink-*` / `--line` / `--surface-raised`, commented "DELETE in
-   1a.4 once the three page files consume the canonical names".
-   `blog-list.css` uses six of them (`:27, 77, 98, 122, 140, 185, 196, 204`).
+4. **`--rr-*` aliases are on death row. `blog-list.css` is ONE of three
+   consumers, NOT the last** (corrected 2026-08-21 — the first draft of this
+   item said "last consumer" and listed the wrong lines, which is exactly how
+   a premature alias deletion would happen).
+   `foundations/css-variables.css:110-116` defines `--rr-ink-900/700/500`,
+   `--rr-line`, `--rr-surface-raised` as aliases of the canonical `--ink-*` /
+   `--line` / `--surface-raised`, commented "DELETE in 1a.4 once the three
+   page files consume the canonical names". Verified live consumers
+   (`grep -rn 'var(--rr-' themes/beaver/assets/css/`):
+   `blog-list.css` **nine** lines (`:27, 77, 78, 98, 122, 140, 185, 196,
+   203`), `single-post.css` six (`:434, 448, 453, 474, 479, 491`),
+   `pages/blog-single.css` three (`:65, 73, 88`). §3.4 clears only the first;
+   see the deletion rule under §3.
 5. **Inline `!important` on the H1.** `blog/list.html:42-44` —
    `style="margin: 0!important;padding: 0!important"`. It blocks the Phase 1b
    4px space scale from reaching this page and cannot be overridden from a
@@ -248,11 +261,12 @@ by eye in the scroll gate; the baseline will not fail if they break.
    forward work; it shipped 2026-08-20 in #487/#494. Confirm the residual
    punch-list in §3 is the intended 2.1 scope, or close 2.1 as done and route
    §3 to 1a.4 / a hygiene PR.
-2. **`.okf/workflows/site-redesign-rollout.md` does not exist** in this
-   worktree (`ls .okf/workflows/` — ten files, none of them that). The
-   sequencing rules and the blog-first token consequence were taken from
-   20.01 §"Phase 2" instead. Either the concept was never written or it lives
-   under another name; if a reviewer expects it, it is a missing OKF artifact.
+2. ~~**`.okf/workflows/site-redesign-rollout.md` does not exist**~~ **CLOSED
+   2026-08-21 - it exists and governs this spec.** It read as absent because
+   this spec was drafted from a worktree checked out on an unmerged branch
+   predating the concept. Per CLAUDE.md: if a file you know exists reports
+   missing, check the working directory and branch before concluding it is
+   unwritten. What was derived here from 20.01 agrees with it.
 3. **The 25.2% figure is not segmented by device or by list-vs-post.** "Blog
    pages" in the Clarity query covers `/blog/` and 540+ post URLs together. A
    list page and a 2,000-word post have structurally different scroll curves,

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.03-phase-2.1-blog-list-spec.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.03-phase-2.1-blog-list-spec.md
@@ -41,8 +41,12 @@ site's entire Google traffic** (105 GSC clicks / 28d).
 | Reading time | `partials/blog/post-row.html:18` and `blog/list.html:69` — `{{ .ReadingTime }} min read` |
 | CTA band + proof note | `partials/blog/cta-band.html:7-12`, proof line `4.8/5 on Clutch` linked, no review count (claims-canon compliant) |
 
-Tag pages share all of it: `themes/beaver/layouts/list.html:79,82,85` calls the
-same three partials.
+Tag pages share the SHARED COMPONENTS only - the post rows, filters and CTA
+band, via the same three partials (`themes/beaver/layouts/list.html:79,82,85`) -
+plus the styles. **They do NOT have a feature slot**: that lives in
+`blog/list.html` behind a first-page guard and has no equivalent in `list.html`
+(see open question 4). Verifying tag pages against the full 2.1 scope list would
+return a false negative on an item they were never meant to carry.
 
 ### 1b. What is actually still wrong — six defects, with evidence
 
@@ -120,9 +124,14 @@ featured post, topic self-selection, and one CTA.
 
 ## 3. Exact changes
 
-Six edits, two files plus one shared file. All are hygiene or bug fixes; none
-moves an element on desktop except 3.1, which fixes a rule that was meant to
-move one on mobile.
+**Seven edits across four files** (recount 2026-08-21 - 3.7 was added in review
+and the summary still said six across three, which would let an executor skip
+the taxonomy cleanup): `pages/blog-list.css`, `blog/list.html`,
+`partials/page/analytics.html`, `layouts/list.html`. Rows 3.1-3.7 below are the
+authority; if they and this sentence ever disagree again, believe the rows.
+
+All are hygiene or bug fixes; none moves an element on desktop except 3.1, which
+fixes a rule that was meant to move one on mobile.
 
 | # | File | Selector / line | Change |
 |---|---|---|---|

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.03-phase-2.1-blog-list-spec.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.03-phase-2.1-blog-list-spec.md
@@ -1,0 +1,231 @@
+# 20.03 — Phase 2.1 implementation spec: blog LIST page
+
+**Date:** 2026-08-21
+**Status:** Proposed
+**Scope row:** [20.01 rollout plan](20.01-rollout-plan.md) Phase 2 table, row 2.1 —
+"feature slot, category filters, ink tags, wider measure, reading time, CTA band
+with proof note".
+**Palette:** `.okf/design/site-palette.md` (light, Rescue Room). No colour is
+invented here.
+
+> **Premise correction, read this first.** Every item in the 2.1 scope row is
+> **already shipped** — landed in #487 (`f80de808`) and #494 (`e1fa5409`), both
+> on `origin/master`. This spec is therefore not "build 2.1"; it is the
+> verification of what shipped plus the residual punch-list that 2.1 left
+> behind. Writing it as greenfield would have produced a plan to rebuild working
+> code. Evidence for each shipped item is in §1.
+
+---
+
+## 1. What the page has TODAY
+
+**The number this phase exists to move:** blog pages read **25.2% average scroll
+depth / 26.3s engagement** against a site average of 32.9–40.3% / 28–34s
+(Clarity, bot-filtered, 3 days to 2026-08-20; 219 sessions). Visitors leave in
+the first quarter of the page.
+
+### 1a. The 2.1 scope row, verified present
+
+| Scope item | Where it lives now |
+|---|---|
+| Feature slot | `themes/beaver/layouts/blog/list.html:58-81` (page 1 only, `range first 1`), styled `themes/beaver/assets/css/pages/blog-list.css:93-132` |
+| Category filters | `themes/beaver/layouts/partials/blog/filters.html:5-19` (7 curated pills), styled `blog-list.css:60-90` |
+| Ink tags | `blog-list.css:202-208` — `.blog .post-tags-card a { color: var(--rr-ink-500) }`, ruby on hover |
+| Wider measure | `blog-list.css:18-23` container `max-width: 1080px`; per-element caps `.blog-lead` 62ch (`:26`), `.post-description` 68ch (`:198`) |
+| Reading time | `partials/blog/post-row.html:18` and `blog/list.html:69` — `{{ .ReadingTime }} min read` |
+| CTA band + proof note | `partials/blog/cta-band.html:7-12`, proof line `4.8/5 on Clutch` linked, no review count (claims-canon compliant) |
+
+Tag pages share all of it: `themes/beaver/layouts/list.html:79,82,85` calls the
+same three partials.
+
+### 1b. What is actually still wrong — six defects, with evidence
+
+1. **The mobile tag-hide is a no-op — dead selectors.** `blog-list.css:188-191`
+   and `:226` target `.post-meta .post-tags`. `post-row.html:21` emits
+   `class="post-tags-card"`. No element on this page has class `post-tags`
+   (`post-tags` exists only on `layouts/single.html:143` and
+   `layouts/course/single.html:128`). So `@media (max-width: 860px) { .post-meta
+   .post-tags { display: none } }` hides nothing and tags render on phones —
+   where 28% of GSC clicks come from (`.okf/design/site-palette.md`).
+2. **Off-palette literal in the cover slot.** `blog-list.css:150` —
+   `background: #10141a`. The palette's dark surface is `--surface-ink`
+   `#14110f`. Every legacy non-1200:630 cover letterboxes against a colour that
+   is in no token file.
+3. **Second literal, active filter pill.** `blog-list.css:88` — `color: #fff`
+   where `--surface` is `#ffffff`.
+4. **`--rr-*` aliases are on death row and blog-list.css is their last
+   consumer.** `foundations/css-variables.css:110-116` defines
+   `--rr-ink-900/700/500`, `--rr-line`, `--rr-surface-raised` as aliases of the
+   canonical `--ink-*` / `--line` / `--surface-raised`, commented "DELETE in
+   1a.4 once the three page files consume the canonical names".
+   `blog-list.css` uses six of them (`:27, 77, 98, 122, 140, 185, 196, 204`).
+5. **Inline `!important` on the H1.** `blog/list.html:42-44` —
+   `style="margin: 0!important;padding: 0!important"`. It blocks the Phase 1b
+   4px space scale from reaching this page and cannot be overridden from a
+   stylesheet.
+6. **The list page has no scroll-depth instrumentation at all.**
+   `partials/page/analytics.html:72` gates the 25/50/75/90 milestones on
+   `{{ if and .IsPage (eq .Section "blog") }}`. A list page is not `.IsPage`, so
+   `/blog/` fires no `scroll_depth` event. The phase justified by a scroll-depth
+   number cannot read its own number in GA4; only Clarity sees it.
+
+---
+
+## 2. Target layout, section by section
+
+The layout below is what ships today (§1a) unless marked **RESIDUAL**. Each
+entry states why it should move scroll depth. Per the plan's measurement pivot
+(20.01 §"Measurement pivot"), **no per-item attribution is available** — one
+whole-blog read runs after the rebuild. These are design rationales, not
+predicted lifts.
+
+1. **H1 + lead (62ch), then filter pills.** The lead names the ICP promise
+   ("founder-tested patterns … the questions burned founders ask"), the pills
+   give a burned founder a topic to self-select before scrolling. F-pattern: a
+   decision offered above the fold is a reason to stay on the page rather than
+   bounce to SERP. **RESIDUAL:** drop the inline `!important` (defect 5).
+2. **Feature slot, page 1 only.** A single 1.1fr/0.9fr card with eyebrow,
+   title, description, date · reading time, and an eager-loaded 1200:630 cover.
+   The 71%-drop rule (`10.05-content-organization-patterns-2026.md`) says the
+   first fold needs a hero visual; this is it, and it is the only element on the
+   page that offers one post rather than a wall of twenty.
+3. **List rows.** 220px cover, title, date · reading time, ink tags,
+   68ch description, hairline separator. Reading time is the cheapest
+   scroll-continuation signal on a list page: it converts "how long is this
+   wall" into a per-row cost. **RESIDUAL:** tags must actually collapse on
+   mobile (defect 1) — a stacked row with a tag list under it pushes the next
+   row's cover below the fold on a phone.
+4. **CTA band before pagination.** One offer, one proof line. Placed after the
+   rows, so it is the reward for reaching the bottom rather than an interruption.
+5. **Centered pagination.** Fixed 2026-08-20 (`blog-list.css:30-35`); a bare
+   bottom-left "Next" under a centered band read as an orphan.
+
+Nothing in this section changes the page's thesis: a scannable index with one
+featured post, topic self-selection, and one CTA.
+
+---
+
+## 3. Exact changes
+
+Six edits, two files plus one shared file. All are hygiene or bug fixes; none
+moves an element on desktop except 3.1, which fixes a rule that was meant to
+move one on mobile.
+
+| # | File | Selector / line | Change |
+|---|---|---|---|
+| 3.1 | `themes/beaver/assets/css/pages/blog-list.css` | `:188-191`, `:226` | `.post-meta .post-tags` → `.post-meta .post-tags-card` (both places). Mobile hide starts working. |
+| 3.2 | same | `:150` | `background: #10141a` → `background: var(--surface-ink)` |
+| 3.3 | same | `:88` | `color: #fff` → `color: var(--surface)` |
+| 3.4 | same | `:27, 77, 98, 122, 140, 185, 196, 204` | `--rr-ink-900/700/500` → `--ink-900/700/500`; `--rr-line` → `--line`; `--rr-surface-raised` → `--surface-raised`. Values are identical by definition (`css-variables.css:112-116`), so this is a zero-delta rename. |
+| 3.5 | `themes/beaver/layouts/blog/list.html` | `:42-44` | Delete the inline `style` attribute; add `.blog-index h1 { margin: 0; padding: 0 }` to `blog-list.css` |
+| 3.6 | `themes/beaver/layouts/partials/page/analytics.html` | `:72` | Widen the gate so `/blog/` and tag pages emit `scroll_depth` too (e.g. `{{ if eq .Section "blog" }}`). Verify in DebugView per 20.01 Phase 0.1's gate. |
+
+**Do NOT delete the `--rr-*` aliases in this phase.** 3.4 removes blog-list.css
+as a consumer; `blog-single.css` and `vibe-code-rescue.css` are the others, and
+the alias block dies in 1a.4 when all three are clear.
+
+### The token-definition rule this phase inherits
+
+20.01 §"Consequence for Phase 1" specified that blog tokens are defined inside
+`pages/blog-list.css` first and promoted to `foundations/css-variables.css` in
+Phase 1a later. **That promotion has already happened on the 1a branch** — the
+`--rr-*` names now live in `css-variables.css:112-116` as aliases, and
+`blog-list.css:7-10` records that the definitions moved out to `single-post.css`
+in between. So the definitions have moved **twice, on purpose**, exactly as the
+plan said they would. A reviewer seeing `--rr-ink-500` aliasing `--ink-500` and
+calling it redundant duplication is reading the intermediate state of a planned
+two-step, not a defect. Step 3.4 above is the second half of it; the alias block
+is deleted in 1a.4, not here.
+
+### Token set to write against
+
+Post-1a.3: `--ink-900/700/500/300`, `--line`, `--surface`, `--surface-raised`,
+`--surface-sunken`, `--surface-ink`, `--color-ruby`, `--ruby-700/100/050`,
+`--link` / `--link-hover` / `--link-underline`. **`--color-primary` does not
+exist** — deleted in 1a.2; the eight remaining occurrences in
+`themes/beaver/assets/css/` are all in explanatory comments (`theme-main.css:127,
+134, 619, 638, 650, 2271`, `style.css:193`, `css-variables.css:90`). Same for
+`#0066d6`: comments only. Never reintroduce either.
+
+---
+
+## 4. Out of scope
+
+- **`blog-single` / `pages/blog-single.css`** — Phase 2.2, another agent owns it.
+  The only shared boundary is the token layer (`foundations/css-variables.css`)
+  and `single-post.css`, which holds the shared `.blog-cta`. **This spec edits
+  neither.** If a change here needs `single-post.css`, it is out of scope and
+  goes to 2.2's owner.
+- Deleting the `--rr-*` alias block (Phase 1a.4).
+- The site-wide 4px space scale, the ~200px dead fold, nav 7→5 (Phase 1b).
+- The `.stitch` cover-image system and the 1200:630 `object-fit: contain`
+  decision (`blog-list.css:161-166`) — deliberate, 515 of 596 covers are not
+  1200:630.
+- The three logo SVGs and the ~29 hardcoded-fill theme icons (out of scope for
+  every design-system phase, per `.okf/design/site-palette.md`).
+- Any A/B test or per-phase engagement read — retired as a gate by the
+  measurement pivot in 20.01.
+
+---
+
+## 5. The gate
+
+**macOS local only.** In order:
+
+1. `bin/qtest --changed` — this diff touches `themes/` CSS and a template, so the
+   visual gate applies in full (not the content-only exemption).
+2. `bin/test` — full macOS leg, at branch head before `gh pr create`.
+3. `bin/hugo-build` — validators + banned-string ratchet.
+4. Rendered scroll gate on `/blog/` and `/blog/tags/rails/` at 1440×900 and
+   390×844 (`docs/workflows/visual-scroll-gate.md`). Mobile is the one that
+   matters here: defect 1 is a mobile-only bug and **the screenshot suite cannot
+   see it** — see the caveat below.
+
+**CI is unreliable and Linux baselines cannot be recorded locally.** `bin/dtest`
+under emulated Docker produces false reds (see `project-stale-linux-baselines-pending`),
+so the Linux leg of this change needs **one `update-baselines` workflow dispatch
+on CI after merge**, not a local re-record. State that in the PR; do not treat a
+local Docker red as a blocker, and do not commit locally-generated Linux PNGs.
+
+**Caveat that limits this whole gate:** `desktop_site_test.rb:34` and
+`mobile_site_test.rb:24` both capture `blog/index` with
+`skip_area: [".blog-post", ".post-feature"]`. The feature slot and every list
+row — the two things 2.1 built — are masked out of the baseline. The screenshot
+suite protects the page chrome around them and nothing else. Judge 3.1 and 3.2
+by eye in the scroll gate; the baseline will not fail if they break.
+
+---
+
+## 6. Risks and rollback
+
+| Risk | Rollback |
+|---|---|
+| 3.1 makes tags vanish on mobile where a reader wanted them (it is a behaviour change, not a no-op fix) | one-line revert of the media-query rule; keep the `:188` rename |
+| 3.4 is not actually zero-delta (an alias resolves differently in some bundle order) | revert 3.4 alone; the aliases stay live until 1a.4 regardless |
+| 3.5 changes H1 spacing because some other rule was relying on the inline `!important` | restore the attribute; the CSS rule is additive and harmless |
+| 3.6 floods GA4 with `scroll_depth` from list pages and muddies the post-level curve | revert the gate widening; Clarity remains the primary read either way |
+| Linux CI red after merge because the dispatch was skipped | re-run the `update-baselines` dispatch; no site change |
+| Reviewer "fixes" the `--rr-*`/`--ink-*` duplication | §3 states the two-step is deliberate — point at it |
+
+---
+
+## Open questions
+
+1. **This spec's premise was wrong as written.** The 2.1 row was requested as
+   forward work; it shipped 2026-08-20 in #487/#494. Confirm the residual
+   punch-list in §3 is the intended 2.1 scope, or close 2.1 as done and route
+   §3 to 1a.4 / a hygiene PR.
+2. **`.okf/workflows/site-redesign-rollout.md` does not exist** in this
+   worktree (`ls .okf/workflows/` — ten files, none of them that). The
+   sequencing rules and the blog-first token consequence were taken from
+   20.01 §"Phase 2" instead. Either the concept was never written or it lives
+   under another name; if a reviewer expects it, it is a missing OKF artifact.
+3. **The 25.2% figure is not segmented by device or by list-vs-post.** "Blog
+   pages" in the Clarity query covers `/blog/` and 540+ post URLs together. A
+   list page and a 2,000-word post have structurally different scroll curves,
+   so the number cannot tell us whether the list page is the problem at all.
+   Defect 6 is why we cannot answer this from GA4 either. Recommend splitting
+   the Clarity query before anyone attributes a delta to this page.
+4. Should the feature slot appear on tag pages too? Today it is index-only
+   (`blog/list.html:58`, guarded `eq $pag.PageNumber 1`), and
+   `layouts/list.html` has no equivalent. Deliberate or an omission?

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.04-phase-2.2-blog-single-spec.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.04-phase-2.2-blog-single-spec.md
@@ -1,0 +1,350 @@
+# 20.04 — Phase 2.2: blog post (single) implementation spec
+
+**Date:** 2026-08-21
+**Status:** Spec of record — **most of it has already shipped**
+**Plan row:** [20.01](20.01-rollout-plan.md) Phase 2 table, `2.2 blog-single`, plus its "2.2 note"
+**Decisions:** [ADR-0003](../../../adr/0003-site-design-system.md) · [ADR-0004](../../../adr/0004-static-site-experimentation.md)
+**Palette:** `.okf/design/site-palette.md`
+
+> **Read this first.** The four scope items in the 20.01 table — 68ch measure,
+> full-bleed cover, `surface-ink` code blocks, article-end CTA card — were
+> implemented in **PR #494** (`e1fa5409`, "Whole-blog rebuild: post header, ink
+> code blocks, wide covers, responsive mobile covers (2608 2.2b)"), which is on
+> `origin/master` (verified: `git merge-base --is-ancestor e1fa5409 origin/master`).
+> This document is therefore the spec **of record** for what is on the page, plus
+> the residual work in §4b. Do not re-implement §4a.
+>
+> One plan item did **not** ship as written: the cover is article-bleed (900px),
+> not full-bleed. §4b carries the decision.
+>
+> `.okf/workflows/site-redesign-rollout.md` was named as a governing source but
+> **does not exist** in this tree (`ls .okf/workflows/` — the closest live files
+> are `css-maintainability-plan.md` and `visual-scroll-gate.md`). Sequencing
+> rules below are taken from 20.01 itself; see Open questions §1.
+
+---
+
+## 1. The problem the post page had
+
+Blog pages: **25.2% average scroll depth / 26.3s engagement**, against a site
+average of 32.9–40.3% / 28–34s (Clarity, bot-filtered, 3 days to 2026-08-20;
+219 sessions). Visitors leave posts in the first quarter of the page. This is
+where the humans already are — the 145 GSC clicks/28d land overwhelmingly on
+posts — so it is the cheapest place to learn whether the design engages anyone
+at all.
+
+Structural causes visible in the pre-#494 template and CSS:
+
+| # | Defect | Evidence |
+|---|---|---|
+| 1 | **No measure.** The post body ran to the full `.single-post-row` width (1180px) | `themes/beaver/assets/css/pages/blog-single.css:7-12` — `.single-post-row { max-width: 1180px }`, the only width constraint the article had |
+| 2 | **A shared `ch` measure is a trap, not a fix.** `ch` is font-relative *per element*, so one `68ch` on a shared group gives the 12px meta line ~480px, the H1 ~1900px and the prose a third width | recorded in the fix itself: `pages/blog-single.css:50-53` |
+| 3 | **Nothing above the H1.** No date, no reading time — the two facts a returning reader checks before committing | `themes/beaver/layouts/single.html:48-55` now opens with `.post-meta-top`; before #494 the header opened on the H1 |
+| 4 | **Code blocks were a second dark palette.** Chroma emits an inline `#282a36` (dracula) background with `noClasses`, so every code block on a light page was a bluish-purple slab unrelated to the cover art | fix + rationale: `pages/blog-single.css:83-93` |
+| 5 | **No conversion path at the end of a post.** The reader who finished a rescue-adjacent post is the warmest visitor the site has | `single.html:152-158` comment; the `blog-cta` band existed only on the index (`single-post.css:430-437`) |
+| 6 | **Legacy heading margins fight any sane specificity**, forcing `!important` for basic title centring | `pages/blog-single.css:19-27` — three `!important`s against `style.css` |
+
+Per ADR-0004 none of this is A/B testable at ~9.7 human sessions/day. The 20.01
+"measurement pivot" retired per-phase reads as gates: the whole blog is rebuilt,
+then measured once.
+
+---
+
+## 2. Course-single coupling map — **verdict: decoupled, 2.3 is NOT blocked**
+
+20.01's "2.2 note" says: *"`blog-single` shares `pages/blog-single.css` with
+`course-single`. Changing it moves the course page too; sequence 2.3 immediately
+after, or accept the coupling and screenshot both."*
+
+**That is true of the file and false of the selectors.** Verified by reading both
+templates.
+
+### Bundle membership (both true)
+
+- `themes/beaver/layouts/single.html:3-13` loads `css/pages/blog-single.css`.
+- `themes/beaver/layouts/course/single.html:3-14` loads the **same** file, then
+  `css/pages/course-single.css` after it (comment at `:15-16`: course must load
+  last so its reading scale wins).
+- `single-post.css` is in **three** bundles — blog-list, blog-single,
+  course-single (`themes/beaver/assets/css/single-post.css:420-422`). It is the
+  genuinely shared file, not `pages/blog-single.css`.
+
+### Selector-by-selector
+
+| Selector | File:line | Reaches course? | Why |
+|---|---|---|---|
+| `.single-post-row` | `pages/blog-single.css:7-12` | **YES** | `course/single.html:54` uses it |
+| `.blog article.single-content > header h1.post-title` | `pages/blog-single.css:14-17` | **YES** | course article is `class="single-content"` inside `<div class="blog">` with `<header><h1 class="post-title">` (`course/single.html:53-59`) |
+| `.blog .post-article h1.post-title` | `pages/blog-single.css:23-27` | no | needs `.post-article` |
+| `.post-article` (900px, gutters) | `:37-42` | no | — |
+| `.post-article .post-meta-top / .post-title / .post-lead / .post-meta-byline / .post-prose / .post-tags` (680px group) | `:44-57` | no | — |
+| `.post-article .post-meta-top` | `:60-67` | no | course has no `.post-meta-top` at all |
+| `.post-article .post-lead` | `:70-75` | no | course has no `.post-lead` |
+| `.post-article .post-cover-figure` | `:78-81` | no | course figure is `.post-cover-figure` but not inside `.post-article` (`course/single.html:76`) |
+| `.post-article .highlight pre`, `.post-article .post-prose > pre`, `.post-article .highlight` | `:86-93` | no | course body is `.fl-rich-text.c-content-block__text` with **no** `.post-prose` (`course/single.html:115-117`) |
+
+**The lock:** `course/single.html:55-57` renders
+`<article class="single-content" style="max-width: 720px; …">` — **no
+`.post-article` class**. The `.post-article` scope is what makes the coupling
+inert, and `single.html:43-46` says so at the call site.
+
+### Selectors that DO move the course page (watch these, they are not in this bundle)
+
+- `single-post.css:487-493` — `.blog .post-tags a` colour. Course renders
+  `.post-tags` at `course/single.html:128`. Shared by design (one tag look).
+- `single-post.css:306-320` — the print block hides `.post-cover-figure` and
+  `.post-tags`; it drives `bin/generate-template-pdfs` output. Touching cover or
+  tag rules there means regenerating the committed PDFs.
+- `single-post.css:430-483` — `.blog-cta`. Course does **not** call
+  `partials/blog/cta-band.html` (`course/single.html:121-135` has no such call),
+  so the band is blog-index + article-end only.
+
+### Decision this forces
+
+**Scope the change so the course page is untouched; 2.3 does not need to be
+sequenced immediately after 2.2.** Any new rule in `pages/blog-single.css` is
+prefixed `.post-article`. The two pre-existing shared selectors
+(`.single-post-row`, `.blog article.single-content > header h1.post-title`) are
+**frozen** for the duration of 2.2 — if a change appears to need one of them, it
+belongs in `pages/course-single.css` (course side) or under `.post-article`
+(blog side), never in the shared pair.
+
+**Proof obligation, not assertion:** `test/fixtures/screenshots/{macos,linux}/{desktop,mobile}/course/chapter.png`
+must come out of the run **byte-identical**. A moved course baseline means the
+scope leaked; that is the blocking check, not a reading of the diff.
+
+---
+
+## 3. Target layout, section by section, and why each should move scroll depth
+
+The failure mode is abandonment in the first quarter, so every item below is
+judged on "does it earn the next scroll", not on looks.
+
+1. **Meta line above the H1** — `Aug 20, 2026 · 7 min read`, 12px, uppercase,
+   `--rr-ink-500`. A reader deciding whether to commit wants the cost up front;
+   an unpriced page is easier to abandon than an expensive one. Cheapest possible
+   first-fold intervention.
+2. **Title on a 680px measure** — a 1180px H1 wraps into a banner, not a
+   sentence. Centring it in the wide article also makes the column edge legible
+   before any body text is read.
+3. **Dek / lead** — the frontmatter description promoted to a lead paragraph,
+   **suppressed when it merely repeats the opening line** (529 of 607 posts are
+   dev.to imports that do exactly that). A duplicated first sentence is a signal
+   the page has nothing new, which is an abandonment cue.
+4. **Cover at article width (900px), below the byline** — wider than the prose
+   column, so the fold has one confident visual without pushing the opening hook
+   off a phone screen. Placement rationale is in `single.html:83-87`: on mobile
+   the text comes first.
+5. **Prose at 680px** — ~68ch at the 17px body size. The measure is the single
+   largest lever on long-form reading comfort and therefore on scroll depth.
+6. **Code blocks on `--rr-ink-900`** — the page's dark moments (cover art, code)
+   come from one palette. Dracula purple on a warm-ink light page reads as a
+   foreign embed and breaks the reading rhythm mid-article, which is where the
+   second abandonment cliff sits.
+7. **Tags after the content, ink not link colour** — navigation after reading,
+   not decoration before it.
+8. **Article-end CTA card** — one audit CTA with its proof line, on
+   `--rr-surface-raised`. This is a *conversion* item, not a scroll-depth one;
+   it exists because a finished reader had nowhere to go. It carries
+   `data-cta-location="article-end"` for the 0.1 event, which is how "which CTA
+   earns the click" becomes answerable at all.
+   Suppressed on course chapters (`single.html:156`), which have their own
+   arrival actions.
+
+---
+
+## 4a. What shipped (#494) — do not re-implement
+
+**Template `themes/beaver/layouts/single.html`**
+
+| Lines | What |
+|---|---|
+| `41-47` | `.blog > .single-post-row > article.single-content.post-article` — the scoping class, with the coupling rationale at the call site |
+| `48-55` | `header` opening on `.post-meta-top` (date · reading time), then `h1.post-title` |
+| `57-74` | `.post-lead`, with the two-tell duplicate-description suppression (trailing `...`; body-prefix match after curly-apostrophe normalisation) |
+| `76-81` | `.post-meta-byline` |
+| `83-126` | `figure.post-cover-figure` with 640/960/1920 srcset, `sizes="(max-width: 900px) calc(100vw - 36px), 864px"`, `loading="eager"`, `fetchpriority="high"` |
+| `129-131` | body wrapper gains `.post-prose` |
+| `142-150` | `.post-tags` after content |
+| `156-158` | `partial "blog/cta-band.html" "article-end"`, gated on `ne .Params.course_chapter true` |
+
+**CSS `themes/beaver/assets/css/pages/blog-single.css`**
+
+| Lines | Rule |
+|---|---|
+| `29-34` | The scoping contract, written into the file |
+| `37-42` | `.post-article { max-width: 900px; margin: 0 auto; padding: 0 18px }` |
+| `44-57` | the six-selector 680px group + the "fixed px, NOT ch" rationale |
+| `60-67` | `.post-meta-top` — 12px/600/0.08em/uppercase/`--rr-ink-500` |
+| `70-75` | `.post-lead` — 1.15rem/1.6/`--rr-ink-500` |
+| `78-81` | `.post-cover-figure` — full article width |
+| `86-93` | `.post-article .highlight pre`, `.post-article .post-prose > pre` → `background-color: var(--rr-ink-900) !important`; `.post-article .highlight { background: transparent !important }` |
+
+**Partial** `themes/beaver/layouts/partials/blog/cta-band.html` — one `h2`, one
+line of copy, one `.blog-cta-btn` to `/free-consultation/`, one
+`.blog-cta-note` carrying "4.8/5 on Clutch" with the profile linked and **no**
+review count (claims-canon). Styling: `single-post.css:430-485`.
+
+### Token policy — **deliberate, do not "fix"**
+
+20.01 Phase 2 states: new tokens are defined in the blog bundles' own CSS first
+and promoted to `foundations/css-variables.css` in Phase 1a later. That
+promotion **has already happened**: `foundations/css-variables.css:110-116`
+now defines `--rr-ink-900/700/500`, `--rr-line`, `--rr-surface-raised` as
+aliases onto the canonical `--ink-*` / `--line` / `--surface-raised` ramp, with
+the comment "the blog shipped against these names… DELETE in 1a.4 once the
+three page files consume the canonical names."
+
+So the current state is: **canonical tokens in foundations, `--rr-*` aliases
+kept only until the three page files are renamed in 1a.4.** Neither direction is
+a defect to be tidied here. A reviewer who deletes the aliases before 1a.4 breaks
+the blog; a reviewer who "consolidates" the blog files onto them permanently
+undoes 1a.4. Leave both alone in 2.2.
+
+### Post-1a.3 token set — nothing to do
+
+`pages/blog-single.css` contains **no** `--color-primary` and no `#0066d6`
+declaration; the only match is the word `#0066d6` inside a comment at `:21`.
+PR #518 (deleting `--color-primary`, retiring the anchor rule across 194 files)
+therefore does not change this file's behaviour. Two follow-ups it does create:
+
+- `:19-22` comment says "both die in Phase 1a" — once #518 lands, that is
+  history, and the comment should be updated to past tense.
+- The three `!important`s at `:16`, `:25-26` exist because of the same
+  late-cascade fight. After #518, **test whether they can be removed** (per the
+  palette doc: retiring the scoped `!important` workarounds is the phase's
+  success signal). Removing them is a separate, verifiable change — not a
+  drive-by.
+
+## 4b. Residual work
+
+**R1 — Cover: article-bleed (900px) vs the plan's "full-bleed". Recommend
+keeping article-bleed; record the deviation.**
+
+Current: `pages/blog-single.css:77-81`, comment reads "Full-bleed(ish): full
+article width, wider than the prose column". True full-bleed (a `100vw`
+break-out) is not implemented. Reasons not to add it:
+
+- A `100vw` break-out inside a centred column is the classic source of
+  horizontal body scroll, which CLAUDE.md forbids outright, on 624 post
+  directories at once.
+- The `sizes` attribute (`single.html:99`, `:114`) is written for an 864px
+  render box. Full-bleed makes every one of those wrong, so the change is not
+  CSS-only — it is CSS **plus** a srcset/sizes revision, on the LCP image.
+- The stated purpose ("one confident visual in the fold, wider than the prose")
+  is already met at 900px against a 680px measure.
+
+**Decision: keep 900px. Log it as a scope deviation from 20.01's table wording.**
+If Paul wants literal full-bleed, it is a separate change with its own baseline
+run — see Open questions §2.
+
+**R2 — Comment hygiene after #518** (`:19-22` past tense) and the `!important`
+removal probe described above. Sequence: after #518 merges, not before.
+
+**R3 — Verify the 0.1 instrumentation actually fires from the article-end band.**
+`data-cta-location="article-end"` is emitted (`cta-band.html`), and 20.01 Phase 0
+requires each event verified in GA4 DebugView on staging *and once in
+production*. That verification is not recorded anywhere in this project. Until it
+is, "which CTA earns the click" is still unanswerable and the whole-blog measure
+loses its conversion half.
+
+**R4 — Record the firm "before" for the whole-blog measure.** 20.01 asks for the
+same Clarity query re-pulled in rolling 3-day windows for the 14 days before
+ship. Only the 3-day 2026-08-20 sample (25.2% / 26.3s / 219 sessions) exists.
+The measure protocol is 40.01; this is a data task, not a code task.
+
+---
+
+## 5. Out of scope
+
+- **The course page.** 2.3 owns every course visual. No rule in this phase may
+  reach `course/single.html`; the two shared selectors are frozen (§2).
+- **`blog-list`** — Phase 2.1, a different agent. The only contact surface is
+  shared tokens and `single-post.css`'s `.blog-cta`; do not edit either from 2.2.
+- **The cover-image *system*** — obsidian art, `.stitch/design.md`. Untouched by
+  design (palette doc: blog cover art is one of the three deliberate dark
+  surfaces).
+- **Typeface, PostCSS pipeline, the cover generator** — ADR-0003 non-goals.
+- **The three blue logo SVGs** — out of scope for every design-system phase.
+- **`--color-primary` deletion** — PR #518's job, not 2.2's.
+- **Post content.** 540+ posts' prose, dev.to import quality, banned strings —
+  Phase 3 and the blog pipeline.
+- **A/B testing.** Not available at this traffic (ADR-0004); no lift may be
+  claimed from this phase.
+
+---
+
+## 6. Gate
+
+**macOS local only.** Linux baselines cannot be recorded on this machine.
+
+1. `bin/hugo-build` — validators + banned-string ratchet. Blocking.
+2. `bin/qtest --changed` — routine visual gate on the pages the diff touches.
+3. `bin/test` — full macOS leg. Required because this is a template/CSS change
+   and the diff reaches every post.
+4. **Rendered scroll gate** (`docs/workflows/visual-scroll-gate.md`) on one
+   normal post, one code-heavy post, one mermaid post, at 1280×800 and 390×844.
+   Text validators cannot see rendered output.
+5. **Course non-regression, blocking:** `macos/{desktop,mobile}/course/chapter.png`
+   unchanged. If either moves, the `.post-article` scope leaked — fix the
+   selector, do not accept the baseline.
+
+**Baseline movement.** "540+ posts" is production reach, not baseline count.
+The post template has **24 macOS baselines**: `desktop/blog/post.png`,
+`mobile/blog/post.png`, `desktop|mobile/blog/special/code_highlight_post.png`,
+`.../codeblocks/{bare,html,indented,js,md,python,ruby,text}.png` ×2 viewports,
+`desktop/blog/special/{inline_style_post,mermaid_post,youtube_post}.png`,
+`mobile/blog/special/mermaid_post.png`. Expect most of them to move — the code
+block recolour alone hits all 18 codeblock/code-highlight shots. Accept them
+**with the screenshots reviewed, not merely captured**, and commit them in the
+same commit as the change (baselines compare against git HEAD, not the working
+tree — an uncommitted "accepted" PNG changes nothing).
+
+**Linux needs one CI dispatch, later.** `bin/dtest` on this host runs emulated
+Docker and its red is emulation drift, not signal; `mermaid_post` has been red on
+native CI since #470. The Linux leg is re-recorded by dispatching the `test.yml`
+`update-baselines` workflow on the branch once, and the resulting commit is what
+makes CI green. Do not hand-record Linux locally.
+
+**Gates A/B/C (20.01):** A = the screenshot + scroll review above, plus ≥20
+Clarity post sessions read in week one. B = GSC average position/impressions on
+the top 20 URLs (prefix property), Bing+DDG sessions, LCP — thresholds written
+into the PR *before* merge. C = one PR, revert restores the previous post page
+whole.
+
+---
+
+## 7. Risks and rollbacks
+
+| # | Risk | Likelihood | Rollback / mitigation |
+|---|---|---|---|
+| 1 | A new rule loses the `.post-article` prefix and moves the course page | medium | `course/chapter.png` baselines are the tripwire (§6.5). Rollback: re-scope the selector; no revert needed if caught pre-commit |
+| 2 | The `background-color: … !important` on `pre` misses a code path Chroma emits differently (fenced vs indented vs inline-style posts) | medium | 18 codeblock baselines already cover the fence languages. Rollback: revert `pages/blog-single.css:86-93` alone — it is a 4-line block, independent of the measure work |
+| 3 | The dek-suppression heuristic hides a legitimate lead, or shows a duplicated one | medium | It already regressed once (Codex P2, 2026-08-20 — a post whose description matched the opening verbatim), which is why there are two tells (`single.html:64-71`). Rollback: the `with .Params.description` block reverts alone |
+| 4 | LCP regresses — the cover is `loading="eager" fetchpriority="high"` at up to 1920w | low-medium | LCP is a Gate B guardrail with a declared threshold. Rollback: drop `fetchpriority`, or narrow the srcset ceiling; no layout change needed |
+| 5 | The article-end CTA reads as an ad and *shortens* sessions | low | Gate A Clarity recordings, week one. Rollback: `single.html:156-158` — delete three lines; the partial and its CSS stay for the index |
+| 6 | Baseline churn (24 shots) hides a real regression inside an accepted batch | medium | Review each accepted PNG against the previous state; the codeblock set should differ only in background colour — anything that also moved *geometry* is a defect, not a recolour |
+| 7 | Removing the `!important`s after #518 quietly re-breaks title centring | medium | R2 is a separate commit with its own `bin/qtest --changed`; never bundled with a baseline-accepting commit |
+| 8 | This spec is read as a to-do and 2.2 gets implemented twice | **high** | the banner at the top, and §4a listing exact line ranges of what already exists |
+
+---
+
+## Open questions
+
+1. **`.okf/workflows/site-redesign-rollout.md` does not exist.** It was cited as
+   governing (sequencing rules, the token-moves-twice consequence, the course
+   coupling) but is absent from `.okf/workflows/`. Either it is unwritten, lives
+   under a different name, or sits on an unmerged branch. Everything in this
+   spec is sourced from 20.01 and the code instead. Someone should either write
+   it or stop citing it.
+2. **Does Paul want literal full-bleed covers?** §4b/R1 recommends no and
+   explains the cost (srcset rewrite on the LCP image, horizontal-scroll risk
+   across 624 posts). The 20.01 table says "full-bleed"; the implementation says
+   "full-bleed(ish)". This deviation needs a yes/no, not a guess.
+3. **Was the article-end `cta_click` event ever verified in GA4 DebugView
+   (staging *and* production)?** Phase 0.1 requires it; no record exists in this
+   project (R3).
+4. **When does 1a.4 run?** The `--rr-*` aliases at
+   `foundations/css-variables.css:110-116` are explicitly temporary. If 1a.4
+   slips indefinitely, the "temporary" alias layer becomes permanent debt and
+   the comment becomes a lie.

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.04-phase-2.2-blog-single-spec.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.04-phase-2.2-blog-single-spec.md
@@ -241,7 +241,10 @@ break-out) is not implemented. Reasons not to add it:
 - The stated purpose ("one confident visual in the fold, wider than the prose")
   is already met at 900px against a 680px measure.
 
-**Decision: keep 900px. Log it as a scope deviation from 20.01's table wording.**
+**DECISION (2026-08-21): keep 900px.** Made autonomously under Paul's "do
+not wait for me" grant rather than parked - a deviation that blocks nothing and
+reverses in one `max-width` does not need a person. Logged as a scope deviation
+from 20.01's table wording; the TABLE is what should change, not the code.
 If Paul wants literal full-bleed, it is a separate change with its own baseline
 run — see Open questions §2.
 
@@ -352,10 +355,15 @@ whole.
    under a different name, or sits on an unmerged branch. Everything in this
    spec is sourced from 20.01 and the code instead. Someone should either write
    it or stop citing it.
-2. **Does Paul want literal full-bleed covers?** §4b/R1 recommends no and
-   explains the cost (srcset rewrite on the LCP image, horizontal-scroll risk
-   across 624 posts). The 20.01 table says "full-bleed"; the implementation says
-   "full-bleed(ish)". This deviation needs a yes/no, not a guess.
+2. ~~**Does Paul want literal full-bleed covers?**~~ **CLOSED 2026-08-21 -
+   keep 900px.** Decided under Paul's standing autonomy grant ("do not wait
+   for me"), on §4b/R1's reasoning: a `100vw` break-out risks horizontal body
+   scroll across 624 post dirs, it invalidates the `sizes` attribute on the
+   LCP image so the change is not CSS-only, and the stated purpose - one
+   confident visual wider than the prose - is already met at 900px against a
+   680px measure. **Reversible**: it is one `max-width` plus a `sizes`
+   revision if Paul disagrees. 20.01's table wording should be corrected to
+   "article-bleed" rather than the implementation chasing the table.
 3. **Was the article-end `cta_click` event ever verified in GA4 DebugView
    (staging *and* production)?** Phase 0.1 requires it; no record exists in this
    project (R3).

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.04-phase-2.2-blog-single-spec.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.04-phase-2.2-blog-single-spec.md
@@ -210,11 +210,18 @@ therefore does not change this file's behaviour. Two follow-ups it does create:
 
 - `:19-22` comment says "both die in Phase 1a" — once #518 lands, that is
   history, and the comment should be updated to past tense.
-- The three `!important`s at `:16`, `:25-26` exist because of the same
-  late-cascade fight. After #518, **test whether they can be removed** (per the
-  palette doc: retiring the scoped `!important` workarounds is the phase's
-  success signal). Removing them is a separate, verifiable change — not a
-  drive-by.
+- The three `!important`s at `:16`, `:25-26` — **DO NOT probe these for
+  removal. Corrected 2026-08-21 after review (Codex).** The earlier text here
+  said to test whether #518 lets them go. It does not. `20.02-phase-1a-plan.md:69-81`
+  draws exactly this distinction and it is the reason the phase's success
+  signal was rewritten: these fight the LEGACY HEADING-MARGIN rules, not the
+  retired `#0066d6` anchor rule. Same *class* of fight, different *cause*.
+  They die when `style.css`'s heading rules die, which is not this phase.
+  Removing them now restores the title-alignment regression.
+
+  The falsifiable rule from 20.02, which supersedes any count: **every
+  `!important` whose comment cites the anchor rule must go, and no other
+  `!important` may be touched.** Read the comment on each one before acting.
 
 ## 4b. Residual work
 
@@ -248,10 +255,18 @@ production*. That verification is not recorded anywhere in this project. Until i
 is, "which CTA earns the click" is still unanswerable and the whole-blog measure
 loses its conversion half.
 
-**R4 — Record the firm "before" for the whole-blog measure.** 20.01 asks for the
-same Clarity query re-pulled in rolling 3-day windows for the 14 days before
-ship. Only the 3-day 2026-08-20 sample (25.2% / 26.3s / 219 sessions) exists.
-The measure protocol is 40.01; this is a data task, not a code task.
+**R4 — Record the firm "before" for the whole-blog measure. DONE 2026-08-21,
+with one follow-on.** Five rolling 3-day Clarity windows covering
+2026-08-06 → 08-20 are recorded in
+[40.01](../40-49-measurement/40.01-blog-engagement-baseline.md), superseding
+the single 3-day sample this task was written against. That sample (25.2% /
+26.3s / 219) turned out to be the LOWEST of the five and to straddle the
+08-20 deploy; the clean pre-ship figure is 08-06 → 08-17, 451 sessions,
+56.4% scroll / 40.1s.
+
+Follow-on, not a repeat of the work: the clean window is 12 days against a
+planned 28-day "after". Extend it backwards to a full 28 days ending
+2026-08-17 (four more 3-day pulls) before the comparison is treated as final.
 
 ---
 

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.04-phase-2.2-blog-single-spec.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.04-phase-2.2-blog-single-spec.md
@@ -290,7 +290,9 @@ the single 3-day sample this task was written against. That sample (25.2% /
 
 Follow-on, not a repeat of the work: the clean window is 12 days against a
 planned 28-day "after". Extend it backwards to a full 28 days ending
-2026-08-17 (four more 3-day pulls) before the comparison is treated as final.
+2026-08-17 before the comparison is treated as final. That is **16 further
+days** - five 3-day pulls plus a 1-day pull, not four pulls (which would reach
+only 24 days).
 
 ---
 
@@ -333,8 +335,17 @@ The post template has **24 macOS baselines**: `desktop/blog/post.png`,
 `mobile/blog/post.png`, `desktop|mobile/blog/special/code_highlight_post.png`,
 `.../codeblocks/{bare,html,indented,js,md,python,ruby,text}.png` ×2 viewports,
 `desktop/blog/special/{inline_style_post,mermaid_post,youtube_post}.png`,
-`mobile/blog/special/mermaid_post.png`. Expect most of them to move — the code
-block recolour alone hits all 18 codeblock/code-highlight shots. Accept them
+`mobile/blog/special/mermaid_post.png`.
+
+**HISTORICAL — this describes #494, which already shipped** (clarified
+2026-08-21 after review). Those 18 codeblock/code-highlight shots moved when the
+ink recolour landed; they are not going to move again.
+
+**For the residual work in §4b the requirement is the opposite: ZERO visual
+delta.** R1 is closed, R2 is comment-only, R3 is verification and R4 is
+measurement — none of them touches a rendered pixel. **If a residual execution
+moves a baseline, that is a regression to investigate, not a baseline to
+accept.** Should a future change legitimately move them, accept them
 **with the screenshots reviewed, not merely captured**, and commit them in the
 same commit as the change (baselines compare against git HEAD, not the working
 tree — an uncommitted "accepted" PNG changes nothing).

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.04-phase-2.2-blog-single-spec.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.04-phase-2.2-blog-single-spec.md
@@ -17,21 +17,34 @@
 > One plan item did **not** ship as written: the cover is article-bleed (900px),
 > not full-bleed. §4b carries the decision.
 >
-> `.okf/workflows/site-redesign-rollout.md` was named as a governing source but
-> **does not exist** in this tree (`ls .okf/workflows/` — the closest live files
-> are `css-maintainability-plan.md` and `visual-scroll-gate.md`). Sequencing
-> rules below are taken from 20.01 itself; see Open questions §1.
+> `.okf/workflows/site-redesign-rollout.md` **does exist and governs this spec**
+> (resolved 2026-08-21). It read as absent only because this spec was drafted
+> from a worktree checked out on an unmerged branch that predated it - the
+> CLAUDE.md rule applies: if a file you know exists reports missing, check the
+> working directory and branch before believing it. Its sequencing rules and
+> the token-moves-twice consequence match what was independently derived from
+> 20.01 below; it additionally supersedes 20.01 on the course coupling, which
+> is DECOUPLED.
 
 ---
 
 ## 1. The problem the post page had
 
-Blog pages: **25.2% average scroll depth / 26.3s engagement**, against a site
-average of 32.9–40.3% / 28–34s (Clarity, bot-filtered, 3 days to 2026-08-20;
-219 sessions). Visitors leave posts in the first quarter of the page. This is
-where the humans already are — the 145 GSC clicks/28d land overwhelmingly on
-posts — so it is the cheapest place to learn whether the design engages anyone
-at all.
+**The premise this section was written on does not hold — corrected 2026-08-21
+against the measured baseline in
+[40.01](../40-49-measurement/40.01-blog-engagement-baseline.md).**
+
+The 25.2% / 26.3s / 219-session figure is ONE 3-day Clarity window of five,
+the lowest, and it straddles the 2026-08-20 deploy. The clean pre-ship
+window (08-06 → 08-17) reads **56.4% scroll / 40.1s over 451 sessions**.
+**"Visitors leave posts in the first quarter" is therefore not supported** and
+must not be repeated as the rationale. GSC over the same period is **105
+blog clicks / 28d**, not 145.
+
+What survives, and is the honest reason this template matters: those 105
+clicks are **77% of the entire site's Google traffic**. This is where the
+humans are - which justifies attention regardless of whether an engagement
+deficit exists.
 
 Structural causes visible in the pre-#494 template and CSS:
 
@@ -248,8 +261,16 @@ from 20.01's table wording; the TABLE is what should change, not the code.
 If Paul wants literal full-bleed, it is a separate change with its own baseline
 run — see Open questions §2.
 
-**R2 — Comment hygiene after #518** (`:19-22` past tense) and the `!important`
-removal probe described above. Sequence: after #518 merges, not before.
+**R2 — Comment hygiene after #518** (`:19-22` past tense). Sequence: after #518
+merges, not before.
+
+**Scope is the comment ONLY.** An earlier draft of this residual also carried an
+`!important` removal probe; that was wrong and is deleted (2026-08-21, second
+review). §4a records why: those declarations fight the LEGACY HEADING-MARGIN
+rules, not the retired anchor rule, and `20.02-phase-1a-plan.md:69-81` defers
+them until `style.css`'s heading rules die. Removing them here restores the
+title-alignment regression. Touch no `!important` whose comment does not cite
+the anchor rule.
 
 **R3 — Verify the 0.1 instrumentation actually fires from the article-end band.**
 `data-cta-location="article-end"` is emitted (`cta-band.html`), and 20.01 Phase 0
@@ -349,12 +370,13 @@ whole.
 
 ## Open questions
 
-1. **`.okf/workflows/site-redesign-rollout.md` does not exist.** It was cited as
-   governing (sequencing rules, the token-moves-twice consequence, the course
-   coupling) but is absent from `.okf/workflows/`. Either it is unwritten, lives
-   under a different name, or sits on an unmerged branch. Everything in this
-   spec is sourced from 20.01 and the code instead. Someone should either write
-   it or stop citing it.
+1. ~~**`.okf/workflows/site-redesign-rollout.md` does not exist.**~~ **CLOSED
+   2026-08-21 - it exists and always did.** The correct third branch of the
+   guess was the right one: it sat on an unmerged branch while this spec was
+   drafted from a worktree checked out elsewhere. Nothing in this spec
+   contradicts it; it additionally supersedes 20.01 on the course coupling
+   (DECOUPLED). Generalisable: a missing-file conclusion from inside a worktree
+   is a branch question first, an authoring question second.
 2. ~~**Does Paul want literal full-bleed covers?**~~ **CLOSED 2026-08-21 -
    keep 900px.** Decided under Paul's standing autonomy grant ("do not wait
    for me"), on §4b/R1's reasoning: a `100vw` break-out risks horizontal body

--- a/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
+++ b/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
@@ -111,11 +111,18 @@ Top `/blog/` pages by session, 2026-08-18 → 08-20 (Clarity):
 | `/blog/implementing-instant-search-dynamic-forms-infinite/` | 7 | 2% |
 | `/blog/langgraph-workflows-state-machines-ai-agents/` | 6 | 5.89% |
 
-**These do not reconcile with the aggregate and must not be quoted.** A
-session-weighted average of this table is ~9%; the aggregate for the same window
-and same page-set is 25.56%. Two Clarity aggregations that disagree by ~3x mean
-at least one is not measuring what its label says. Recorded as a gap below, not
-as a per-post baseline.
+**Not yet reconciled - and NOT evidence that Clarity disagrees with itself
+(corrected 2026-08-21 after review).** A session-weighted average of this
+table is ~9%, against a 25.56% aggregate. That is NOT the same page-set: this
+table is the TOP TEN pages by clicks, the aggregate covers EVERY `/blog/`
+page. The omitted long tail can account for the entire gap, so no
+contradiction has been demonstrated.
+
+What this does mean: **per-post scroll is not yet retrieved, not proven
+unobtainable.** Retrieving all page rows (or reconciling the omitted
+population) is the open task; abandoning per-post analysis on the strength of
+this comparison would have been wrong. Recorded as a gap below on those
+narrower terms.
 
 ## Source 2 — Google Search Console, `https://jetthoughts.com/` (prefix property)
 
@@ -203,8 +210,26 @@ inventory to this baseline. It contributes no human-traffic number.**
 
 ## The headline before/after comparator
 
-**Clarity session-weighted average engagement time on `/blog/` pages:
-34.97s over 743 sessions, 2026-08-06 → 2026-08-20.**
+**SUPERSEDED 2026-08-21 - the deploy time is now confirmed, and this window is
+contaminated.** The rebuild shipped on 2026-08-20 at **17:35** (#487) and
+**20:16** (#494), both inside the 08-18→20 window. A "before" that contains
+post-change sessions is not a before.
+
+**Use the clean pre-ship window: 2026-08-06 → 2026-08-17, 451 sessions,
+56.4% scroll / 40.1s.**
+
+Two caveats a reader must carry, both raised in review:
+
+* **It is 12 days, and the planned "after" read is 28.** Comparing a 12-day
+  before with a 28-day after mixes window lengths on a metric that already
+  swings 2.9x window-to-window. Extend the before backwards to a full 28 days
+  ending 2026-08-17 before this is treated as final - the Clarity data exists,
+  it just needs four more 3-day pulls.
+* The contaminated figure is retained below for audit, not for use.
+
+~~Clarity session-weighted average engagement time on `/blog/` pages:
+34.97s over 743 sessions, 2026-08-06 → 2026-08-20.~~ (contaminated - straddles
+the deploy)
 
 Chosen over scroll depth (which swung 2.9x across the same five windows vs
 engagement's 2.3x) and over GSC clicks (which measures search demand, not what a

--- a/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
+++ b/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
@@ -51,3 +51,202 @@ pre/post read on a single short window would be noise dressed as a result.
 **Read due:** 28 days after the `e1fa5409d` deploy date (≈2026-09-17 if it
 deploys same-day; re-date from the actual deploy, since a delayed deploy
 shifts the whole window rather than shortening it).
+
+---
+
+# Pre-ship baseline (recorded 2026-08-21)
+
+Pulled live via the Clarity, GSC and GA4 MCP servers on 2026-08-21, per
+`.okf/workflows/analytics-access.md`. This is the **"before" half of the single
+whole-blog before/after read** — per Paul's 2026-08-20 pivot there are no
+per-phase gates, so this record is the only pre-ship measurement that will
+exist. Every figure carries its window and its source.
+
+Two corrections to the section above are folded in here rather than edited over
+it: the earlier read was taken mid-day 2026-08-20 with that day incomplete, and
+it covered 9 days rather than 15.
+
+## Source 1 — Microsoft Clarity, project `xum05dgnec`, pages under `/blog/`
+
+Bot-filtered by Clarity. The API caps a query at 3 days, so the 15 days before
+ship are five separate rolling windows. **They are recorded separately on
+purpose — averaging them into one number hides that the metric swings 2.9x.**
+
+| Window (3d) | Avg scroll depth | Avg engagement | Sessions (denominator) |
+|---|---|---|---|
+| 2026-08-06 → 08-08 | 29.89% | 62.38s | 49 |
+| 2026-08-09 → 08-11 | 51.13% | 33.79s | 185 |
+| 2026-08-12 → 08-14 | 75.11% | 32.31s | 144 |
+| 2026-08-15 → 08-17 | 50.91% | 56.41s | 73 |
+| 2026-08-18 → 08-20 | 25.56% | 27.06s | 292 |
+| **Session-weighted, 08-06 → 08-20** | **44.31%** | **34.97s** | **743** |
+
+Reproducibility check: the 08-12→14 and 08-15→17 windows re-pulled on 2026-08-21
+returned **identical** figures to the 2026-08-20 record (75.11/32.31/144 and
+50.91/56.41/73). Clarity's historical ranges are stable, not recomputed.
+
+**Correction to the window above:** 08-18→20 was recorded on 2026-08-20 as
+25.2% / 26.3s / 219 sessions while that day was still in progress. The complete
+window is **25.56% / 27.06s / 292 sessions**. The earlier 9-day weighted figure
+of 46.0% / 35.3s is superseded by the 15-day **44.31% / 34.97s** above.
+
+Range across the five windows: scroll **25.6% – 75.1%** (2.9x), engagement
+**27.1s – 62.4s** (2.3x). At 49–292 sessions per window, neither range is a
+design signal; it is which posts drew traffic that week.
+
+### Per-page Clarity scroll depth — pulled, and NOT usable
+
+Top `/blog/` pages by session, 2026-08-18 → 08-20 (Clarity):
+
+| Page | Sessions | Avg scroll depth |
+|---|---|---|
+| `/blog/laravel-ai-integration-tutorial-complete-guide/` | 23 | 0% |
+| `/blog/mastering-command-line-create-new-rails/` | 18 | 0% |
+| `/blog/rails-testing-best-practices-complete-guide-2025/` | 17 | 1% |
+| `/blog/laravel-11-migration-guide-production-deployment-strategies/` | 16 | 1.88% |
+| `/blog/langchain-python-tutorial-complete-guide/` | 14 | 1.64% |
+| `/blog/` (index) | 11 | 49.91% |
+| `/blog/rails-8-authentication-generator-devise-migration/` | 10 | 2.3% |
+| `/blog/rubyllm-rails-getting-started/` | 10 | 79.2% |
+| `/blog/implementing-instant-search-dynamic-forms-infinite/` | 7 | 2% |
+| `/blog/langgraph-workflows-state-machines-ai-agents/` | 6 | 5.89% |
+
+**These do not reconcile with the aggregate and must not be quoted.** A
+session-weighted average of this table is ~9%; the aggregate for the same window
+and same page-set is 25.56%. Two Clarity aggregations that disagree by ~3x mean
+at least one is not measuring what its label says. Recorded as a gap below, not
+as a per-post baseline.
+
+## Source 2 — Google Search Console, `https://jetthoughts.com/` (prefix property)
+
+Prefix property, not `sc-domain:`, per the `elital.` pollution rule in
+`analytics-access.md`. Window 2026-07-24 → 2026-08-20 (28 days).
+
+| Segment | Window | Clicks | Impressions | CTR | Avg position |
+|---|---|---|---|---|---|
+| Pages containing `/blog/` | 07-24 → 08-20 (28d) | 105 | 100,070 | 0.105% | — |
+| Pages containing `/blog/`, **lag-trimmed** | 07-24 → **08-17** (25d) | **94** | **93,794** | **0.100%** | — |
+| Site-wide (all pages) | 07-24 → 08-20 (28d) | 136 | 100,031 | 0.136% | — |
+| Site-wide, DESKTOP | 07-24 → 08-20 | 99 | 93,561 | 0.106% | 20.5 |
+| Site-wide, MOBILE | 07-24 → 08-20 | 36 | 6,383 | 0.564% | 16.5 |
+| Site-wide, TABLET | 07-24 → 08-20 | 1 | 87 | 1.15% | 28.9 |
+
+The blog is **105 of 136 site-wide Google clicks — 77% of the site's search
+traffic.** Lag-trimmed blog rate: **3.8 clicks/day**.
+
+**Lag is visible in the raw daily series and the tail was trimmed for that
+reason:** 08-18 = 6 clicks / 2,750 impr, 08-19 = 5 / 2,623, **08-20 = 0 / 903**.
+Aug 20 at 903 impressions against a ~2,700/day baseline is unreported data, not
+a traffic collapse. Any post-ship read must trim its own tail the same way.
+
+TABLET (1 click / 87 impressions) is **too small to carry a rate** — the 1.15%
+is one click and is reported here only so the row is not silently dropped.
+
+### Top blog pages by clicks, 2026-07-24 → 2026-08-20
+
+| Page | Clicks | Impressions | CTR | Position |
+|---|---|---|---|---|
+| `/blog/langchain-python-tutorial-complete-guide/` | 11 | 4,141 | 0.27% | 15.1 |
+| `/blog/auto-install-system-dependencies-for-ruby-on-rails-programming/` | 8 | 100 | 8.0% | 8.5 |
+| `/blog/rails-8-solid-queue-migration-guide/` | 6 | 711 | 0.84% | 23.5 |
+| `/blog/how-create-triangles-in-tailwindcss-html-css/` | 5 | 336 | 1.49% | 7.3 |
+| `/blog/comprehensive-list-of-recruitment-agencies-in/` | 4 | 1,164 | 0.34% | 38.3 |
+| `/blog/rails-event-structured-logging-8-1/` | 4 | 347 | 1.15% | 11.6 |
+| `/blog/ruby-3-4-yjit-performance-guide/` | 4 | 1,659 | 0.24% | 10.1 |
+
+**Below 4 clicks the page-level CTR is not a rate.** The 28-day list has a long
+tail of 1-click pages, including one at 1 impression / 1 click ("100% CTR") and
+one at 4 impressions / 1 click ("25%"). Those are not reported as rates here and
+must not be compared after the rebuild.
+
+## Source 3 — GA4 property `328508492` (bot-inflated, quoted as such)
+
+Window 2026-07-24 → 2026-08-20, same 28 days as GSC.
+
+| Channel | Sessions | Engaged sessions | Engagement rate |
+|---|---|---|---|
+| Direct | 8,598 | 4,005 | 46.6% |
+| Organic Search | 574 | 361 | 62.9% |
+| Unassigned | 144 | 10 | 6.9% |
+| Referral | 88 | 68 | 77.3% |
+| AI Assistant | 34 | 27 | 79.4% |
+| Organic Social | 15 | 13 | 86.7% |
+| Email | 5 | 2 | 40.0% |
+| **Total** | **9,458** | 4,486 | 47.4% |
+
+**Reconciliation, as required before quoting any of this:** GA4 reports **574
+Organic Search sessions**; GSC reports **136 Google clicks** for the identical
+window and site. A **4.2x gap**. None of the 9,458 GA4 sessions above may be
+quoted as human traffic. The Direct row (8,598 sessions, 91% of the total, 46.6%
+engagement) is the crawler bulk.
+
+Blog landing pages, GA4, same window — **1,260 distinct `/blog/` landing pages**
+recorded sessions. Top by sessions, with the per-session engagement that shows
+why the counts are not people:
+
+| Landing page | Sessions | Engaged | Engagement per session |
+|---|---|---|---|
+| `/blog/` (index) | 162 | 74 | 3.8s |
+| `/blog/autogen-crewai-langgraph-ai-agent-frameworks-2025/` | 114 | 39 | 4.5s |
+| `/blog/langgraph-workflows-state-machines-ai-agents/` | 103 | 49 | 30.1s |
+| `/blog/langchain-python-tutorial-complete-guide/` | 66 | 38 | 29.5s |
+| `/blog/elixir-ai-integration-tutorial-complete-guide/` | 64 | 35 | 63.1s |
+| `/blog/laravel-ai-integration-tutorial-complete-guide/` | 63 | 33 | 5.3s |
+| `/blog/crewai-multi-agent-systems-orchestration/` | 62 | 19 | **0.11s** |
+| `/blog/laravel-11-migration-guide-production-deployment-strategies/` | 55 | 29 | 14.7s |
+| `/blog/rails-testing-best-practices-complete-guide-2025/` | 41 | 21 | 31.0s |
+| `/blog/rails-8-authentication-generator-devise-migration/` | 40 | 25 | 37.0s |
+
+62 sessions totalling 7 seconds of engagement is a bot signature, and it sits
+third from top by volume. **GA4 adds a bot-volume datapoint and a landing-page
+inventory to this baseline. It contributes no human-traffic number.**
+
+## The headline before/after comparator
+
+**Clarity session-weighted average engagement time on `/blog/` pages:
+34.97s over 743 sessions, 2026-08-06 → 2026-08-20.**
+
+Chosen over scroll depth (which swung 2.9x across the same five windows vs
+engagement's 2.3x) and over GSC clicks (which measures search demand, not what a
+template rebuild changes). Its denominator, 743 sessions, is the largest
+bot-filtered human-behaviour denominator available on this site.
+
+Scroll depth is the **secondary** comparator at **44.31% / 743 sessions**, same
+window, and must be read alongside its five constituent windows, never alone.
+
+# Gaps and caveats
+
+1. **Per-post Clarity scroll depth is unavailable at usable fidelity.** The
+   per-page and aggregate figures for the same window and page-set disagree by
+   ~3x (see the table above). Protocol step 3 ("segment by post, top-5 of each
+   period") **cannot be executed** against Clarity as it stands. No estimate is
+   substituted. Resolving this needs either a Clarity support answer on how the
+   two aggregations differ, or the GA4 `scroll_depth` milestones as the per-post
+   source instead.
+2. **No pre-ship `scroll_depth` GA4 milestone data exists.** The events shipped
+   in PR #489 alongside the rebuild, so their first 28 days are their own
+   baseline with no "before" to diff. Unchanged from the protocol above.
+3. **Clarity retention was not probed past 2026-08-06.** 15 days of before-mass
+   is what this record holds. Windows earlier than 08-06 were not attempted, so
+   whether Clarity would serve them is unknown, not refuted.
+4. **The 08-18 → 08-20 window overlaps the ship.** The three rebuild merges
+   landed on 2026-08-20 (14:35 / 16:29 / 17:16 UTC). If any deployed to
+   production that day, the final window is contaminated by post-ship traffic.
+   Deploy time was not confirmed at record time. Treat the 08-06 → 08-17 subset
+   (451 sessions, weighted **56.4% scroll / 40.1s engagement**) as the clean-room
+   before if the deploy is later confirmed to be same-day.
+5. **No conversion metric exists in this baseline.** GA4 has no form submit and
+   no booking event; `page_view` was a key event for the whole window, so
+   `keyEvents` here counts page views. "Did the rebuild convert better" is
+   unanswerable from any before-side data.
+6. **GSC blog-filtered impressions (100,070) exceed the site-wide total
+   (100,031) by 39.** A page-filtered GSC query aggregates differently from an
+   unfiltered one; the 0.04% discrepancy is an artifact, not a data error, and
+   is recorded so a future reader does not chase it.
+7. **Blog CTR is not comparable to a pre-2026-08 figure computed on
+   `sc-domain:`.** This record uses the prefix property throughout to exclude
+   `elital.jetthoughts.com`. Any historical CTR from the domain property is a
+   different metric.
+8. **Clarity session counts and GA4 session counts are different populations**
+   (Clarity bot-filters, GA4 does not) and must never be summed, diffed, or used
+   as each other's denominator.

--- a/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
+++ b/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
@@ -224,8 +224,13 @@ inventory to this baseline. It contributes no human-traffic number.**
 ## The headline before/after comparator
 
 **SUPERSEDED 2026-08-21 - the deploy time is now confirmed, and this window is
-contaminated.** The rebuild shipped on 2026-08-20 at **17:35** (#487) and
-**20:16** (#494), both inside the 08-18→20 window. A "before" that contains
+contaminated.** #487 MERGED at **17:35** and #494 at **20:16** on 2026-08-20, both inside the
+08-18→20 window. **These are merge times, not confirmed production deploys** -
+GitHub Pages publishes on a separate workflow run that can lag or fail, and this
+document's own opening requires the deploy to be confirmed. Treat the window as
+CONTAMINATED-PENDING-CONFIRMATION: if the deploy is later shown to have landed
+after 08-20, the window is clean and can be restored. Confirm via the Pages
+deployment record before treating this as settled either way. A "before" that contains
 post-change sessions is not a before.
 
 **Use the clean pre-ship window: 2026-08-06 → 2026-08-17, 451 sessions,

--- a/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
+++ b/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
@@ -182,10 +182,23 @@ Window 2026-07-24 → 2026-08-20, same 28 days as GSC.
 | **Total** | **9,458** | 4,486 | 47.4% |
 
 **Reconciliation, as required before quoting any of this:** GA4 reports **574
-Organic Search sessions**; GSC reports **136 Google clicks** for the identical
-window and site. A **4.2x gap**. None of the 9,458 GA4 sessions above may be
-quoted as human traffic. The Direct row (8,598 sessions, 91% of the total, 46.6%
-engagement) is the crawler bulk.
+Organic Search sessions**; GSC reports **136 Google clicks** for the same
+window and site.
+
+**The "4.2x gap" that stood here was overstated and is withdrawn
+(2026-08-21, second review).** These are not equivalent populations: GA4's
+`Organic Search` channel includes Bing, DuckDuckGo and every other engine,
+while the GSC figure is **Google only**. Some of the 438-session difference is
+simply non-Google organic traffic. `.okf/workflows/analytics-access.md:122-125`
+prescribes the correct comparison and it was not performed: either query GA4
+for the `google / organic` source-medium specifically, or add Bing and DDG to
+the GSC side. **Open task; no multiplier should be quoted until one of those
+is done.**
+
+What does NOT depend on that comparison, and still stands: the Direct row is
+**8,598 sessions - 91% of the site total** - which is not a plausible human
+direct-navigation figure for a site drawing 136 Google clicks in the same
+window. **None of the 9,458 GA4 sessions may be quoted as human traffic.**
 
 Blog landing pages, GA4, same window — **1,260 distinct `/blog/` landing pages**
 recorded sessions. Top by sessions, with the per-session engagement that shows
@@ -231,23 +244,37 @@ Two caveats a reader must carry, both raised in review:
 34.97s over 743 sessions, 2026-08-06 → 2026-08-20.~~ (contaminated - straddles
 the deploy)
 
-Chosen over scroll depth (which swung 2.9x across the same five windows vs
-engagement's 2.3x) and over GSC clicks (which measures search demand, not what a
-template rebuild changes). Its denominator, 743 sessions, is the largest
-bot-filtered human-behaviour denominator available on this site.
+Engagement time is chosen over scroll depth (which swung 2.9x across the five
+windows vs engagement's 2.3x) and over GSC clicks (which measure search
+demand, not what a template rebuild changes).
 
-Scroll depth is the **secondary** comparator at **44.31% / 743 sessions**, same
-window, and must be read alongside its five constituent windows, never alone.
+**Both active comparators are the CLEAN-window figures. The 743-session
+numbers below are audit history and must not be compared against** - that
+denominator includes post-deploy sessions.
+
+| Role | Value | Window | Sessions |
+|---|---|---|---|
+| **Primary** | **40.1s engagement** | 2026-08-06 → 08-17 | 451 |
+| **Secondary** | **56.4% scroll** | 2026-08-06 → 08-17 | 451 |
+| ~~audit only~~ | ~~34.97s / 44.31%~~ | ~~08-06 → 08-20~~ | ~~743 (contaminated)~~ |
+
+Scroll must be read alongside its constituent windows, never alone. The 451
+denominator is the largest CLEAN bot-filtered denominator available; extending
+the before-window to a full 28 days ending 08-17 would enlarge it and is the
+outstanding follow-on.
 
 # Gaps and caveats
 
-1. **Per-post Clarity scroll depth is unavailable at usable fidelity.** The
-   per-page and aggregate figures for the same window and page-set disagree by
-   ~3x (see the table above). Protocol step 3 ("segment by post, top-5 of each
-   period") **cannot be executed** against Clarity as it stands. No estimate is
-   substituted. Resolving this needs either a Clarity support answer on how the
-   two aggregations differ, or the GA4 `scroll_depth` milestones as the per-post
-   source instead.
+1. **Per-post Clarity scroll depth is NOT YET RETRIEVED — not proven
+   unavailable (corrected 2026-08-21).** An earlier version of this caveat
+   said the per-page and aggregate figures "for the same window and page-set"
+   disagree ~3x and concluded protocol step 3 cannot run. They are NOT the
+   same page-set: the per-page table is the TOP TEN pages, the aggregate
+   covers every `/blog/` page, and the omitted long tail can account for the
+   whole gap (see the corrected note above the table). **Protocol step 3
+   remains executable.** The open task is retrieving all page rows, or
+   reconciling the omitted population — not abandoning per-post segmentation.
+   No estimate is substituted in the meantime.
 2. **No pre-ship `scroll_depth` GA4 milestone data exists.** The events shipped
    in PR #489 alongside the rebuild, so their first 28 days are their own
    baseline with no "before" to diff. Unchanged from the protocol above.

--- a/docs/projects/2608-site-design-system/README.md
+++ b/docs/projects/2608-site-design-system/README.md
@@ -44,9 +44,18 @@ mobile; and a lead conversion event exists so the next change can be measured.
 
 **Re-sequenced 2026-08-20 (Paul): BLOG FIRST** — confirm engagement on the
 surface where the humans already land before touching chrome or money pages.
-Tokens scope into the blog bundles first, promote site-wide later. Blog
-engagement baseline (Clarity, bot-filtered): **25.2% avg scroll depth / 26.3s
-engagement** vs site avg 33–40% / 28–34s.
+Tokens scope into the blog bundles first, promote site-wide later.
+
+**Blog engagement baseline, corrected 2026-08-21** (Clarity, bot-filtered):
+**56.4% avg scroll depth / 40.1s engagement over 451 sessions**, clean pre-ship
+window 08-06 → 08-17. The **25.2% / 26.3s** figure previously quoted here was
+ONE 3-day window of five, the lowest, and straddles the 08-20 ship - it is NOT
+the baseline and does not support "visitors leave in the first quarter". Full
+record: [40.01](40-49-measurement/40.01-blog-engagement-baseline.md).
+
+The durable reason for blog-first is traffic share, not an engagement deficit:
+the blog draws **105 GSC clicks / 28d - 77% of the site's entire Google
+traffic**.
 
 | Phase | What | Gate | Status |
 |---|---|---|---|


### PR DESCRIPTION
Docs only — no code, templates, or CSS. Three artifacts from a parallel
spec/measurement pass, and the headline is a premise inversion.

## Phases 2.1 and 2.2 already shipped

Both landed on master on 2026-08-20 — **#487** (17:35, blog index/tags/posts
restyle) and **#494** (20:16, whole-blog rebuild). Verified with
`git merge-base --is-ancestor e1fa5409 origin/master`.

The plan's Phase 2 table still lists them as pending rows. `20.03` and `20.04`
are therefore **specs-of-record plus residual punch-lists**, not to-do lists.

## The number that justified blog-first does not survive recomputation

The plan cites blog engagement at **25.2% scroll / 26.3s** against a 32.9-40.3%
site average. That is ONE 3-day Clarity window of five, and the lowest:

| Window | Scroll | Engagement |
|---|---|---|
| 08-06→08 | 29.89% | 62.38s |
| 08-09→11 | 51.13% | 33.79s |
| 08-12→14 | **75.11%** | 32.31s |
| 08-15→17 | 50.91% | 56.41s |
| 08-18→20 | **25.56%** | 27.06s |

Session-weighted over all 743 bot-filtered sessions: **44.31% scroll / 34.97s** —
at or above the average it was said to trail. That last window also **straddles
the 08-20 deploy**, so the clean pre-ship baseline is 08-06→08-17: 451 sessions,
**56.4% / 40.1s**.

The strategy is not wrong. Its stated evidence was a single unlucky window,
quoted rather than recomputed. What DOES hold up: GSC shows the blog at
**105 clicks / 28d — 77% of the site's entire Google traffic.**

## The course coupling was pointed at the wrong file

`20.01`'s "2.2 note" is true of the FILE and false of the SELECTORS.
`course/single.html:55` renders `class="single-content"` with **no
`.post-article`**, and all 15 styled rules in `pages/blog-single.css` are
`.post-article`-prefixed. Exactly two selectors reach course.

**Verdict: DECOUPLED — 2.3 need not follow 2.2.** The genuinely shared file is
`single-post.css`.

## Two blindnesses, both verified

These explain why nobody noticed the phases had already shipped:

- **`/blog/` fires no `scroll_depth` at all.** `page/analytics.html:72` gates on
  `.IsPage`, false for list pages. GA4 cannot see the blog index.
- **All four blog/index screenshots mask `.blog-post` AND `.post-feature`**
  (`desktop_site_test.rb:34,42`, `mobile_site_test.rb:25,33`). `.post-feature`
  IS the feature slot. The visual gate has never covered the index's content
  area — not a tolerance problem, an explicit mask.

## Gaps recorded as gaps, not estimated

- Per-post scroll depth unobtainable: Clarity per-page (0-2%) contradicts its own
  aggregate (25.56%) for the identical window and page-set, ~3x.
- No pre-ship GA4 `scroll_depth` exists — it shipped WITH the rebuild.
- No conversion metric for the window (no form-submit event; `page_view` was a
  key event throughout).
- 9,458 GA4 sessions vs 136 GSC clicks (4.2x, 91% Direct) — recorded as bot
  volume; no GA4 figure is quoted as human traffic.

## Open decision

The cover shipped **article-bleed at 900px**, not the plan's full-bleed.
Recommendation: keep 900px. A `100vw` break-out risks horizontal body scroll
across 624 post dirs and invalidates the `sizes="…864px"` on the LCP image
(`single.html:99`, `:114`).

## Gate

Docs only, so `bin/hugo-build` is the applicable gate (green). No visual suite —
`bin/qtest --changed` correctly reports no visual-affecting changes for a
markdown-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
