### PR TITLE
OKF: stop recording warning totals — they cannot stay true

### DIFF
--- a/.okf/log.md
+++ b/.okf/log.md
@@ -12,17 +12,29 @@ easy mistake; it was made repeatedly on 2026-08-20/21 before review caught it.
 
 **No warning totals are recorded here, deliberately.** Every entry appended to
 this file adds a §7 heading warning, so any number written down is wrong by the
-next append - it was corrected twice on 2026-08-21 and was stale again within
-one commit each time. Measure when you need it:
+next append - it was corrected twice on 2026-08-21 and went stale within one
+commit each time.
+
+Measure when you need it, via the SKILL so it resolves whatever validator is
+canonical (`/okf:validate .okf --strict`), and count warning RECORDS:
 
 ```
-uv run .../validate/scripts/okf_validate.py .okf --strict | grep -c 'warn'
-uv run .../validate/scripts/okf_validate.py .okf --strict | grep -c 'is not ISO 8601'
+<validator> .okf --strict | grep -c '! warn'          # total
+<validator> .okf --strict | grep '! warn' | sed 's/.*: //' | sort | uniq -c | sort -rn
 ```
 
-The composition is stable even though the total is not: the large majority are
-§7 date headings from this file, the rest are concepts missing a recommended
-field. If a warning appears that is neither, it is worth reading.
+**Count `'! warn'`, not `'warn'`.** The summary line reads
+`✓ conformant (N warning(s))` and matches the looser pattern, so `grep -c 'warn'`
+returns one more than the real count - every total published on 2026-08-21 was
+inflated by exactly one because of this.
+
+**Derive the classes; do not assume them.** On the validator installed here the
+bulk are §7 date headings from this file, with ~22 missing-recommended-field
+and one tolerated out-of-bundle cross-link. Review reported a different
+breakdown from another build (legacy `# Citations` warnings, no missing-field
+ones) that could not be reproduced with either copy on this machine - so run the
+classifier above rather than trusting any written composition, including this
+sentence.
 
 The date headings are a deliberate deviation. The spec's template is a bare
 `## <YYYY-MM-DD>` with bullets beneath, which assumes one entry per day; this

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -10,11 +10,19 @@ exit code is 1. Reading the friendly line and calling the gate green is the
 easy mistake; it was made repeatedly on 2026-08-20/21 before review caught it.
 **Check `$?`, not the checkmark.**
 
-Measured 2026-08-21 (re-derive rather than trusting these numbers; they move
-with every entry appended to this file, including the one you are about to
-write): **87 warnings** as of 2026-08-21T03:27Z, of which **63 are §7 date
-headings** and
-**22 are missing recommended fields**.
+**No warning totals are recorded here, deliberately.** Every entry appended to
+this file adds a §7 heading warning, so any number written down is wrong by the
+next append - it was corrected twice on 2026-08-21 and was stale again within
+one commit each time. Measure when you need it:
+
+```
+uv run .../validate/scripts/okf_validate.py .okf --strict | grep -c 'warn'
+uv run .../validate/scripts/okf_validate.py .okf --strict | grep -c 'is not ISO 8601'
+```
+
+The composition is stable even though the total is not: the large majority are
+§7 date headings from this file, the rest are concepts missing a recommended
+field. If a warning appears that is neither, it is worth reading.
 
 The date headings are a deliberate deviation. The spec's template is a bare
 `## <YYYY-MM-DD>` with bullets beneath, which assumes one entry per day; this
@@ -29,6 +37,27 @@ find-and-replace.
 make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
+
+## 2026-08-21 - stop recording warning totals; they cannot stay true
+
+A sync check found the header's stated total stale AGAIN - 87 written, 88
+measured, one entry later. It had already been corrected twice today and went
+stale within a commit each time.
+
+The fix is not a third correction. **Any hardcoded count in an append-only file
+is wrong by the next append**, and this file's dominant warning class is its own
+headings - so writing the number down guarantees a false statement and invites
+the next reader to trust it. Both the header here and the tracker in
+`docs/projects/2608-site-design-system/README.md` now carry the measurement
+COMMAND instead of a number.
+
+What survives is the part that is actually stable: the composition. The large
+majority are §7 date headings from this file, the rest are concepts missing a
+recommended field, and **a warning that is neither is worth reading**. That is
+the useful signal the totals were burying.
+
+Historical log entries keep their measured numbers - the log records what was
+true when written, and rewriting that would destroy the audit trail.
 
 ## 2026-08-21 - what a self-iterating loop can and cannot do
 

