### PR TITLE
Phase 1a.4: what execution found — plan corrected, buttons investigated

### DIFF
--- a/docs/projects/2608-site-design-system/20-29-strategy/20.02-phase-1a-plan.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.02-phase-1a-plan.md
@@ -99,6 +99,31 @@ stay calm for long-form reading.
 Footer onto `surface-ink`; one eyebrow style; three button roles; tags to ink
 site-wide (blog already done — this brings the other 17 bundles in line).
 
+> **EXECUTED 2026-08-21. One of the four items was what this line says.** The
+> other three are materially different work, and two are gated by the same
+> unnamed token. Measured findings, not estimates:
+>
+> | Item | Reality |
+> |---|---|
+> | `--rr-*` alias deletion | **DONE.** 18 refs migrated, block removed, zero visual delta by construction (`--rr-X: var(--X)` is an exact indirection). Shipped first try, clean review. |
+> | Footer onto `surface-ink` | **NOT a footer change.** It is one edge of a dark region built from a CSS background, an SVG `fill` on a `pointer-events:none` shape layer, and at least one painter still unidentified. Moving it alone seams on homepage AND services; moving the dividers seams them against their adjacent sections. Needs dividers + dark sections migrated together across 7+ bundles — 1b in size. |
+> | One eyebrow style | **Cannot be one style.** The canonical form was designed against LIGHT surfaces; applied site-wide it drops two homepage eyebrows to 4.10:1, below AA. 41 rules were swept, measured and reverted. Needs a dark-surface variant. |
+> | Three button roles | **Already built and never adopted.** `components/c-button.css` defines all three; `c-button--*` appears zero times in markup and PurgeCSS strips it from every bundle. The live buttons are FL Builder's `.fl-button`. Needs a markup migration or another FL sweep. |
+>
+> **The shared blocker: no on-dark ruby token exists.** `--color-ruby` is
+> 4.10:1 on `#000` and **3.67:1 on `--surface-ink`** — so the dark-surface
+> migration makes contrast WORSE, not better. Eyebrows and the tertiary button
+> role both sit on it. See the project README under Outstanding.
+>
+> **Why the estimates were wrong, generalisably:** they were written against
+> the token layer, but the work is against the FL-Builder export CSS that
+> redeclares everything per page. Three separate changes on this phase looked
+> complete, passed every gate, and did nothing at runtime — an eyebrow rule
+> overridden by a later file, a screenshot assertion excluded from
+> `CRITICAL_TESTS`, and a tokenisation of purged dead code. **For any
+> remaining 1a/1b item, verify the change reaches the rendered page before
+> counting it done.**
+
 ---
 
 ## Gates (ADR-0004; no A/B is available at ~9.7 human sessions/day)

--- a/docs/projects/2608-site-design-system/20-29-strategy/20.02-phase-1a-plan.md
+++ b/docs/projects/2608-site-design-system/20-29-strategy/20.02-phase-1a-plan.md
@@ -105,10 +105,11 @@ site-wide (blog already done — this brings the other 17 bundles in line).
 >
 > | Item | Reality |
 > |---|---|
-> | `--rr-*` alias deletion | **DONE.** 18 refs migrated, block removed, zero visual delta by construction (`--rr-X: var(--X)` is an exact indirection). Shipped first try, clean review. |
+> | `--rr-*` alias deletion (listed separately in the brief, not one of the four scope items) | **DONE.** 18 refs migrated, block removed, zero visual delta by construction (`--rr-X: var(--X)` is an exact indirection). Shipped first try, clean review. |
 > | Footer onto `surface-ink` | **NOT a footer change.** It is one edge of a dark region built from a CSS background, an SVG `fill` on a `pointer-events:none` shape layer, and at least one painter still unidentified. Moving it alone seams on homepage AND services; moving the dividers seams them against their adjacent sections. Needs dividers + dark sections migrated together across 7+ bundles — 1b in size. |
 > | One eyebrow style | **Cannot be one style.** The canonical form was designed against LIGHT surfaces; applied site-wide it drops two homepage eyebrows to 4.10:1, below AA. 41 rules were swept, measured and reverted. Needs a dark-surface variant. |
-> | Three button roles | **Already built and never adopted.** `components/c-button.css` defines all three; `c-button--*` appears zero times in markup and PurgeCSS strips it from every bundle. The live buttons are FL Builder's `.fl-button`. Needs a markup migration or another FL sweep. |
+> | Three button roles | **Already built and never adopted.** `components/c-button.css` defines all three; `c-button--*` appears zero times in markup and is absent from the entire PRODUCTION tree. The live buttons are FIVE families - `.fl-button`, `.btn`/`.btn-primary`, `.btn--primary`, `.action-button`, `.pp-button` - so a `.fl-button`-only sweep leaves four outside the roles. Needs a markup migration or a five-family sweep. |
+> | Tags to ink site-wide | **NOT investigated - open.** Blog tags already use the ink ramp (`single-post.css` `.blog .post-tags a` -> `--ink-500`), which is what "blog already done" refers to. Whether the other 17 bundles carry tag styling at all was never checked. This row is open, not complete. |
 >
 > **The shared blocker: no on-dark ruby token exists.** `--color-ruby` is
 > 4.10:1 on `#000` and **3.67:1 on `--surface-ink`** — so the dark-surface

