### PR TITLE
OKF sync: what three review rounds taught, plus timestamp and deploy-state integrity fixes

### DIFF
--- a/.okf/architecture/blog-list-page.md
+++ b/.okf/architecture/blog-list-page.md
@@ -10,7 +10,7 @@ generated:
 verified:
   - by: claude/opus-5
     at: 2026-08-20T00:00:00Z
-timestamp: 2026-08-20T23:20:00Z
+timestamp: 2026-08-20T23:11:35Z
 ---
 
 # Overview

--- a/.okf/architecture/blog-list-page.md
+++ b/.okf/architecture/blog-list-page.md
@@ -10,7 +10,7 @@ generated:
 verified:
   - by: claude/opus-5
     at: 2026-08-20T00:00:00Z
-timestamp: 2026-08-21T01:20:00Z
+timestamp: 2026-08-20T23:20:00Z
 ---
 
 # Overview

--- a/.okf/architecture/blog-list-page.md
+++ b/.okf/architecture/blog-list-page.md
@@ -10,7 +10,7 @@ generated:
 verified:
   - by: claude/opus-5
     at: 2026-08-20T00:00:00Z
-timestamp: 2026-08-20T23:28:00Z
+timestamp: 2026-08-20T23:20:00Z
 ---
 
 # Overview

--- a/.okf/architecture/blog-list-page.md
+++ b/.okf/architecture/blog-list-page.md
@@ -10,7 +10,7 @@ generated:
 verified:
   - by: claude/opus-5
     at: 2026-08-20T00:00:00Z
-timestamp: 2026-08-20T23:20:00Z
+timestamp: 2026-08-20T23:28:00Z
 ---
 
 # Overview

--- a/.okf/architecture/hugo-site.md
+++ b/.okf/architecture/hugo-site.md
@@ -4,9 +4,9 @@ title: JetThoughts Hugo Site
 description: Hugo static site generator setup for the JetThoughts marketing site and blog (JTWay).
 resource: config/_default/hugo.toml
 tags: [hugo, build, config]
-timestamp: 2026-08-20T23:28:00Z
+timestamp: 2026-08-20T23:20:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T23:20:00Z }
 generated:
   by: process:okf-migrate
   at: 2026-07-12T00:00:00Z

--- a/.okf/architecture/hugo-site.md
+++ b/.okf/architecture/hugo-site.md
@@ -4,9 +4,9 @@ title: JetThoughts Hugo Site
 description: Hugo static site generator setup for the JetThoughts marketing site and blog (JTWay).
 resource: config/_default/hugo.toml
 tags: [hugo, build, config]
-timestamp: 2026-08-20T23:20:00Z
+timestamp: 2026-08-20T23:11:35Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T23:20:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
 generated:
   by: process:okf-migrate
   at: 2026-07-12T00:00:00Z

--- a/.okf/architecture/hugo-site.md
+++ b/.okf/architecture/hugo-site.md
@@ -4,9 +4,9 @@ title: JetThoughts Hugo Site
 description: Hugo static site generator setup for the JetThoughts marketing site and blog (JTWay).
 resource: config/_default/hugo.toml
 tags: [hugo, build, config]
-timestamp: 2026-08-21T01:20:00Z
+timestamp: 2026-08-20T23:20:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-21T01:20:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T23:20:00Z }
 generated:
   by: process:okf-migrate
   at: 2026-07-12T00:00:00Z

--- a/.okf/architecture/hugo-site.md
+++ b/.okf/architecture/hugo-site.md
@@ -4,9 +4,9 @@ title: JetThoughts Hugo Site
 description: Hugo static site generator setup for the JetThoughts marketing site and blog (JTWay).
 resource: config/_default/hugo.toml
 tags: [hugo, build, config]
-timestamp: 2026-08-20T23:20:00Z
+timestamp: 2026-08-20T23:28:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T23:20:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
 generated:
   by: process:okf-migrate
   at: 2026-07-12T00:00:00Z

--- a/.okf/architecture/seo-meta-tags.md
+++ b/.okf/architecture/seo-meta-tags.md
@@ -8,8 +8,8 @@ generated:
   by: process:okf-migrate
   at: 2026-07-12T00:00:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T23:50:00Z }
-timestamp: 2026-08-20T23:50:00Z
+  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
+timestamp: 2026-08-20T23:28:00Z
 ---
 
 # Overview

--- a/.okf/architecture/seo-meta-tags.md
+++ b/.okf/architecture/seo-meta-tags.md
@@ -8,8 +8,8 @@ generated:
   by: process:okf-migrate
   at: 2026-07-12T00:00:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
-timestamp: 2026-08-20T23:28:00Z
+  - { by: claude/opus-5, at: 2026-08-20T21:50:00Z }
+timestamp: 2026-08-20T21:50:00Z
 ---
 
 # Overview

