### PR TITLE
OKF: the NULL CHANGE — a diff that passes every gate and alters nothing

### DIFF
--- a/.okf/build/index.md
+++ b/.okf/build/index.md
@@ -1,6 +1,6 @@
 # Build & Test
 
 * [Hugo build pipeline](hugo-build.md) - bin/hugo-build with the 8 course validators; also the PurgeCSS cold-start race and the minified-unquoted-attribute audit-tool trap
-* [Test gates](test-gates.md) - the local suites, when each is a commit blocker, bin/record-baselines for accepting only the baselines you meant to move, and why a deleted source file still serves from every local _dest/ tree
+* [Test gates](test-gates.md) - the local suites, when each is a commit blocker, bin/record-baselines for accepting only the baselines you meant to move, and why a deleted source file still serves from every local _dest/ tree, plus the NULL CHANGE - a diff that passes every gate and alters nothing
 * [CI gates](ci-gates.md) - what GitHub Actions enforces: build, unit, path-scoped link check (visual regression is report-only), and what gates a PR never sees
 * [Template PDFs](pdf-templates.md) - regenerating the downloadable course PDFs

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -6,6 +6,7 @@ tags: [testing, visual-regression, gates]
 status: stable
 generated: { by: claude/opus-4-8, at: 2026-08-12T20:20:00Z }
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T03:27:09Z }
   - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
   - { by: claude/fable-5, at: 2026-08-01T11:30:00Z }
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -11,7 +11,7 @@ verified:
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
   - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
-timestamp: 2026-08-20T23:11:35Z
+timestamp: 2026-08-21T03:27:09Z
 ---
 
 # The suites
@@ -238,6 +238,35 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
   `_dest/public-test-local`. Clear the dest dir before trusting a RED, the
   same way a screenshot baseline must be COMMITTED before trusting a
   re-record (both are "the assertion is right, the input is stale").
+
+- **The NULL CHANGE: a diff that passes every gate and alters nothing at
+  runtime** (2026-08-21, four instances in one phase). Every gate here is
+  designed to catch a change that does the WRONG thing. None catches a change
+  that does NOTHING, because nothing is indistinguishable from no-regression.
+  The four, all caught only by asking "what does this alter at runtime?" AFTER
+  the edit looked finished:
+
+  | Change | Why it was null |
+  |---|---|
+  | An eyebrow rule in `critical/careers-critical.css` | `pages/careers.css` redeclares the same selector at equal specificity and loads LATER |
+  | A screenshot assertion for `/friday-report/` | the test name was not in `CRITICAL_TESTS`, so `bin/test` never ran it - suite reported the same 34 runs / 53 screenshots |
+  | Tokenising `components/c-button.css` | `c-button--*` appears zero times in markup; absent from the whole production tree |
+  | A DevTools recipe added to a concept | its last statement was the cleanup call, so pasting it returned `undefined` and discarded the result it promised |
+
+  Each produced a clean diff, a green suite and a plausible commit message.
+  **Before counting a change done, name the observable it moves** - a computed
+  style, a rendered pixel, a test that newly runs, a byte in the built output -
+  and check that one thing. "The suite is still green" is consistent with
+  having changed nothing at all.
+
+- **An empty query result is not evidence of absence** (2026-08-21). Hunting a
+  black band on `/services/`, `document.querySelectorAll('path.fl-shape')`
+  returned `[]`. That read as "no shape layer on this page" and an entire
+  theory of an undetectable painter got built on it. The real answer: services
+  uses `<rect>`, the homepage uses `<path>`, and the layer was in a rule
+  already edited once. Match on the CLASS or the container, never the element
+  name - and when a query comes back empty, suspect the query before
+  concluding the thing does not exist.
 
 - **A `skip_area` mask can blind a gate completely, at any tolerance**
   (2026-08-21). All four blog-index screenshots mask BOTH `.blog-post` and

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -28,6 +28,29 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
+## 2026-08-21 - the NULL CHANGE, and empty results that are not absence
+
+Two patterns recurred through Phase 1a.4 often enough to be rules, and neither
+was in the bundle. Both now in
+[build/test-gates.md](build/test-gates.md).
+
+**The null change: a diff that passes every gate and alters nothing at
+runtime.** Four instances in one phase - an eyebrow rule overridden by a
+later-loading file, a screenshot assertion excluded from `CRITICAL_TESTS` so it
+never ran, a tokenisation of code absent from the production tree, and a
+DevTools recipe whose last statement discarded its own result. Every gate here
+is built to catch a change doing the WRONG thing; none catches one doing
+NOTHING, because nothing is indistinguishable from no-regression. The rule:
+before counting a change done, NAME the observable it moves - a computed style,
+a rendered pixel, a test that newly runs - and check that one thing.
+
+**An empty query result is not evidence of absence.**
+`querySelectorAll('path.fl-shape')` returned `[]` on /services/, which read as
+"no shape layer here". Services uses `<rect>`; the homepage uses `<path>`. An
+entire theory of an undetectable painter got built on one wrong query, and the
+answer was in a rule already edited once. Suspect the query before concluding
+the thing does not exist.
+
 ## 2026-08-21 - the unidentified /services/ painter, found
 
 Closed the one technical unknown left from the footer work. The painter was

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -11,8 +11,10 @@ easy mistake; it was made repeatedly on 2026-08-20/21 before review caught it.
 **Check `$?`, not the checkmark.**
 
 Measured 2026-08-21 (re-derive rather than trusting these numbers; they move
-with every entry): 82 warnings, of which **57 are §7 date headings** and
-**23 are missing recommended fields**.
+with every entry appended to this file, including the one you are about to
+write): **87 warnings** as of 2026-08-21T03:27Z, of which **63 are §7 date
+headings** and
+**22 are missing recommended fields**.
 
 The date headings are a deliberate deviation. The spec's template is a bare
 `## <YYYY-MM-DD>` with bullets beneath, which assumes one entry per day; this


### PR DESCRIPTION
Bundle only. Two patterns recurred through Phase 1a.4 often enough to be rules,
and neither was recorded.

## The null change

**Four instances in one phase**, each a clean diff with a green suite and a
plausible commit message:

| Change | Why it was null |
|---|---|
| Eyebrow rule in `critical/careers-critical.css` | `pages/careers.css` redeclares the same selector at equal specificity and loads **later** |
| Screenshot assertion for `/friday-report/` | test name not in `CRITICAL_TESTS` — `bin/test` never ran it; suite reported the same 34 runs / 53 screenshots |
| Tokenising `components/c-button.css` | `c-button--*` appears **zero times** in markup, absent from the production tree |
| A DevTools recipe added to a concept | last statement was its own cleanup call — pasting it returned `undefined` |

**Every gate in this repo is built to catch a change doing the *wrong* thing.
None catches a change doing *nothing*, because nothing is indistinguishable from
no-regression.**

The rule: before counting a change done, **name the observable it moves** — a
computed style, a rendered pixel, a test that newly runs, a byte in the built
output — and check that one thing. *"The suite is still green"* is entirely
consistent with having changed nothing at all.

## An empty query result is not evidence of absence

`querySelectorAll('path.fl-shape')` returned `[]` on `/services/`, which read as
*"no shape layer on this page."* Services uses `<rect>`; the homepage uses
`<path>`.

An entire theory of an undetectable painter was built on that one wrong query —
and the real answer sat in a rule I had already edited once and reverted. Match
on the class or the container, never the element name; when a query comes back
empty, **suspect the query first**.

## Gates

`okf_validate .okf` exits **0**, conformant; `--strict` exits **1** by design on
this bundle. `bin/hugo-build` clean. Bundle only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
