### PR TITLE
Found the /services/ painter: a rect, not a path

### DIFF
--- a/.okf/architecture/css-pipeline.md
+++ b/.okf/architecture/css-pipeline.md
@@ -135,8 +135,9 @@ The services painter was `rect.fl-shape` inside the same
 const s = document.createElement('style');
 s.textContent = '*, *::before, *::after { pointer-events: auto !important; }';
 document.head.appendChild(s);
-document.elementsFromPoint(x, y);   // overlays now appear in the stack
+const stack = document.elementsFromPoint(x, y);  // overlays now appear
 s.remove();
+stack;   // <- must be last: otherwise the completion value is s.remove()'s undefined
 ```
 
 Forcing hit-testability turns a click-through overlay into an ordinary stack

--- a/.okf/architecture/css-pipeline.md
+++ b/.okf/architecture/css-pipeline.md
@@ -4,7 +4,7 @@ title: CSS Build Pipeline (PostCSS + per-bundle PurgeCSS)
 description: PostCSS pipeline that concatenates per-page CSS resource slices and purges unused rules per bundle before shipping.
 resource: postcss.config.js
 tags: [css, build, performance]
-timestamp: 2026-08-21T01:59:50Z
+timestamp: 2026-08-21T03:20:07Z
 verified:
   - { by: claude/opus-5, at: 2026-08-21T01:43:19Z }
 generated:
@@ -115,10 +115,34 @@ value.
 The check that is actually decisive: screenshot the region and sample the pixel
 (`magick img -format '%[pixel:p{x,y}]' info:`). A pixel value is a fact; a rule
 list is a hypothesis. On 2026-08-21 the candidate-rule method found the homepage
-painter and then FAILED on the equivalent /services/ surface - both
-`elementFromPoint` and a geometric scan of every element reported white where
-the rendered pixel was black, and that painter is still unidentified. Treat DOM
-inspection as evidence that can be silently incomplete.
+painter and then FAILED on the equivalent /services/ surface. **Resolved
+2026-08-21, and the cause generalises twice over.**
+
+The services painter was `rect.fl-shape` inside the same
+`.fl-builder-bottom-edge-layer`, filled by
+`.services-showcase .fl-builder-bottom-edge-layer .fl-shape-content .fl-shape`
+(`pages/services.css`). Two things hid it:
+
+* **The homepage shape is a `<path>`; the services shape is a `<rect>`.** A
+  query scoped to `path.fl-shape` returns `[]` on services, which reads as
+  "no shape layer here" rather than "wrong primitive". Match on the CLASS
+  (`.fl-shape`) or the layer, never on the element name.
+* `pointer-events: none` again, so every hit-test skipped it.
+
+**The one-line technique that works, and should be reached for first:**
+
+```js
+const s = document.createElement('style');
+s.textContent = '*, *::before, *::after { pointer-events: auto !important; }';
+document.head.appendChild(s);
+document.elementsFromPoint(x, y);   // overlays now appear in the stack
+s.remove();
+```
+
+Forcing hit-testability turns a click-through overlay into an ordinary stack
+entry. It found in one call what a geometric element scan, a pseudo-element
+sweep and a stylesheet walk had all missed.
+
 
 **The layered lesson:** source grep proves what the CSS says; computed style
 proves what an ELEMENT resolves to; only the rendered pixel proves what the

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -28,6 +28,28 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
+## 2026-08-21 - the unidentified /services/ painter, found
+
+Closed the one technical unknown left from the footer work. The painter was
+`rect.fl-shape` in the same `.fl-builder-bottom-edge-layer` pattern as the
+homepage, filled by `.services-showcase ...` in `pages/services.css` - the exact
+rule the broad sweep had converted and I then reverted as "internal".
+
+Two causes, both now in
+[architecture/css-pipeline.md](architecture/css-pipeline.md):
+
+* **Homepage uses `<path>`, services uses `<rect>`.** My query was
+  `path.fl-shape`, which returned `[]` on services - and an empty result reads
+  as "no shape layer here" rather than "wrong primitive". That single wrong
+  assumption sent the investigation sideways for a long stretch. Match on the
+  CLASS or the layer, never the element name.
+* `pointer-events: none`, again, so every hit-test skipped it.
+
+**The technique worth keeping:** force `pointer-events: auto !important` on
+`*, *::before, *::after`, then call `elementsFromPoint`. Click-through overlays
+become ordinary stack entries. One call found what a geometric element scan, a
+pseudo-element sweep and a stylesheet walk had all missed.
+
 ## 2026-08-21 - ruby fails AA on dark surfaces, and it gates two phases
 
 Measured, not estimated: `--color-ruby` is **4.10:1 on #000 and 3.67:1 on


### PR DESCRIPTION
Closes the last technical unknown from the footer work. Bundle only.

## What it was

`rect.fl-shape` inside the same `.fl-builder-bottom-edge-layer` pattern as the
homepage, filled by
`.services-showcase .fl-builder-bottom-edge-layer .fl-shape-content .fl-shape`
in `pages/services.css` — **the exact rule the broad sweep converted and I then
reverted as "internal."**

## Why it stayed hidden

**Homepage uses `<path>`; services uses `<rect>`.** My query was
`path.fl-shape`, which returned `[]` on services — and an empty result reads as
*"no shape layer on this page"* rather than *"wrong primitive."*

That one wrong assumption is what sent the investigation sideways: I went on to
conclude the painter was invisible to DOM inspection entirely, when it was
sitting in a selector I had already edited once. **Match on the class
(`.fl-shape`) or the layer, never the element name.**

## The technique, now recorded to be reached for first

```js
const s = document.createElement('style');
s.textContent = '*, *::before, *::after { pointer-events: auto !important; }';
document.head.appendChild(s);
document.elementsFromPoint(x, y);   // overlays now appear in the stack
s.remove();
```

Forcing hit-testability turns a click-through overlay into an ordinary stack
entry. **One call found what a geometric element scan, a pseudo-element sweep
and a stylesheet walk had all missed.**

## Why it matters for the blocked work

The dark-surface migration no longer contains an unknown painter. Both known
instances are the same `.fl-builder-bottom-edge-layer` pattern differing only in
SVG primitive, so that sweep is now **enumerable rather than exploratory** —
which changes it from "unbounded investigation" to "bounded change, pending the
`--ruby-on-ink` decision."

## Gates

`okf_validate .okf` exits **0**, conformant; `--strict` exits **1** by design on
this bundle. `bin/hugo-build` clean. Bundle only — no CSS or baselines touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
