### PR TITLE
OKF: test the instrument, not just the result

### DIFF
--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -6,13 +6,14 @@ tags: [testing, visual-regression, gates]
 status: stable
 generated: { by: claude/opus-4-8, at: 2026-08-12T20:20:00Z }
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T04:01:38Z }
   - { by: claude/opus-5, at: 2026-08-21T03:27:09Z }
   - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
   - { by: claude/fable-5, at: 2026-08-01T11:30:00Z }
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
   - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
-timestamp: 2026-08-21T03:27:09Z
+timestamp: 2026-08-21T04:01:38Z
 ---
 
 # The suites
@@ -259,6 +260,23 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
   style, a rendered pixel, a test that newly runs, a byte in the built output -
   and check that one thing. "The suite is still green" is consistent with
   having changed nothing at all.
+
+- **Test the instrument, not just the result: ask what your command would
+  return if the claim were FALSE** (2026-08-21, two instances). A null change
+  does nothing and is at least silent about it. A wrong instrument RUNS,
+  returns a plausible number, and is believed.
+
+  | Command | Why it could not answer the question |
+  |---|---|
+  | `okf_validate .okf --strict \| grep -c 'warn'` | the summary line `✓ conformant (N warning(s))` matches too, so every total was one high - every count published on 2026-08-21 was inflated, including the ones inside an argument about not trusting written numbers |
+  | `grep -rc 'c-button--primary' _dest/public-dev/css/*.css` | `public-dev` is a DEV build with PurgeCSS disabled, and that CSS ships INLINE in the HTML - the command returns 0 whether or not the component is adopted |
+
+  The second is the pure case: **it returns the same answer either way**, so it
+  carries no information at all, and it was quoted as proof. The check that
+  catches both takes one run - execute the command against a case where the
+  answer is known to differ (`grep -c '! warn'` against the record count; the
+  same grep against a PRODUCTION tree) and confirm the two disagree. If they
+  cannot disagree, you have a ritual, not a measurement.
 
 - **An empty query result is not evidence of absence** (2026-08-21). Hunting a
   black band on `/services/`, `document.querySelectorAll('path.fl-shape')`

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -289,6 +289,13 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
   positive also returns nothing, the command is looking in the wrong place. If
   it returns a count, the zero you got is real.
 
+    Worked once immediately, on this very entry: `grep -c` for the new wording
+    returned 0, and so did the positive control - both phrases wrap across lines
+    and `grep` is line-oriented. The control refused the answer instead of
+    confirming a false one. Flatten first (`tr '\n' ' ' < file | tr -s ' '`),
+    then grep; same reason `marketing_copy_test` misses banned phrases split
+    across two template lines.
+
 - **An empty query result is not evidence of absence** (2026-08-21). Hunting a
   black band on `/services/`, `document.querySelectorAll('path.fl-shape')`
   returned `[]`. That read as "no shape layer on this page" and an entire

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -261,22 +261,33 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
   and check that one thing. "The suite is still green" is consistent with
   having changed nothing at all.
 
-- **Test the instrument, not just the result: ask what your command would
-  return if the claim were FALSE** (2026-08-21, two instances). A null change
-  does nothing and is at least silent about it. A wrong instrument RUNS,
-  returns a plausible number, and is believed.
+- **Test the instrument, not just the result: run it against a case where the
+  answer is KNOWN to differ** (2026-08-21). A null change does nothing and is
+  at least silent about it. A wrong instrument RUNS, returns a plausible
+  number, and gets believed.
 
-  | Command | Why it could not answer the question |
-  |---|---|
-  | `okf_validate .okf --strict \| grep -c 'warn'` | the summary line `✓ conformant (N warning(s))` matches too, so every total was one high - every count published on 2026-08-21 was inflated, including the ones inside an argument about not trusting written numbers |
-  | `grep -rc 'c-button--primary' _dest/public-dev/css/*.css` | `public-dev` is a DEV build with PurgeCSS disabled, and that CSS ships INLINE in the HTML - the command returns 0 whether or not the component is adopted |
+  The real instance: `okf_validate .okf --strict | grep -c 'warn'` also matches
+  the summary line `✓ conformant (89 warning(s))`, so it returns 90 - every
+  warning total published on 2026-08-21 was one high, including the totals
+  inside an argument about not trusting written numbers.
 