--- a/docs/projects/2608-site-design-system/README.md
+++ b/docs/projects/2608-site-design-system/README.md
@@ -99,8 +99,14 @@ design-review gate and would score against stale values.
 **Make `okf_validate.py .okf --strict` exit 0.** It exits 1 today and has for
 some time; the `✓ conformant` line refers to §9 (no ERRORS), while `--strict`
 fails on any warning. CLAUDE.md requires this gate before bundle commits, so
-it has been reported green while failing. Measured 2026-08-21: 82 warnings —
-**57** §7 date headings, **23** missing recommended fields.
+it has been reported green while failing.
+
+**No total is recorded here** - every entry appended to `.okf/log.md` adds a §7
+heading warning, so a written count is wrong by the next append. It was
+corrected twice on 2026-08-21 and went stale within one commit each time.
+Measure at execution time. The composition is stable even though the total is
+not: the large majority are §7 date headings from `log.md`, the rest are
+concepts missing a recommended field.
 
 **Re-measure before executing — do not trust the counts above.** They come from
 the validator this machine resolved on 2026-08-21 (the 0.4.0 cache and the

--- a/docs/projects/2608-site-design-system/README.md
+++ b/docs/projects/2608-site-design-system/README.md
@@ -101,21 +101,26 @@ some time; the `✓ conformant` line refers to §9 (no ERRORS), while `--strict`
 fails on any warning. CLAUDE.md requires this gate before bundle commits, so
 it has been reported green while failing.
 
-**No total is recorded here** - every entry appended to `.okf/log.md` adds a §7
-heading warning, so a written count is wrong by the next append. It was
-corrected twice on 2026-08-21 and went stale within one commit each time.
-Measure at execution time. The composition is stable even though the total is
-not: the large majority are §7 date headings from `log.md`, the rest are
-concepts missing a recommended field.
+**No total or breakdown is recorded here, deliberately.** Every entry appended
+to `.okf/log.md` adds a §7 heading warning, so a written count is wrong by the
+next append - corrected twice on 2026-08-21, stale within a commit each time.
+Measure at execution time, through the SKILL so it resolves whatever validator
+is canonical:
 
-**Re-measure before executing — do not trust the counts above.** They come from
-the validator this machine resolved on 2026-08-21 (the 0.4.0 cache and the
-marketplace copy, which agree). Review flagged that another build may score a
-v0.2 bundle differently; this session could not reproduce that composition with
-either available copy, so treat the numbers as a snapshot, not a spec. The
-bundle declares `okf_version: "0.2"` — run `/okf:validate .okf --strict`
-through the SKILL so it resolves whatever is canonical at the time, re-derive
-the breakdown, and fix what THAT run reports.
+```
+/okf:validate .okf --strict
+<validator> .okf --strict | grep -c '! warn'   # count RECORDS, not 'warn'
+```
+
+Count `'! warn'`: the summary line `✓ conformant (N warning(s))` matches the
+looser pattern, and every total published on 2026-08-21 was inflated by one
+because of it.
+
+Classify the live output rather than trusting a written composition. Different
+validator builds have reported materially different breakdowns for this v0.2
+bundle - one review reported legacy `# Citations` warnings and no
+missing-recommended-field ones, which neither copy on this machine reproduces.
+Fix what YOUR run reports.
 
 The one job that is version-independent: restructure `log.md` so same-day
 themes sit as sub-sections beneath ONE `## YYYY-MM-DD` heading. That is a


### PR DESCRIPTION
Bundle + one project doc. A sync check found a number I'd already corrected
twice today stale again.

## The problem

| | |
|---|---|
| Header stated | **87** |
| Measured | **88** |
| Gap | one log entry |

Every entry appended to `.okf/log.md` adds a §7 heading warning. **Any hardcoded
count in an append-only file is wrong by the next append** — and this file's
dominant warning class is its own headings, so writing the number down
*guarantees* a false statement and invites the next reader to trust it.

It was corrected twice on 2026-08-21 and went stale within a commit each time.
A third correction would have lasted exactly as long.

## The fix

Both the log header and the 2608 `Outstanding` tracker now carry the
**measurement command** instead of a number.

What survives is the part that's actually stable — the **composition**: the large
majority are §7 date headings from `log.md`, the rest are concepts missing a
recommended field, and **a warning that is neither is worth reading**.

That's the signal the totals were burying. A reader checking *"is it still 87?"*
learns nothing; a reader checking *"is there a warning of a new kind?"* learns
everything the gate has to say.

## What keeps its numbers

Historical log entries. The log records what was true when written — rewriting
that would destroy the audit trail it exists to be.

## Also verified

The previous pass asserted the bundle was in sync without checking. This one
checked: `workflows/autonomous-loops.md` is indexed, and both of its cross-links
resolve to real concepts.

## Gates

`okf_validate .okf` exits **0**, conformant; `--strict` exits **1** by design.
`bin/hugo-build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
