### PR TITLE
Phase 1a.4 blocker: on-dark ruby candidates derived — a yes/no for Paul

### DIFF
--- a/.okf/design/site-palette.md
+++ b/.okf/design/site-palette.md
@@ -7,7 +7,7 @@ tags: [design, palette, css, tokens, adr]
 generated:
   by: claude/opus-5
   at: 2026-08-20T00:00:00Z
-timestamp: 2026-08-21T02:51:33Z
+timestamp: 2026-08-21T03:17:09Z
 ---
 
 # Resolved: LIGHT (ADR-0003, 2026-08-20)
@@ -106,10 +106,29 @@ Two consequences, and the second is the one that is easy to miss:
    footer/dark-surface migration cannot ship before the on-dark accent is
    decided, or it degrades contrast on every band it touches.
 
-Only `--color-ruby-hover` clears AA on both grounds, and it is named for a
-hover state - semantically wrong as a static accent. The ramp has `--ruby-700`
-for "text-on-light where AA needs more" and **no counterpart for dark**.
-Naming one is a design decision; tracked in
+**Candidates derived and measured 2026-08-21. Recommended: `#e85a52`, named
+`--ruby-on-ink`.**
+
+| Candidate | on `--surface-ink` | on `#000` | on white |
+|---|---|---|---|
+| `--color-ruby` `#cc342d` | 3.67 FAIL | 4.10 FAIL | 5.13 pass |
+| `--color-ruby-hover` `#e04a42` | 4.68 thin | 5.23 pass | **4.02 FAIL** |
+| **`#e85a52`** | **5.39 pass** | 6.02 pass | 3.49 FAIL |
+| `#ef6a61` | 6.18 pass | 6.90 pass | 3.04 FAIL |
+
+**The name carries the constraint, and that is the point.** Every value that
+works on dark FAILS on white - `#e85a52` is 3.49:1 there - so this token is
+dark-surface-ONLY. A neutral name like `--ruby-400` invites the misuse that
+breaks it; `--ruby-on-ink` says where it may be used.
+
+**Do not reach for `--color-ruby-hover` as the shortcut.** Besides being
+semantically a hover state, it fails on white at 4.02, so using it as a
+general accent trades an AA failure on dark for one on light. The ramp has
+`--ruby-700` for "text-on-light where AA needs more" and no counterpart for
+dark; that gap is the whole issue.
+
+Not yet applied - it changes the rendered colour on every dark band, which is
+Paul's call. Tracked in
 `docs/projects/2608-site-design-system/README.md` under Outstanding.
 
 **Until it is named: do not apply a ruby text token to any surface in the

--- a/docs/projects/2608-site-design-system/README.md
+++ b/docs/projects/2608-site-design-system/README.md
@@ -164,13 +164,11 @@ accent either.
 Applying it is a visible brand change on the dark bands, so it is recorded as
 a decision rather than executed - but the analysis is done and every number
 here is measured.
-Only `--color-ruby-hover` clears AA on both grounds, and it is named for a
-hover state - using it as a static on-dark accent is semantically wrong. The
-ramp has `--ruby-700` for "text-on-light where AA needs more" and no
-counterpart for dark. **The decision is whether to name one** (e.g.
-`--ruby-on-ink`, seeded at `#e04a42` or lighter for more margin), which is a
-design call rather than a sweep. `technologies.css:10` already gestures at
-the problem in a comment.
+
+The ramp has `--ruby-700` for "text-on-light where AA needs more" and no
+counterpart for dark; naming one is the decision. `technologies.css:10`
+already gestures at the problem in a comment.
+
 **"THREE button roles" is already built - and unused.** Investigated
 2026-08-21. `themes/beaver/assets/css/components/c-button.css` defines exactly
 three roles (`--primary` ruby/white, `--secondary` white/dark, `--tertiary`

--- a/docs/projects/2608-site-design-system/README.md
+++ b/docs/projects/2608-site-design-system/README.md
@@ -138,6 +138,32 @@ Two consequences, and the second is the one that is easy to miss:
    the on-dark accent is decided, or it degrades contrast on every band it
    touches.
 
+
+**Candidate values, derived 2026-08-21 - this is a yes/no, not an open
+question.** Walking lighter along the ruby hue:
+
+| Candidate | on `--surface-ink` | on `#000` | on white |
+|---|---|---|---|
+| `--color-ruby` `#cc342d` | 3.67 FAIL | 4.10 FAIL | 5.13 pass |
+| `--color-ruby-hover` `#e04a42` | 4.68 thin | 5.23 pass | **4.02 FAIL** |
+| **`#e85a52` (recommended)** | **5.39 pass** | 6.02 pass | 3.49 FAIL |
+| `#ef6a61` | 6.18 pass | 6.90 pass | 3.04 FAIL |
+
+**Recommendation: `#e85a52`, named `--ruby-on-ink`.** It clears AA on the dark
+surfaces with real margin rather than the 4.68 squeak, and stays recognisably
+ruby rather than drifting pink.
+
+**The naming is the load-bearing part, not the value.** Every candidate that
+works on dark FAILS on white - `#e85a52` is 3.49:1 there. This token is
+dark-surface-ONLY, and a neutral name like `--ruby-400` invites exactly the
+misuse that breaks it; `--ruby-on-ink` says where it may be used. The same
+finding rules out reusing `--color-ruby-hover`: besides being semantically a
+hover state, it fails on white at 4.02, so it is not a safe general-purpose
+accent either.
+
+Applying it is a visible brand change on the dark bands, so it is recorded as
+a decision rather than executed - but the analysis is done and every number
+here is measured.
 Only `--color-ruby-hover` clears AA on both grounds, and it is named for a
 hover state - using it as a static on-dark accent is semantically wrong. The
 ramp has `--ruby-700` for "text-on-light where AA needs more" and no


### PR DESCRIPTION
Docs only. Turns the standing blocker from "name a token" into a decision with
measured options.

## The candidates

Walking lighter along the ruby hue, every value measured:

| Candidate | on `--surface-ink` | on `#000` | on white |
|---|---|---|---|
| `--color-ruby` `#cc342d` | 3.67 ❌ | 4.10 ❌ | 5.13 ✅ |
| `--color-ruby-hover` `#e04a42` | 4.68 ⚠️ | 5.23 ✅ | **4.02 ❌** |
| **`#e85a52` (recommended)** | **5.39 ✅** | 6.02 ✅ | 3.49 ❌ |
| `#ef6a61` | 6.18 ✅ | 6.90 ✅ | 3.04 ❌ |

**Recommendation: `#e85a52`, named `--ruby-on-ink`.** Real margin rather than
the 4.68 squeak, still recognisably ruby rather than drifting pink.

## The naming is the load-bearing part, not the value

Every candidate that works on dark **fails on white** — `#e85a52` is 3.49:1
there. This token is dark-surface-**only**, so a neutral name like `--ruby-400`
invites exactly the misuse that breaks it. `--ruby-on-ink` says where it may be
used.

The same measurement kills the obvious shortcut: **`--color-ruby-hover` is not a
safe general-purpose accent either** — it fails on white at 4.02. Anyone
reaching for "just use the hover ruby" would have introduced a second AA failure
on light surfaces while fixing the dark one.

## Not executed

Applying it changes the rendered colour on every dark band — a visible brand
change, and yours to make. The analysis is done; the decision is a yes/no.

## What it unblocks

- **One eyebrow style** — the remaining 38 rules, currently 4.10:1 on dark
- **Three button roles** — the tertiary role is ruby-on-transparent

`bin/hugo-build` clean. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