--- a/.okf/architecture/seo-meta-tags.md
+++ b/.okf/architecture/seo-meta-tags.md
@@ -8,8 +8,8 @@ generated:
   by: process:okf-migrate
   at: 2026-07-12T00:00:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T21:50:00Z }
-timestamp: 2026-08-20T21:50:00Z
+  - { by: claude/opus-5, at: 2026-08-20T22:27:35Z }
+timestamp: 2026-08-20T22:27:35Z
 ---
 
 # Overview

--- a/.okf/build/ci-gates.md
+++ b/.okf/build/ci-gates.md
@@ -13,7 +13,7 @@ verified:
   - by: claude/sonnet-5
     at: 2026-08-20T00:00:00Z
   - by: claude/opus-5
-    at: 2026-08-21T00:00:00Z
+    at: 2026-08-20T22:00:00Z
 ---
 
 # What CI enforces on a PR

--- a/.okf/build/ci-gates.md
+++ b/.okf/build/ci-gates.md
@@ -13,7 +13,7 @@ verified:
   - by: claude/sonnet-5
     at: 2026-08-20T00:00:00Z
   - by: claude/opus-5
-    at: 2026-08-20T22:00:00Z
+    at: 2026-08-20T22:27:35Z
 ---
 
 # What CI enforces on a PR

--- a/.okf/build/ci-gates.md
+++ b/.okf/build/ci-gates.md
@@ -13,7 +13,7 @@ verified:
   - by: claude/sonnet-5
     at: 2026-08-20T00:00:00Z
   - by: claude/opus-5
-    at: 2026-08-20T23:28:00Z
+    at: 2026-08-20T22:00:00Z
 ---
 
 # What CI enforces on a PR

--- a/.okf/build/ci-gates.md
+++ b/.okf/build/ci-gates.md
@@ -13,7 +13,7 @@ verified:
   - by: claude/sonnet-5
     at: 2026-08-20T00:00:00Z
   - by: claude/opus-5
-    at: 2026-08-20T22:00:00Z
+    at: 2026-08-20T23:28:00Z
 ---
 
 # What CI enforces on a PR

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -6,12 +6,12 @@ tags: [testing, visual-regression, gates]
 status: stable
 generated: { by: claude/opus-4-8, at: 2026-08-12T20:20:00Z }
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T22:50:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
   - { by: claude/fable-5, at: 2026-08-01T11:30:00Z }
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
-  - { by: claude/opus-5, at: 2026-08-20T21:45:00Z }
-  - { by: claude/opus-5, at: 2026-08-20T22:00:00Z }
-timestamp: 2026-08-20T22:50:00Z
+  - { by: claude/opus-5, at: 2026-08-20T22:27:35Z }
+  - { by: claude/opus-5, at: 2026-08-20T22:27:35Z }
+timestamp: 2026-08-20T23:11:35Z
 ---
 
 # The suites

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -6,12 +6,12 @@ tags: [testing, visual-regression, gates]
 status: stable
 generated: { by: claude/opus-4-8, at: 2026-08-12T20:20:00Z }
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T22:50:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
   - { by: claude/fable-5, at: 2026-08-01T11:30:00Z }
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
-  - { by: claude/opus-5, at: 2026-08-20T23:45:00Z }
-  - { by: claude/opus-5, at: 2026-08-20T22:00:00Z }
-timestamp: 2026-08-20T22:50:00Z
+  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
+timestamp: 2026-08-20T23:28:00Z
 ---
 
 # The suites

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -6,12 +6,12 @@ tags: [testing, visual-regression, gates]
 status: stable
 generated: { by: claude/opus-4-8, at: 2026-08-12T20:20:00Z }
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T22:50:00Z }
   - { by: claude/fable-5, at: 2026-08-01T11:30:00Z }
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
-  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
-  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
-timestamp: 2026-08-20T23:28:00Z
+  - { by: claude/opus-5, at: 2026-08-20T21:45:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T22:00:00Z }
+timestamp: 2026-08-20T22:50:00Z
 ---
 
 # The suites

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -6,12 +6,12 @@ tags: [testing, visual-regression, gates]
 status: stable
 generated: { by: claude/opus-4-8, at: 2026-08-12T20:20:00Z }
 verified:
-  - { by: claude/opus-5, at: 2026-08-21T00:50:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T22:50:00Z }
   - { by: claude/fable-5, at: 2026-08-01T11:30:00Z }
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T23:45:00Z }
-  - { by: claude/opus-5, at: 2026-08-21T00:00:00Z }
-timestamp: 2026-08-21T00:50:00Z
+  - { by: claude/opus-5, at: 2026-08-20T22:00:00Z }
+timestamp: 2026-08-20T22:50:00Z
 ---
 
 # The suites

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -9,8 +9,8 @@ verified:
   - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
   - { by: claude/fable-5, at: 2026-08-01T11:30:00Z }
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
-  - { by: claude/opus-5, at: 2026-08-20T22:27:35Z }
-  - { by: claude/opus-5, at: 2026-08-20T22:27:35Z }
+  - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
+  - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
 timestamp: 2026-08-20T23:11:35Z
 ---
 

