### PR TITLE
OKF: what a self-iterating loop can and cannot do

### DIFF
--- a/.okf/log.md
+++ b/.okf/log.md
@@ -30,6 +30,37 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
+## 2026-08-21 - what a self-iterating loop can and cannot do
+
+New concept [workflows/autonomous-loops.md](workflows/autonomous-loops.md),
+written from running Phase 1a.4 under `/ralph-loop`.
+
+**The structural limit:** a loop re-feeds one prompt until a completion promise
+is true, and ends only on that promise, the iteration cap, or a human cancel.
+**An agent concluding the work is blocked cannot end it** - that conclusion just
+produces another iteration. So a loop fits work whose completion is mechanically
+checkable AND whose scope is known-correct. It has no move for "the
+specification is wrong".
+
+1a.4 was the demonstration: one of four scope items was as written, two were
+gated by an unnamed design token, and the loop kept iterating past the point
+where delivery was blocked - producing investigation and documentation instead
+of the merge the prompt asked for. Useful output, but not what "execute until
+merged" meant. **Cancel signal recorded: the same blocking question asked in
+three or more consecutive iterations.**
+
+**What held up and is worth keeping:** WIP=1 with a codex review before every
+merge, and reverting rather than shipping when a change proved null or harmful -
+five reverts, including a 41-rule sweep that measured as an AA regression. A
+loop rewards visible progress, so revert-discipline is the first thing it
+erodes.
+
+Also recorded: put gate traps IN the prompt. The 1a.4 prompt carried the
+vacuous-green dtest warning, the compared-count rule and the `--strict` exit
+code, and none was violated across the whole run - the loop re-reads the prompt
+every iteration, which makes it the cheapest place for rules that otherwise
+decay.
+
 ## 2026-08-21 - the NULL CHANGE, and empty results that are not absence
 
 Two patterns recurred through Phase 1a.4 often enough to be rules, and neither

--- a/.okf/workflows/autonomous-loops.md
+++ b/.okf/workflows/autonomous-loops.md
@@ -1,0 +1,75 @@
+---
+type: Playbook
+title: Self-iterating loops (ralph-loop) — what they are and are not for
+description: A loop re-feeds one prompt until a completion promise is true; it can iterate but cannot re-scope, so it fits verifiable work with known-correct scope and fails on a mis-scoped plan item.
+tags: [automation, loop, process, ralph]
+status: stable
+generated:
+  by: claude/opus-5
+  at: 2026-08-21T03:34:22Z
+timestamp: 2026-08-21T03:34:22Z
+---
+
+# What it does
+
+`/ralph-loop "<prompt>" --max-iterations N --completion-promise "<text>"` feeds
+the SAME prompt back every time the session tries to stop. It ends on three
+things only: the agent emitting the exact promise, the iteration cap, or the
+human cancelling (`/cancel-ralph`).
+
+**The agent cannot end it by concluding the work is blocked.** That conclusion
+just produces another iteration of the same prompt.
+
+# When it fits
+
+Work whose completion is **mechanically checkable** and whose **scope is
+known-correct**. The promise should be a command anyone can re-run, not a
+judgement:
+
+> "…`grep -rn 'var(--rr-' themes/beaver/assets/css/` returns nothing, the alias
+> block is deleted, `bin/test` reported screenshots compared with zero failures,
+> and the PR is merged"
+
+That shape is what lets an agent refuse to emit a false promise: each clause is
+falsifiable, so there is no room to rationalise.
+
+# When it does not fit
+
+**A plan item that might be mis-scoped.** A loop's only response to "this cannot
+be done as specified" is to try again. It has no move for "the specification is
+wrong".
+
+Demonstrated on 2026-08-21 running Phase 1a.4
+([site-redesign-rollout](/workflows/site-redesign-rollout.md)). Of four scope
+items, one was as written; the other three were materially different work, and
+two were gated by an unnamed design token. The loop could not re-scope, so it
+kept iterating past the point where delivery was blocked - producing
+investigation and documentation rather than the merge the prompt asked for. That
+output was worth having, but it is not what "execute until merged" meant, and a
+human reading only the prompt would have expected shipped CSS.
+
+**Signal to cancel:** the agent has asked the same blocking question in three or
+more consecutive iterations. It is not stuck on execution; it is waiting on a
+decision the loop cannot supply.
+
+# What worked inside the loop, and is worth keeping
+
+The per-iteration cadence held up across nine merged PRs with no regression
+shipped:
+
+1. **WIP=1** - one PR open, merged before the next unit starts.
+2. **`/codex:review` before every merge**, fixing what reproduces against the
+   tree and saying so plainly when a finding does not reproduce.
+3. **Revert rather than ship** when a change proves null or harmful. Five
+   reverts on that phase, including a 41-rule sweep that measured as an AA
+   regression and a tokenisation of dead code. A loop rewards visible progress,
+   so this is the discipline it erodes first - see the NULL CHANGE rule in
+   [test-gates](/build/test-gates.md).
+
+# Write the prompt with the traps in it
+
+The loop re-reads the prompt every iteration, so it is the cheapest place to put
+gate rules that would otherwise decay. The 1a.4 prompt carried "never cite
+`bin/dtest` from this worktree - it is vacuous-green", "quote the
+`[snap_diff] N screenshots compared` count", and "`--strict` EXITS 1 by design",
+and none of those was violated across the whole run.