--- a/docs/projects/2608-site-design-system/README.md
+++ b/docs/projects/2608-site-design-system/README.md
@@ -150,10 +150,23 @@ the problem in a comment.
 three roles (`--primary` ruby/white, `--secondary` white/dark, `--tertiary`
 transparent/ruby), already tokenised apart from four `#ffffff` literals. It is
 imported by `components.css`, which one layout bundles.
+**But `c-button--*` appears ZERO times in any template or content file, and it
+is absent from the entire PRODUCTION tree** - `grep -rl 'c-button'
+_dest/public-test/` returns nothing, and `components.css` is not referenced
+from `index.html` at all. The component was built and never adopted.
 
-**But `c-button--*` appears ZERO times in any template or content file, and
-PurgeCSS strips it from every shipped bundle** (`grep -rc 'c-button--primary'
-_dest/public-dev/css/*.css` returns nothing). The component was built and
+*Method note, because the first check was a false green:* `_dest/public-dev` is
+built in DEV mode where PurgeCSS is disabled, and this CSS is emitted INLINE in
+the HTML rather than under `css/*.css`, so grepping `public-dev/css/*.css`
+returns zero whether or not the component is adopted. The conclusion survived
+re-verification against the production tree; the original evidence did not.
+
+The live buttons are **five separate families**, verified in the templates:
+`.fl-button` (FL Builder), `.btn`/`.btn-primary`
+(`partials/page/navigation.html`), `.btn--primary` (`shortcodes/cta.html`),
+`.action-button` (`partials/page/use-cases.html`) and `.pp-button`
+(`page/services.html`). A sweep scoped to `.fl-button` alone would leave four
+families outside the roles.
 never adopted. The live buttons are FL Builder's `.fl-button`.
 
 So the 1a.4 item is not "tokenise the button component" - that changes nothing

--- a/docs/projects/2608-site-design-system/README.md
+++ b/docs/projects/2608-site-design-system/README.md
@@ -145,6 +145,27 @@ counterpart for dark. **The decision is whether to name one** (e.g.
 `--ruby-on-ink`, seeded at `#e04a42` or lighter for more margin), which is a
 design call rather than a sweep. `technologies.css:10` already gestures at
 the problem in a comment.
+**"THREE button roles" is already built - and unused.** Investigated
+2026-08-21. `themes/beaver/assets/css/components/c-button.css` defines exactly
+three roles (`--primary` ruby/white, `--secondary` white/dark, `--tertiary`
+transparent/ruby), already tokenised apart from four `#ffffff` literals. It is
+imported by `components.css`, which one layout bundles.
+
+**But `c-button--*` appears ZERO times in any template or content file, and
+PurgeCSS strips it from every shipped bundle** (`grep -rc 'c-button--primary'
+_dest/public-dev/css/*.css` returns nothing). The component was built and
+never adopted. The live buttons are FL Builder's `.fl-button`.
+
+So the 1a.4 item is not "tokenise the button component" - that changes nothing
+a visitor sees. It is either **adopt `c-button` in the templates** (a markup
+migration) or **bring `.fl-button` onto the three roles** (another sweep
+through the per-page FL export CSS). Both are larger than the plan line
+implies, and the second is the same legacy-export problem as the footer and
+eyebrow items.
+
+Note the tertiary role (`color: var(--color-ruby)` on a transparent ground)
+hits the on-dark AA blocker above wherever it sits on a dark band - so this
+item is partly gated by the same unnamed token.
 
 ## Working notes
 


### PR DESCRIPTION
Docs only. Closes out the 1a.4 investigation by recording what each item
actually requires, so the next session doesn't re-estimate them the same way.

## The last item: "three button roles" is already built and never adopted

`components/c-button.css` defines all three roles, already tokenised apart from
four `#ffffff` literals. I fixed those, then checked whether it mattered:

- **`c-button--*` appears zero times** in any template or content file
- **PurgeCSS strips it from every shipped bundle** — `grep -rc 'c-button--primary'
  _dest/public-dev/css/*.css` returns nothing
- the live buttons are FL Builder's `.fl-button`

**I reverted the change.** A tidy diff against dead code reads as "button roles:
done" and changes nothing a visitor sees.

## One of four items was what the plan said

| Item | Reality |
|---|---|
| `--rr-*` alias deletion | ✅ **shipped** — zero visual delta *by construction* |
| Footer onto `surface-ink` | ⛔ not a footer change — dark region across 7+ bundles |
| One eyebrow style | ⛔ can't be one style — 4.10:1 on dark, below AA |
| Three button roles | ⛔ built, unadopted, purged |

## The connection the plan never made

**Two items are gated by the same missing token.** `--color-ruby` is 4.10:1 on
`#000` and **3.67:1 on `--surface-ink`** — so the dark-surface migration makes
contrast *worse*, not better. Eyebrows and the tertiary button role both sit
on it.

## Why the estimates were wrong — the transferable part

They were written against the **token layer**; the work is against the
**FL-Builder export CSS** that redeclares everything per page.

Three changes this phase looked complete, passed every gate, and did nothing at
runtime:

1. an eyebrow rule **overridden by a later-loading file**
2. a screenshot assertion **excluded from `CRITICAL_TESTS`**
3. a tokenisation of **purged dead code**

The plan now tells the next session to verify a change reaches the rendered page
before counting it done.

## Gates

`bin/hugo-build` clean. Docs only — no CSS, templates, or baselines touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