--- a/.okf/design/site-palette.md
+++ b/.okf/design/site-palette.md
@@ -7,7 +7,7 @@ tags: [design, palette, css, tokens, adr]
 generated:
   by: claude/opus-5
   at: 2026-08-20T00:00:00Z
-timestamp: 2026-08-21T01:20:00Z
+timestamp: 2026-08-20T23:20:00Z
 ---
 
 # Resolved: LIGHT (ADR-0003, 2026-08-20)

--- a/.okf/design/site-palette.md
+++ b/.okf/design/site-palette.md
@@ -7,7 +7,7 @@ tags: [design, palette, css, tokens, adr]
 generated:
   by: claude/opus-5
   at: 2026-08-20T00:00:00Z
-timestamp: 2026-08-20T23:20:00Z
+timestamp: 2026-08-20T23:11:35Z
 ---
 
 # Resolved: LIGHT (ADR-0003, 2026-08-20)

--- a/.okf/design/site-palette.md
+++ b/.okf/design/site-palette.md
@@ -7,7 +7,7 @@ tags: [design, palette, css, tokens, adr]
 generated:
   by: claude/opus-5
   at: 2026-08-20T00:00:00Z
-timestamp: 2026-08-20T23:28:00Z
+timestamp: 2026-08-20T23:20:00Z
 ---
 
 # Resolved: LIGHT (ADR-0003, 2026-08-20)

--- a/.okf/design/site-palette.md
+++ b/.okf/design/site-palette.md
@@ -7,7 +7,7 @@ tags: [design, palette, css, tokens, adr]
 generated:
   by: claude/opus-5
   at: 2026-08-20T00:00:00Z
-timestamp: 2026-08-20T23:20:00Z
+timestamp: 2026-08-20T23:28:00Z
 ---
 
 # Resolved: LIGHT (ADR-0003, 2026-08-20)

--- a/.okf/index.md
+++ b/.okf/index.md
@@ -23,12 +23,19 @@ verification really happened, and dropping one falsifies the provenance the
 field exists to carry (2026-08-20, `build/test-gates.md`).
 
 **Stamp actual UTC - take it from `date -u`, never compose it** (2026-08-20).
-Fourteen stamps across eight concepts were written as local time carrying a `Z`
+Eighteen stamps across nine concepts were written as local time carrying a `Z`
 suffix, putting them ~2h in the future. That is not cosmetic HERE of all
 places: the conflict rule above resolves by taking the LATER timestamp, so a
 future-dated stamp silently outranks a genuinely newer edit from a concurrent
 session. The session clock displays local time; `Z` means UTC. Run `date -u`
 and paste the result.
+
+**Repair by CONVERTING each stamp, not by flattening them to one value.** The
+first repair attempt normalised every affected stamp to the sweep time, which
+fixed the future-dating and destroyed the thing `verified:` exists for: three
+distinct checks became three identical entries, losing their order. Convert with
+the offset the stamp was WRITTEN at (recoverable from the session or the
+commit), or mark it unknown - never overwrite history with now.
 
 # Sections
 

--- a/.okf/index.md
+++ b/.okf/index.md
@@ -22,6 +22,14 @@ sessions verify the same concept concurrently and a rebase conflicts on the
 verification really happened, and dropping one falsifies the provenance the
 field exists to carry (2026-08-20, `build/test-gates.md`).
 
+**Stamp actual UTC - take it from `date -u`, never compose it** (2026-08-20).
+Fourteen stamps across eight concepts were written as local time carrying a `Z`
+suffix, putting them ~2h in the future. That is not cosmetic HERE of all
+places: the conflict rule above resolves by taking the LATER timestamp, so a
+future-dated stamp silently outranks a genuinely newer edit from a concurrent
+session. The session clock displays local time; `Z` means UTC. Run `date -u`
+and paste the result.
+
 # Sections
 
 * [Build & Test](build/) - build pipeline, validators, and the blocking test gates

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -3,6 +3,32 @@
 Newest first. Entries before 2026-08-19 are squashed to one line each
 (compacted 2026-08-20); their full text is in this file's git history.
 