--- a/.okf/workflows/index.md
+++ b/.okf/workflows/index.md
@@ -2,6 +2,7 @@
 
 * [Company-layer ownership](company-layer-ownership.md) - vault owns ALL operations (loop, pipeline, runbook; re-settled 2026-08-20), repo owns growth/marketing campaigns, claims canon owns the facts
 * [Render verification](render-verification.md) - headless Chrome + slicing recipes for the visual scroll gate
+* [Autonomous loops](autonomous-loops.md) - ralph-loop fits verifiable work with known-correct scope; it can iterate but cannot re-scope, and only a true promise or the human ends it
 * [Review swarm](review-swarm.md) - the two-critic review pattern, its failure modes, and the /stitch-design design-review route with the surface-to-design-source table
 * [Blog Post Pipeline](blog-pipeline.md) - mandatory end-to-end workflow for writing/publishing blog posts, plus the execute-don't-read claims gate, the frontmatter claims check, and the `## Sources` citation convention
 * [LinkedIn Post Pipeline](linkedin-post-pipeline.md) - Paul Keen voice rules and posting workflow


### PR DESCRIPTION
Bundle only. New concept written from running Phase 1a.4 under `/ralph-loop`.

## The structural limit

A loop re-feeds one prompt until a completion promise is true, and ends on three
things only: the promise, the iteration cap, or a human cancel.

**An agent that correctly concludes the work is *blocked* cannot end it** — that
conclusion just produces another iteration of the same prompt.

So a loop fits work whose completion is **mechanically checkable** and whose
**scope is known-correct**. It has no move for *"the specification is wrong."*

## 1a.4 was the demonstration

One of four scope items was as written; two were gated by an unnamed design
token. The loop kept iterating past the point where delivery was blocked,
producing investigation and documentation instead of the merge the prompt asked
for.

That output was worth having — but a human reading only the prompt would have
expected shipped CSS.

**Cancel signal recorded:** the same blocking question asked in three or more
consecutive iterations means the agent is waiting on a *decision*, not stuck on
execution.

## What held up, and is worth keeping

- **WIP=1** with `/codex:review` before every merge — nine PRs, no regression shipped
- **Revert rather than ship** when a change proves null or harmful — five
  reverts, including a 41-rule sweep that measured as an AA regression and a
  tokenisation of dead code

Noted explicitly: **a loop rewards visible progress, so revert-discipline is the
first thing it erodes.**

## Put the gate traps in the prompt

The loop re-reads the prompt every iteration, which makes it the cheapest place
for rules that otherwise decay. The 1a.4 prompt carried the vacuous-green
`dtest` warning, the compared-count rule and the `--strict` exit code — **none
was violated across the whole run.**

## Gates

`okf_validate .okf` exits **0**, conformant, no warnings on the new concept;
`--strict` exits **1** by design on this bundle. `bin/hugo-build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