-  The second is the pure case: **it returns the same answer either way**, so it
-  carries no information at all, and it was quoted as proof. The check that
-  catches both takes one run - execute the command against a case where the
-  answer is known to differ (`grep -c '! warn'` against the record count; the
-  same grep against a PRODUCTION tree) and confirm the two disagree. If they
-  cannot disagree, you have a ritual, not a measurement.
+  **The check cuts both ways, and that is the point.** The same day, this file
+  nearly recorded a second instance: `grep -rc 'c-button--primary'
+  _dest/public-dev/css/*.css` returning 0, dismissed as vacuous on the theory
+  that the bundles ship inline via `partials/assets/css-inline.html` and never
+  land under `css/`. Running the positive control refuted that in one command -
+  `blog-eyebrow`, a class known to be adopted, returns **13 files** through the
+  exact same glob. The command can differ, so it is a valid instrument, and its
+  0 was a TRUE reading: `c-button` lives in 2 source files that reach 0 bundles.
+  The accusation was as unevidenced as the measurement it accused.
+
+  So the control is not "run it somewhere else" - re-running the c-button grep
+  against a production tree proves nothing, because `css-inline.html` inlines
+  the bundle in every environment and only adds `minify` under
+  `hugo.IsProduction`. The control is **a positive case through the identical
+  command**: a class, string, or file you already know is present. If the known
+  positive also returns nothing, the command is looking in the wrong place. If
+  it returns a count, the zero you got is real.
 
 - **An empty query result is not evidence of absence** (2026-08-21). Hunting a
   black band on `/services/`, `document.querySelectorAll('path.fl-shape')`

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -52,29 +52,27 @@ time, which is verifiable - never invented).
 
 ## 2026-08-21 - test the instrument, not just the result
 
-Recorded in [build/test-gates.md](build/test-gates.md) as its own rule, because
-it is distinct from the NULL CHANGE beside it: a null change does nothing and is
-at least silent about it, while a wrong instrument RUNS, returns a plausible
-number, and gets believed.
+Recorded in [build/test-gates.md](build/test-gates.md), distinct from the NULL
+CHANGE rule beside it: a null change does nothing and is at least silent about
+it, while a wrong instrument RUNS, returns a plausible number, and gets believed.
 
-Two instances tonight:
+The real instance: `okf_validate .okf --strict | grep -c 'warn'` also matches the
+summary line `✓ conformant (89 warning(s))`, returning 90 - every warning total
+published on 2026-08-21 was one high.
 
-* `okf_validate .okf --strict | grep -c 'warn'` also matches the summary line
-  `✓ conformant (N warning(s))`, so every total published on 2026-08-21 was one
-  high - including the ones inside an argument about not trusting written
-  numbers.
-* `grep -rc 'c-button--primary' _dest/public-dev/css/*.css` returns 0 whether or
-  not the component is adopted: `public-dev` is a DEV build with PurgeCSS
-  disabled, and that CSS ships INLINE in the HTML rather than under `css/`.
+**The rule caught its own draft.** A second instance was nearly recorded:
+`grep -rc 'c-button--primary' _dest/public-dev/css/*.css` returning 0, dismissed
+as vacuous on the theory that bundles ship inline and never land under `css/`.
+The positive control refuted it in one command - `blog-eyebrow`, a class known to
+be adopted, returns 13 files through the identical glob. The instrument is valid
+and its 0 was true (`c-button` sits in 2 source files that reach 0 bundles). The
+accusation was as unevidenced as the measurement it accused.
 