+## 2026-08-21 - what three review rounds taught, lifted from the PR into concepts
+
+#519 took three Codex rounds (8, 7, 9 findings). None cosmetic. The durable
+part is not the individual fixes - those shipped with the PR - but why a
+docs-only change needed three passes.
+
+* `workflows/review-swarm.md` - **a correction is an edit, and it can break
+  what the file already held.** Round three's findings were largely defects
+  that rounds one and two INTRODUCED: adding "phase status comes from git" left
+  a sentence four lines away still routing to the plan doc; adding a corrected
+  click figure left the superseded one earlier in the same file. The correcting
+  mindset asks "am I right here now" and does not look sideways. Re-read the
+  whole file, not the paragraph. Plus: **sweep a corrected metric through the
+  canonical summaries** (the README and the plan's own justification still
+  carried the superseded figure, and those are read FIRST), and **budget more
+  than one review round for docs** - prose has no compiler, so a reader
+  checking claims against the tree is the only gate there is.
+
+* `workflows/analytics-access.md` - **cut a measurement window on the DEPLOY,
+  not the MERGE.** The first correction used #487/#494 merge timestamps as
+  proof a Clarity window was contaminated. A merge is not a release: Pages
+  publishes from a separate run that can lag, fail or be re-run. This cuts both
+  ways - it can condemn a usable window as easily as bless a contaminated one.
+  Read the deployment record; if you cannot, mark the window
+  contaminated-pending-confirmation with the restore condition written down.
+
 ## 2026-08-21 - the Hugo trap behind the analytics finding, lifted from spec to bundle
 
 The Codex round fixed the 2608 specs. One of its findings was a durable CODE

--- a/.okf/workflows/analytics-access.md
+++ b/.okf/workflows/analytics-access.md
@@ -6,7 +6,7 @@ tags: [analytics, ga4, search-console, mcp, seo, tooling]
 generated:
   by: claude/opus-5
   at: 2026-08-13T00:00:00Z
-timestamp: 2026-08-21T00:50:00Z
+timestamp: 2026-08-21T01:50:00Z
 verified:
   - { by: claude/opus-5, at: 2026-08-21T00:50:00Z }
   - by: claude/opus-5
@@ -171,11 +171,21 @@ swing**. Session-weighted across all 743 sessions: **44.31% scroll /
 
 Two rules fall out. **Session-weight across every window** rather than
 averaging the windows or picking one. And **check whether a window straddles
-a deploy** - the low window contained the 08-20 rebuild ship (17:35 and
-20:16), so the honest pre-ship baseline is the clean 08-06 -> 08-17 stretch
-(451 sessions, 56.4% / 40.1s). Same family as the GA4-vs-GSC reconciliation
-above: a flattering or alarming number survives by being quoted rather than
-recomputed.
+a deploy** - the low window contained the 08-20 rebuild ship, so the honest
+pre-ship baseline is the clean 08-06 -> 08-17 stretch (451 sessions,
+56.4% / 40.1s). Same family as the GA4-vs-GSC reconciliation above: a
+flattering or alarming number survives by being quoted rather than recomputed.
+
+**Cut the window on the DEPLOY, not the MERGE** (2026-08-21, caught in review).
+The first version of that correction used the merge timestamps of #487 and #494
+as proof the window was contaminated. A merge is not a release: GitHub Pages
+publishes from a separate workflow run that can lag, fail, or be re-run, so the
+content a visitor saw at a given hour is a question about the DEPLOYMENT record,
+not about `git log`. This cuts both ways - it can wrongly condemn a usable
+window as easily as it can wrongly bless a contaminated one. Read the Pages
+deployment for the ship time, and if you cannot, mark the window
+**contaminated-pending-confirmation** with the restore condition written down
+rather than deciding on the merge time.
 
 **A near-miss worth keeping, because it is this same rule failing one step
 deeper.** The first write-up of this claimed Clarity's per-page numbers

--- a/.okf/workflows/analytics-access.md
+++ b/.okf/workflows/analytics-access.md
@@ -6,9 +6,9 @@ tags: [analytics, ga4, search-console, mcp, seo, tooling]
 generated:
   by: claude/opus-5
   at: 2026-08-13T00:00:00Z
-timestamp: 2026-08-20T23:28:00Z
+timestamp: 2026-08-20T23:44:03Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T22:50:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
   - by: claude/opus-5
     at: 2026-08-13T00:00:00Z
   - by: claude/opus-5

--- a/.okf/workflows/analytics-access.md
+++ b/.okf/workflows/analytics-access.md
@@ -8,7 +8,7 @@ generated:
   at: 2026-08-13T00:00:00Z
 timestamp: 2026-08-20T23:28:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T22:50:00Z }
   - by: claude/opus-5
     at: 2026-08-13T00:00:00Z
   - by: claude/opus-5

--- a/.okf/workflows/analytics-access.md
+++ b/.okf/workflows/analytics-access.md
@@ -6,9 +6,9 @@ tags: [analytics, ga4, search-console, mcp, seo, tooling]
 generated:
   by: claude/opus-5
   at: 2026-08-13T00:00:00Z
-timestamp: 2026-08-20T23:18:00Z
+timestamp: 2026-08-20T23:28:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T22:50:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
   - by: claude/opus-5
     at: 2026-08-13T00:00:00Z
   - by: claude/opus-5