-The second is the pure case - **it cannot return a different answer**, so it
-carries no information, and it was quoted as proof. The test that catches both
-takes one run: execute the command against a case where the answer is KNOWN to
-differ and confirm the two disagree. If they cannot disagree, it is a ritual,
-not a measurement.
-
-This is "produce the check that would fail if the claim were false" turned on
-the check itself.
+The control is therefore NOT "run it somewhere else" - re-running that grep
+against a production tree proves nothing, since `css-inline.html` inlines the
+bundle in every environment and only adds `minify` under `hugo.IsProduction`
+(found by codex review of PR #536). The control is **a positive case through the
+identical command**.
 
 ## 2026-08-21 - stop recording warning totals; they cannot stay true
 

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -50,6 +50,32 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
+## 2026-08-21 - test the instrument, not just the result
+
+Recorded in [build/test-gates.md](build/test-gates.md) as its own rule, because
+it is distinct from the NULL CHANGE beside it: a null change does nothing and is
+at least silent about it, while a wrong instrument RUNS, returns a plausible
+number, and gets believed.
+
+Two instances tonight:
+
+* `okf_validate .okf --strict | grep -c 'warn'` also matches the summary line
+  `✓ conformant (N warning(s))`, so every total published on 2026-08-21 was one
+  high - including the ones inside an argument about not trusting written
+  numbers.
+* `grep -rc 'c-button--primary' _dest/public-dev/css/*.css` returns 0 whether or
+  not the component is adopted: `public-dev` is a DEV build with PurgeCSS
+  disabled, and that CSS ships INLINE in the HTML rather than under `css/`.
+
+The second is the pure case - **it cannot return a different answer**, so it
+carries no information, and it was quoted as proof. The test that catches both
+takes one run: execute the command against a case where the answer is KNOWN to
+differ and confirm the two disagree. If they cannot disagree, it is a ritual,
+not a measurement.
+
+This is "produce the check that would fail if the claim were false" turned on
+the check itself.
+
 ## 2026-08-21 - stop recording warning totals; they cannot stay true
 
 A sync check found the header's stated total stale AGAIN - 87 written, 88


### PR DESCRIPTION
Bundle only. Records a rule distinct from the NULL CHANGE beside it — and then gets corrected by its own rule mid-PR.

## The distinction

A **null change** does nothing — and is at least silent about it.
A **wrong instrument** *runs*, returns a plausible number, and gets believed.

## The verified instance

`okf_validate .okf --strict | grep -c 'warn'` also matches the summary line
`✓ conformant (89 warning(s))`, so it returns **90**. Every warning total published
on 2026-08-21 was one high — including the totals inside an argument about not
trusting written numbers.

## The rule caught its own draft

The first commit recorded a second instance: `grep -rc 'c-button--primary' _dest/public-dev/css/*.css`
returning `0`, dismissed as vacuous on the theory that bundles ship inline and never land under `css/`.

Codex review flagged the *remedy* ("run it against a production tree") as still vacuous —
`css-inline.html` inlines the bundle in every environment and `hugo.IsProduction` only adds `minify`.
Verifying that flag refuted more than the remedy:

| command | result |
|---|---|
| `grep -rc 'c-button--primary' _dest/public-dev/css/*.css` | 0 |
| `grep -rc 'blog-eyebrow' _dest/public-dev/css/*.css` | **13 files** |

`blog-eyebrow` is a class known to be adopted, returning through the **identical glob**.
So the command *can* differ, it *is* a valid instrument, and its `0` was a **true** reading —
`c-button` lives in 2 source files that reach 0 bundles.

I called that command vacuous without ever running the control that would have shown otherwise:
the exact failure the rule is about, committed inside the rule.

The instance is removed; the episode is kept as the illustration, because it's the more useful half —
**the test refuses a false accusation as readily as a false measurement.**

## The control, restated

Not *"run it somewhere else."* **A positive case through the identical command** — a class, string,
or file already known to be present.

- Known positive also returns nothing → the command is looking in the wrong place.
- Known positive returns a count → your zero is real.

## Gates

`okf_validate .okf` exits **0**, conformant; `--strict` exits **1** by design.
`bin/hugo-build` clean. Timestamp from a measured \`date -u\`, recorded as a `verified` entry
rather than by overwriting `generated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)