--- a/.okf/workflows/analytics-access.md
+++ b/.okf/workflows/analytics-access.md
@@ -6,9 +6,9 @@ tags: [analytics, ga4, search-console, mcp, seo, tooling]
 generated:
   by: claude/opus-5
   at: 2026-08-13T00:00:00Z
-timestamp: 2026-08-21T01:50:00Z
+timestamp: 2026-08-20T23:18:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-21T00:50:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T22:50:00Z }
   - by: claude/opus-5
     at: 2026-08-13T00:00:00Z
   - by: claude/opus-5
@@ -171,9 +171,12 @@ swing**. Session-weighted across all 743 sessions: **44.31% scroll /
 
 Two rules fall out. **Session-weight across every window** rather than
 averaging the windows or picking one. And **check whether a window straddles
-a deploy** - the low window contained the 08-20 rebuild ship, so the honest
-pre-ship baseline is the clean 08-06 -> 08-17 stretch (451 sessions,
-56.4% / 40.1s). Same family as the GA4-vs-GSC reconciliation above: a
+a deploy**. The low window is BELIEVED to contain the 08-20 rebuild ship - both
+PRs merged inside it - so the pre-ship baseline is provisionally the clean
+08-06 -> 08-17 stretch (451 sessions, 56.4% / 40.1s). **That conclusion is
+conditional on a deployment record nobody has read yet** (see the paragraph
+below); if the deploy landed after 08-20 the low window is clean and its 292
+sessions come back. Same family as the GA4-vs-GSC reconciliation above: a
 flattering or alarming number survives by being quoted rather than recomputed.
 
 **Cut the window on the DEPLOY, not the MERGE** (2026-08-21, caught in review).

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -7,9 +7,9 @@ generated:
   by: process:okf-migrate
   at: 2026-07-24T00:00:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T22:50:00Z }
-  - { by: claude/opus-5, at: 2026-08-20T22:10:00Z }
-timestamp: 2026-08-20T23:28:00Z
+  - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
+  - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
+timestamp: 2026-08-20T23:44:03Z
 ---
 
 # The loop

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -7,8 +7,8 @@ generated:
   by: process:okf-migrate
   at: 2026-07-24T00:00:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
-  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T22:50:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T22:10:00Z }
 timestamp: 2026-08-20T23:28:00Z
 ---
 

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -9,7 +9,7 @@ generated:
 verified:
   - { by: claude/opus-5, at: 2026-08-21T00:50:00Z }
   - { by: claude/opus-5, at: 2026-08-21T00:10:00Z }
-timestamp: 2026-08-21T00:50:00Z
+timestamp: 2026-08-21T01:50:00Z
 ---
 
 # The loop
@@ -135,3 +135,28 @@ verdict format, and the two or three specific things to attack.
   Both overstatements this session were in comments, not code, and one had
   already propagated into two `.okf/` files before review caught it. Grep
   your own explanation for numbers you did not measure.
+- **A correction is an edit, and it can break what the file already held**
+  (2026-08-21). Three review rounds on one docs PR found real defects every
+  time, and the third round's findings were largely defects the FIRST TWO
+  ROUNDS' FIXES INTRODUCED. Adding "phase status comes from git" left an older
+  sentence four lines away still saying status lives in the plan doc; adding a
+  corrected click figure left the superseded one earlier in the same file. The
+  correcting mindset is "am I now right here", which does not look sideways at
+  the invariants the document already carried. After correcting a claim, re-read
+  the WHOLE file, not the paragraph.
+
+- **Sweep a corrected metric through the canonical summaries, not just its home**
+  (2026-08-21). A figure was fixed in two specs and a measurement record while
+  the project README and the plan's own justification still presented the
+  superseded value as current - and those are what a cold session reads FIRST.
+  A number lives in more places than the document that owns it. `grep -rn` the
+  old value across docs and the bundle, and treat every surviving hit as stale
+  unless it is explicitly framed as retracted history.
+
+- **Docs review converges slowly - budget more than one round** (2026-08-21).
+  Three rounds returned 8, 7 and 9 findings on a documentation-only PR, and
+  none were cosmetic: a residual that would have reintroduced a known
+  regression, an alias inventory that would have broken live CSS, an arithmetic
+  error in a measurement plan, an overstated bot multiplier. Prose has no
+  compiler and no test, so the ONLY gate is a reader who checks claims against
+  the tree. One clean round is the signal to stop; one round is not.

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -7,9 +7,9 @@ generated:
   by: process:okf-migrate
   at: 2026-07-24T00:00:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-21T00:50:00Z }
-  - { by: claude/opus-5, at: 2026-08-21T00:10:00Z }
-timestamp: 2026-08-21T01:50:00Z
+  - { by: claude/opus-5, at: 2026-08-20T22:50:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T22:10:00Z }
+timestamp: 2026-08-20T23:18:00Z
 ---
 
 # The loop

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -7,9 +7,9 @@ generated:
   by: process:okf-migrate
   at: 2026-07-24T00:00:00Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-20T22:50:00Z }
-  - { by: claude/opus-5, at: 2026-08-20T22:10:00Z }
-timestamp: 2026-08-20T23:18:00Z
+  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T23:28:00Z }
+timestamp: 2026-08-20T23:28:00Z
 ---
 
 # The loop

--- a/.okf/workflows/site-redesign-rollout.md
+++ b/.okf/workflows/site-redesign-rollout.md
@@ -7,7 +7,7 @@ tags: [design, rollout, sequencing, decision, adr]
 status: stable
 generated:
   by: claude/opus-5
-  at: 2026-08-20T23:28:00Z
+  at: 2026-08-20T22:30:00Z
 timestamp: 2026-08-20T23:28:00Z
 ---
 

--- a/.okf/workflows/site-redesign-rollout.md
+++ b/.okf/workflows/site-redesign-rollout.md
@@ -7,8 +7,8 @@ tags: [design, rollout, sequencing, decision, adr]
 status: stable
 generated:
   by: claude/opus-5
-  at: 2026-08-20T22:30:00Z
-timestamp: 2026-08-20T22:50:00Z
+  at: 2026-08-20T23:28:00Z
+timestamp: 2026-08-20T23:28:00Z
 ---
 
 # Why this concept exists
@@ -75,7 +75,9 @@ ONE 3-day Clarity window of five, and the lowest; the windows swing 2.9x
 (29.89 / 51.13 / 75.11 / 50.91 / 25.56%). Session-weighted over all 743
 bot-filtered sessions the blog sits at **44.31% scroll / 34.97s** - at or above
 the average it was said to trail. The low window also straddles the 08-20
-deploy, so the clean pre-ship baseline is 08-06 -> 08-17: 451 sessions,
+deploy - PROVISIONALLY, on merge times only; no Pages deployment record has
+been read - so the pre-ship baseline is provisionally 08-06 -> 08-17: 451
+sessions,
 **56.4% / 40.1s**.
 
 Blog-first remains right, but on a different fact than the one written down:

--- a/.okf/workflows/site-redesign-rollout.md
+++ b/.okf/workflows/site-redesign-rollout.md
@@ -7,8 +7,8 @@ tags: [design, rollout, sequencing, decision, adr]
 status: stable
 generated:
   by: claude/opus-5
-  at: 2026-08-21T00:30:00Z
-timestamp: 2026-08-21T00:50:00Z
+  at: 2026-08-20T22:30:00Z
+timestamp: 2026-08-20T22:50:00Z
 ---
 
 # Why this concept exists

--- a/.okf/workflows/site-redesign-rollout.md
+++ b/.okf/workflows/site-redesign-rollout.md
@@ -7,8 +7,8 @@ tags: [design, rollout, sequencing, decision, adr]
 status: stable
 generated:
   by: claude/opus-5
-  at: 2026-08-20T22:30:00Z
-timestamp: 2026-08-20T23:28:00Z
+  at: 2026-08-20T23:11:35Z
+timestamp: 2026-08-20T23:44:03Z
 ---
 
 # Why this concept exists

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.01-rollout-plan.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.01-rollout-plan.md
@@ -185,7 +185,9 @@ before, which is a coherent state to sit in indefinitely.
 > Clarity shows blog pages at 25.2% scroll / 26.3s against a 32.9–40.3% site
 > average. Visitors leave posts in the first quarter." That 3-day reading is
 > ONE window of five and the lowest; session-weighted the blog is at 44.31%,
-> and the clean pre-ship window is **56.4% / 40.1s over 451 sessions**
+> and the pre-ship window is provisionally **56.4% / 40.1s over 451 sessions**
+> (provisional: the excluded window is dropped on MERGE times, not a confirmed
+> deploy)
 > ([40.01](../40-49-measurement/40.01-blog-engagement-baseline.md)). There is
 > no demonstrated engagement deficit and "visitors leave in the first quarter"
 > must not be repeated.

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.03-phase-2.1-blog-list-spec.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.03-phase-2.1-blog-list-spec.md
@@ -23,8 +23,10 @@ invented here.
 2026-08-21** against
 [40.01](../40-49-measurement/40.01-blog-engagement-baseline.md). The
 25.2% / 26.3s / 219-session reading is ONE 3-day Clarity window of five, the
-lowest, and it straddles the 2026-08-20 deploy. Clean pre-ship (08-06 →
-08-17): **56.4% scroll / 40.1s over 451 sessions**. Do not repeat "visitors
+lowest, and is BELIEVED to straddle the 2026-08-20 deploy (merge times only -
+the Pages deployment record has not been read). Provisional pre-ship (08-06 →
+08-17): **56.4% scroll / 40.1s over 451 sessions**; if the deploy landed after
+08-20 the excluded 292 sessions come back. Do not repeat "visitors
 leave in the first quarter" - it is unsupported.
 
 The durable reason to care about this page: the blog carries **77% of the

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.04-phase-2.2-blog-single-spec.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.04-phase-2.2-blog-single-spec.md
@@ -35,7 +35,8 @@ against the measured baseline in
 [40.01](../40-49-measurement/40.01-blog-engagement-baseline.md).**
 
 The 25.2% / 26.3s / 219-session figure is ONE 3-day Clarity window of five,
-the lowest, and it straddles the 2026-08-20 deploy. The clean pre-ship
+the lowest, and it is believed to straddle the 2026-08-20 deploy (merge times
+only - deploy unconfirmed). The provisional pre-ship
 window (08-06 → 08-17) reads **56.4% scroll / 40.1s over 451 sessions**.
 **"Visitors leave posts in the first quarter" is therefore not supported** and
 must not be repeated as the rationale. GSC over the same period is **105
@@ -285,7 +286,8 @@ with one follow-on.** Five rolling 3-day Clarity windows covering
 [40.01](../40-49-measurement/40.01-blog-engagement-baseline.md), superseding
 the single 3-day sample this task was written against. That sample (25.2% /
 26.3s / 219) turned out to be the LOWEST of the five and to straddle the
-08-20 deploy; the clean pre-ship figure is 08-06 → 08-17, 451 sessions,
+08-20 deploy (unconfirmed - merge times only); the provisional pre-ship figure
+is 08-06 → 08-17, 451 sessions,
 56.4% scroll / 40.1s.
 
 Follow-on, not a repeat of the work: the clean window is 12 days against a

--- a/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
+++ b/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
@@ -243,28 +243,32 @@ Two caveats a reader must carry, both raised in review:
   swings 2.9x window-to-window. Extend the before backwards to a full 28 days
   ending 2026-08-17 before this is treated as final - the Clarity data exists,
   it just needs four more 3-day pulls.
-* The contaminated figure is retained below for audit, not for use.
+* The excluded figure is retained below for audit, not for use - and comes
+    BACK into use if the deployment record shows the ship landed after 08-20.
 
 ~~Clarity session-weighted average engagement time on `/blog/` pages:
-34.97s over 743 sessions, 2026-08-06 → 2026-08-20.~~ (contaminated - straddles
-the deploy)
+34.97s over 743 sessions, 2026-08-06 → 2026-08-20.~~ (excluded pending the
+deployment record - believed to straddle the ship, on merge times only)
 
 Engagement time is chosen over scroll depth (which swung 2.9x across the five
 windows vs engagement's 2.3x) and over GSC clicks (which measure search
 demand, not what a template rebuild changes).
 
-**Both active comparators are the CLEAN-window figures. The 743-session
-numbers below are audit history and must not be compared against** - that
-denominator includes post-deploy sessions.
+**Both active comparators are the PROVISIONALLY-clean-window figures. The
+743-session numbers below are held out pending the deployment record** - that
+denominator is believed to include post-ship sessions, on merge times alone. If
+the deploy is shown to have landed after 08-20, the 743-session figures become
+the better comparator and should be restored.
 
 | Role | Value | Window | Sessions |
 |---|---|---|---|
 | **Primary** | **40.1s engagement** | 2026-08-06 → 08-17 | 451 |
 | **Secondary** | **56.4% scroll** | 2026-08-06 → 08-17 | 451 |
-| ~~audit only~~ | ~~34.97s / 44.31%~~ | ~~08-06 → 08-20~~ | ~~743 (contaminated)~~ |
+| held out (pending deploy record) | 34.97s / 44.31% | 08-06 → 08-20 | 743 |
 
 Scroll must be read alongside its constituent windows, never alone. The 451
-denominator is the largest CLEAN bot-filtered denominator available; extending
+denominator is the largest PROVISIONALLY-clean bot-filtered denominator
+available; extending
 the before-window to a full 28 days ending 08-17 would enlarge it and is the
 outstanding follow-on.
 

--- a/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
+++ b/docs/projects/2608-site-design-system/40-49-measurement/40.01-blog-engagement-baseline.md
@@ -223,8 +223,8 @@ inventory to this baseline. It contributes no human-traffic number.**
 
 ## The headline before/after comparator
 
-**SUPERSEDED 2026-08-21 - the deploy time is now confirmed, and this window is
-contaminated.** #487 MERGED at **17:35** and #494 at **20:16** on 2026-08-20, both inside the
+**SUPERSEDED 2026-08-21 - this window is contaminated PENDING CONFIRMATION.**
+The deploy time is NOT confirmed; only merge times were read. #487 MERGED at **17:35** and #494 at **20:16** on 2026-08-20, both inside the
 08-18→20 window. **These are merge times, not confirmed production deploys** -
 GitHub Pages publishes on a separate workflow run that can lag or fail, and this
 document's own opening requires the deploy to be confirmed. Treat the window as
@@ -233,7 +233,7 @@ after 08-20, the window is clean and can be restored. Confirm via the Pages
 deployment record before treating this as settled either way. A "before" that contains
 post-change sessions is not a before.
 
-**Use the clean pre-ship window: 2026-08-06 → 2026-08-17, 451 sessions,
+**Use the provisional pre-ship window: 2026-08-06 → 2026-08-17, 451 sessions,
 56.4% scroll / 40.1s.**
 
 Two caveats a reader must carry, both raised in review:

--- a/docs/projects/2608-site-design-system/README.md
+++ b/docs/projects/2608-site-design-system/README.md
@@ -51,7 +51,8 @@ Tokens scope into the blog bundles first, promote site-wide later.
 window 08-06 → 08-17. **Provisional**: the 08-18→20 window is excluded on MERGE
 times, not a confirmed Pages deploy - if the deploy landed after 08-20 those 292
 sessions come back. The **25.2% / 26.3s** figure previously quoted here was
-ONE 3-day window of five, the lowest, and straddles the 08-20 ship - it is NOT
+ONE 3-day window of five, the lowest, and is BELIEVED to straddle the 08-20
+ship (merge times only - deploy unconfirmed) - it is NOT
 the baseline and does not support "visitors leave in the first quarter". Full
 record: [40.01](40-49-measurement/40.01-blog-engagement-baseline.md).
 

--- a/docs/projects/2608-site-design-system/README.md
+++ b/docs/projects/2608-site-design-system/README.md
@@ -47,8 +47,10 @@ surface where the humans already land before touching chrome or money pages.
 Tokens scope into the blog bundles first, promote site-wide later.
 
 **Blog engagement baseline, corrected 2026-08-21** (Clarity, bot-filtered):
-**56.4% avg scroll depth / 40.1s engagement over 451 sessions**, clean pre-ship
-window 08-06 → 08-17. The **25.2% / 26.3s** figure previously quoted here was
+**56.4% avg scroll depth / 40.1s engagement over 451 sessions**, pre-ship
+window 08-06 → 08-17. **Provisional**: the 08-18→20 window is excluded on MERGE
+times, not a confirmed Pages deploy - if the deploy landed after 08-20 those 292
+sessions come back. The **25.2% / 26.3s** figure previously quoted here was
 ONE 3-day window of five, the lowest, and straddles the 08-20 ship - it is NOT
 the baseline and does not support "visitors leave in the first quarter". Full
 record: [40.01](40-49-measurement/40.01-blog-engagement-baseline.md).


### PR DESCRIPTION
Bundle-only sync following the #519 review rounds, plus two integrity fixes that
took several passes to get right.

## Lifted into concepts

- **`review-swarm.md`** — a correction is an edit, and it can break what the file
  already held; sweep a corrected metric through the canonical summaries, not
  just its home; budget more than one review round for docs.
- **`analytics-access.md`** — cut a measurement window on the **deploy**, not the
  **merge**. Pages publishes from a separate run that can lag or fail.

## Timestamp integrity

Every OKF stamp written this session was local time carrying a `Z` suffix —
**18 literals across 9 concepts**, ~2h in the future. That matters here
specifically: `.okf/index.md` resolves concurrent-edit conflicts by taking the
**later** timestamp, so a future-dated stamp silently outranks genuinely newer
work from a parallel session.

Getting this right took three attempts, and the failures are instructive:

1. Converted `-2h` — correct for the shell offset, but the repo's commits carry
   `+03:00`, and more importantly the original local times were **invented round
   numbers**, so no offset recovers truth from them.
2. Flattened everything to one measured value — fixed the future-dating and
   destroyed what `verified:` exists for: three distinct checks became three
   identical entries.
3. **Anchored each stamp to a verifiable event** — the commit it landed in.
   `git show 8fa41494:.okf/build/test-gates.md` shows which entries existed at
   #516; the two later ones trace to `67bdd78e` (21:43:35Z) and `6c4b7aba`
   (21:47:30Z). Every stamp is now defensible by a command anyone can re-run.

The rule recorded alongside: convert with the offset the stamp was **written**
at, or mark it unknown — never overwrite history with now.

## Deploy-state integrity

`#487`/`#494` **merge** times were treated as proof the 08-18→20 Clarity window
was contaminated. A merge is not a release. The conclusion is now conditional
everywhere it appears — concept, baseline record, README, plan, and both phase
specs — with the restore condition stated: **if the deploy landed after 08-20,
the excluded 292 sessions come back.**

`.okf/log.md` is deliberately unchanged. Its stated contract is "records what
changed, not what is true"; rewriting dated history to match current belief
would destroy its value as an audit trail.

## Gates

`okf validate --strict` conformant, no warnings on any edited concept.
`bin/hugo-build` clean. No stamp ahead of the verified clock. Bundle + docs only
— no code, templates, or CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
