### PR TITLE
OKF: CSS ships BOTH inline and as a file under css/

### DIFF
--- a/.okf/architecture/css-pipeline.md
+++ b/.okf/architecture/css-pipeline.md
@@ -71,10 +71,21 @@ contextual selector, an inactive media/state rule, or an overridden declaration
 still counts, and a class JavaScript adds later is invisible to any static read.
 
 Text search over CSS can tell you a string is ABSENT from what a page loads.
-It cannot tell you a selector applies. For that, use the browser:
+That is the only question it settles. Three different questions hide behind
+"does this selector work", and each needs its own instrument:
+
+| Question | Instrument | What it cannot tell you |
+|---|---|---|
+| Did the rule **ship**? | search the loaded CSS (see the traps above) | whether anything matches it |
+| Does it **match** this element? | CSSOM + `el.matches(rule.selectorText)` | which rule won the cascade |
+| Did it **win** the paint? | `getComputedStyle` | *which* selector produced the value - another matching rule with the same value is indistinguishable |
+
+Both browser-side techniques, and the overlay trap that breaks the naive form
+of the third, are documented below:
 [computed style, not source, proves the paint](#the-white-wash-trap-computed-style-not-source-proves-the-paint)
-below - which is the same conclusion this file already reached for colour, now
-confirmed for selector presence.
+and its `elementFromPoint` subsection. Don't collapse the three - a green
+`getComputedStyle` is routinely quoted as proof that a specific rule applies,
+and it is not.
 
 # Token layer: `foundations/css-variables.css`
 

--- a/.okf/architecture/css-pipeline.md
+++ b/.okf/architecture/css-pipeline.md
@@ -70,22 +70,26 @@ shipped Swiper CSS), then the deeper one - a token present in an unmatched
 contextual selector, an inactive media/state rule, or an overridden declaration
 still counts, and a class JavaScript adds later is invisible to any static read.
 
-Text search over CSS can tell you a string is ABSENT from what a page loads.
-That is the only question it settles. Three different questions hide behind
-"does this selector work", and each needs its own instrument:
+Four instruments sit between "the source says so" and "the user sees it", and
+each one's honest claim is narrower than the question people ask it. Every row's
+limitation below is demonstrated somewhere in this file:
 
-| Question | Instrument | What it cannot tell you |
+| Instrument | Establishes | Does NOT establish |
 |---|---|---|
-| Did the rule **ship**? | search the loaded CSS (see the traps above) | whether anything matches it |
-| Does it **match** this element? | CSSOM + `el.matches(rule.selectorText)` | which rule won the cascade |
-| Did it **win** the paint? | `getComputedStyle` | *which* selector produced the value - another matching rule with the same value is indistinguishable |
+| text search over the loaded CSS | **absence only** - the string is nowhere in what the page loads | presence. A hit can be a comment, a URL, or a longer selector's prefix (see the three traps above) |
+| CSSOM rule scan | a rule with that `selectorText` shipped | that it can apply - the rule may sit inside an inactive `@media` or `@supports` |
+| `el.matches(rule.selectorText)` | the SELECTOR matches this element | that the RULE applies (same enclosing-condition gap), or that it won the cascade |
+| `getComputedStyle(el)` | the value that won the cascade for that element | which selector produced it (another rule with the same value is indistinguishable), or what is actually visible - an overlay can cover it |
+| screenshot + pixel sample | what was painted | why |
 
-Both browser-side techniques, and the overlay trap that breaks the naive form
-of the third, are documented below:
-[computed style, not source, proves the paint](#the-white-wash-trap-computed-style-not-source-proves-the-paint)
-and its `elementFromPoint` subsection. Don't collapse the three - a green
-`getComputedStyle` is routinely quoted as proof that a specific rule applies,
-and it is not.
+Only the last is a fact about the rendered page; the rest are facts about
+intermediate representations. The technique for each, and the overlay trap that
+breaks the naive form of `getComputedStyle`, are below:
+[computed style, not source, proves the paint](#the-white-wash-trap-computed-style-not-source-proves-the-paint).
+
+The recurring error is not using the wrong tool - it is quoting a tool's result
+as an answer to the next question up the ladder. A green `getComputedStyle` gets
+read as "that rule applies"; a grep hit gets read as "it ships".
 
 # Token layer: `foundations/css-variables.css`
 

--- a/.okf/architecture/css-pipeline.md
+++ b/.okf/architecture/css-pipeline.md
@@ -4,8 +4,9 @@ title: CSS Build Pipeline (PostCSS + per-bundle PurgeCSS)
 description: PostCSS pipeline that concatenates per-page CSS resource slices and purges unused rules per bundle before shipping.
 resource: postcss.config.js
 tags: [css, build, performance]
-timestamp: 2026-08-21T03:20:07Z
+timestamp: 2026-08-21T04:17:19Z
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T04:17:19Z }
   - { by: claude/opus-5, at: 2026-08-21T01:43:19Z }
 generated:
   by: process:okf-migrate
@@ -30,6 +31,32 @@ nothing about shipped bytes: consolidating shared source files can
 gzip first-visit per page). Any size/perf claim must be validated on
 **compiled + gzip per-page payload**, never raw source line counts —
 see [css-maintainability-plan](/workflows/css-maintainability-plan.md).
+
+# Where the CSS actually lands: BOTH inline and a file
+
+Two partials ship bundles, and a built page uses both. Measured on
+`_dest/public-test/index.html` (2026-08-21): 3 `<style>` tags AND 3
+`<link rel="stylesheet">`.
+
+| Partial | Emits | Production-only difference |
+|---|---|---|
+| `partials/assets/css-inline.html` | `<style>{{ bundle }}</style>` | one `if hugo.IsProduction` branch, wrapping `\| minify` - nothing else |
+| `partials/assets/css-processor.html` | `<link rel=preload>` + `<link rel=stylesheet>` to `/css/<bundle>[.min].<hash>.css` | the `.min` infix |
+
+Consequences when you grep a built tree:
+
+- **`_dest/*/css/*.css` is a real population, not empty.** A class absent
+  there is genuinely absent from the file-served bundles. Control it before
+  believing a zero: a known-adopted class (`blog-eyebrow`) returns 13 files
+  through the same glob in `public-dev` - see the instrument rule in
+  [test-gates](/build/test-gates.md).
+- **But it is only HALF the shipped CSS.** Inline `<style>` content never
+  appears under `css/`, so a class can be live on the page and absent from
+  every file. To ask "does this ship at all", grep the rendered `*.html`.
+- **Dev vs production changes filenames, not delivery.** `public-dev` has
+  `about-us.<hash>.css`, `public-test` has `about-us.min.<hash>.css`. Re-running
+  a `css/` grep "against production" therefore proves nothing about inlining -
+  both trees inline the same way.
 
 # Token layer: `foundations/css-variables.css`
 

--- a/.okf/architecture/css-pipeline.md
+++ b/.okf/architecture/css-pipeline.md
@@ -61,32 +61,20 @@ Three naive greps, three confident wrong answers:
   matches three times on the homepage: one real link, one inside `<noscript>`, and
   one in the preload polyfill's JavaScript (`this.rel="stylesheet"`).
 
-The check that answers it: parse the page, concatenate every `<style>` text with
-the contents of every `link[rel=stylesheet]` href resolved against the build root,
-then measure the selector against that blob AND against the DOM. Two numbers, not
-one - they answer different questions:
+**There is no reliable text-search answer, and this concept no longer proposes
+one.** Four successive attempts at a grep/parse check were each refuted by the
+next review round: literal `String#scan`, then substring prefixes
+(`\.c-content-block` scoring on `.c-content-block__text`), then comments and
+URLs (`idangero` scoring `1` from `http://www.idangero.us/swiper/` inside the
+shipped Swiper CSS), then the deeper one - a token present in an unmatched
+contextual selector, an inactive media/state rule, or an overridden declaration
+still counts, and a class JavaScript adds later is invisible to any static read.
 
-| `rules` | `dom` | Meaning | Homepage example |
-|---|---|---|---|
-| >0 | >0 | shipped and painted | `fl-button` (89 / 5) |
-| >0 | 0 | rule ships, this page doesn't use it | `c-content-block__text` (1 / 0) - the global components bundle is inlined by `baseof.html` for every page |
-| 0 | >0 | **markup with no CSS** - usually the defect you're hunting | `c-nav` (0 / 1) |
-| 0 | 0 | absent | `zzz-not-a-class` |
-
-Two traps in writing that check, both found by their own controls:
-
-- **Require an identifier boundary.** A bare substring makes any class a false
-  positive for its own prefix: `\.c-content-block` scores 1 on the homepage
-  purely from `.c-content-block__text`, though no `.c-content-block` rule exists.
-  Use `Regexp.new('\.' + Regexp.escape(cls) + '(?![\w-])')`.
-- **`String#scan` with a String argument matches LITERALLY**, so `'\.c-nav'`
-  hunts for a backslash. Wrap it in `Regexp.new` or every escaped control
-  silently reads 0.
-
-Pick controls in both directions before believing a zero, and label them for what
-they prove - a `rules` count proves the rule SHIPS, not that the page paints it.
-If the known-present control also returns 0, the instrument is broken, not the
-codebase; see the instrument rule in [test-gates](/build/test-gates.md).
+Text search over CSS can tell you a string is ABSENT from what a page loads.
+It cannot tell you a selector applies. For that, use the browser:
+[computed style, not source, proves the paint](#the-white-wash-trap-computed-style-not-source-proves-the-paint)
+below - which is the same conclusion this file already reached for colour, now
+confirmed for selector presence.
 
 # Token layer: `foundations/css-variables.css`
 

--- a/.okf/architecture/css-pipeline.md
+++ b/.okf/architecture/css-pipeline.md
@@ -32,31 +32,48 @@ gzip first-visit per page). Any size/perf claim must be validated on
 **compiled + gzip per-page payload**, never raw source line counts —
 see [css-maintainability-plan](/workflows/css-maintainability-plan.md).
 
-# Where the CSS actually lands: BOTH inline and a file
+# Where the CSS actually lands: both a `<style>` block and a linked file
 
-Two partials ship bundles, and a built page uses both. Measured on
-`_dest/public-test/index.html` (2026-08-21): 3 `<style>` tags AND 3
-`<link rel="stylesheet">`.
+Two partials ship bundles and a built page uses both. Counted with a parser on
+`_dest/public-test/index.html` (2026-08-21) - `rg` gets this wrong, see below:
 
-| Partial | Emits | Production-only difference |
+| Partial | Emits | What production adds |
 |---|---|---|
-| `partials/assets/css-inline.html` | `<style>{{ bundle }}</style>` | one `if hugo.IsProduction` branch, wrapping `\| minify` - nothing else |
-| `partials/assets/css-processor.html` | `<link rel=preload>` + `<link rel=stylesheet>` to `/css/<bundle>[.min].<hash>.css` | the `.min` infix |
+| `partials/assets/css-inline.html` | `<style>{{ bundle }}</style>` | `\| minify`, and nothing else |
+| `partials/assets/css-processor.html` | `<link rel=preload as=style>` + `<link rel=stylesheet>` → `/css/<bundle>[.min].<hash>.css` | `\| minify`, `resources.PostProcess`, and an `integrity` attribute on BOTH links (`fingerprint "sha256"` runs in dev too) |
 
-Consequences when you grep a built tree:
+On the homepage that resolves to 3 `<style>` elements of which only **2** are
+pipeline bundles (the third is 174 chars of hard-coded page CSS), and **2**
+`link[rel=stylesheet]` of which one is a `<noscript>` swiper-vendor fallback.
 
-- **`_dest/*/css/*.css` is a real population, not empty.** A class absent
-  there is genuinely absent from the file-served bundles. Control it before
-  believing a zero: a known-adopted class (`blog-eyebrow`) returns 13 files
-  through the same glob in `public-dev` - see the instrument rule in
-  [test-gates](/build/test-gates.md).
-- **But it is only HALF the shipped CSS.** Inline `<style>` content never
-  appears under `css/`, so a class can be live on the page and absent from
-  every file. To ask "does this ship at all", grep the rendered `*.html`.
-- **Dev vs production changes filenames, not delivery.** `public-dev` has
-  `about-us.<hash>.css`, `public-test` has `about-us.min.<hash>.css`. Re-running
-  a `css/` grep "against production" therefore proves nothing about inlining -
-  both trees inline the same way.
+# Answering "does this selector actually ship?"
+
+Neither naive grep works, and both fail in the confident direction:
+
+- **Grepping the rendered `*.html` for a class is a false positive.** It matches
+  the `class="..."` attribute in markup, which says nothing about CSS. Live
+  example: `c-nav` appears in the homepage markup with **zero** matching CSS
+  anywhere in what that page loads.
+- **Grepping `_dest/*/css/*.css` alone is a false negative.** That population is
+  real - a class absent there really is absent from the file-served bundles - but
+  inline `<style>` content never lands under `css/`, so it is only part of what
+  ships.
+- **Counting tags with `rg` over raw HTML is a false positive.** `rel="stylesheet"`
+  matches three times on the homepage: one real link, one inside `<noscript>`,
+  and one in the preload polyfill's JavaScript (`this.rel="stylesheet"`).
+
+The check that answers it: parse the page, concatenate every `<style>` text with
+the contents of every `link[rel=stylesheet]` href resolved against the build
+root, and search that blob. Control it in both directions before believing a
+zero - a selector you know the page paints (`.c-content-block__text` → 1) and one
+you know is absent (`.zzz-not-a-class` → 0). If the known-present one also
+returns 0, the instrument is broken, not the codebase; see the instrument rule in
+[test-gates](/build/test-gates.md).
+
+Ruby trap when writing that check: `String#scan(needle)` with a **String**
+argument matches literally, so `'\.c-nav'` hunts for a backslash. Wrap it -
+`blob.scan(Regexp.new(needle))` - or the control silently reads 0 for everything
+that contains an escape.
 
 # Token layer: `foundations/css-variables.css`
 

--- a/.okf/architecture/css-pipeline.md
+++ b/.okf/architecture/css-pipeline.md
@@ -48,32 +48,45 @@ pipeline bundles (the third is 174 chars of hard-coded page CSS), and **2**
 
 # Answering "does this selector actually ship?"
 
-Neither naive grep works, and both fail in the confident direction:
+Three naive greps, three confident wrong answers:
 
 - **Grepping the rendered `*.html` for a class is a false positive.** It matches
   the `class="..."` attribute in markup, which says nothing about CSS. Live
-  example: `c-nav` appears in the homepage markup with **zero** matching CSS
-  anywhere in what that page loads.
-- **Grepping `_dest/*/css/*.css` alone is a false negative.** That population is
-  real - a class absent there really is absent from the file-served bundles - but
-  inline `<style>` content never lands under `css/`, so it is only part of what
-  ships.
+  example: `c-nav` is on the homepage with **zero** matching CSS in anything that
+  page loads.
+- **Grepping `_dest/*/css/*.css` alone is a false negative.** Real population -
+  a class absent there really is absent from the file-served bundles - but inline
+  `<style>` content never lands under `css/`.
 - **Counting tags with `rg` over raw HTML is a false positive.** `rel="stylesheet"`
-  matches three times on the homepage: one real link, one inside `<noscript>`,
-  and one in the preload polyfill's JavaScript (`this.rel="stylesheet"`).
+  matches three times on the homepage: one real link, one inside `<noscript>`, and
+  one in the preload polyfill's JavaScript (`this.rel="stylesheet"`).
 
 The check that answers it: parse the page, concatenate every `<style>` text with
-the contents of every `link[rel=stylesheet]` href resolved against the build
-root, and search that blob. Control it in both directions before believing a
-zero - a selector you know the page paints (`.c-content-block__text` → 1) and one
-you know is absent (`.zzz-not-a-class` → 0). If the known-present one also
-returns 0, the instrument is broken, not the codebase; see the instrument rule in
-[test-gates](/build/test-gates.md).
+the contents of every `link[rel=stylesheet]` href resolved against the build root,
+then measure the selector against that blob AND against the DOM. Two numbers, not
+one - they answer different questions:
 
-Ruby trap when writing that check: `String#scan(needle)` with a **String**
-argument matches literally, so `'\.c-nav'` hunts for a backslash. Wrap it -
-`blob.scan(Regexp.new(needle))` - or the control silently reads 0 for everything
-that contains an escape.
+| `rules` | `dom` | Meaning | Homepage example |
+|---|---|---|---|
+| >0 | >0 | shipped and painted | `fl-button` (89 / 5) |
+| >0 | 0 | rule ships, this page doesn't use it | `c-content-block__text` (1 / 0) - the global components bundle is inlined by `baseof.html` for every page |
+| 0 | >0 | **markup with no CSS** - usually the defect you're hunting | `c-nav` (0 / 1) |
+| 0 | 0 | absent | `zzz-not-a-class` |
+
+Two traps in writing that check, both found by their own controls:
+
+- **Require an identifier boundary.** A bare substring makes any class a false
+  positive for its own prefix: `\.c-content-block` scores 1 on the homepage
+  purely from `.c-content-block__text`, though no `.c-content-block` rule exists.
+  Use `Regexp.new('\.' + Regexp.escape(cls) + '(?![\w-])')`.
+- **`String#scan` with a String argument matches LITERALLY**, so `'\.c-nav'`
+  hunts for a backslash. Wrap it in `Regexp.new` or every escaped control
+  silently reads 0.
+
+Pick controls in both directions before believing a zero, and label them for what
+they prove - a `rules` count proves the rule SHIPS, not that the page paints it.
+If the known-present control also returns 0, the instrument is broken, not the
+codebase; see the instrument rule in [test-gates](/build/test-gates.md).
 
 # Token layer: `foundations/css-variables.css`
 

--- a/.okf/architecture/index.md
+++ b/.okf/architecture/index.md
@@ -1,7 +1,7 @@
 # Architecture
 
 * [Hugo Site](hugo-site.md) - Hugo static site setup, theme, build/test commands
-* [CSS Build Pipeline](css-pipeline.md) - PostCSS + per-bundle PurgeCSS, the site-wide token layer and its zero-delta promotion pattern, FL-Builder legacy CSS
+* [CSS Build Pipeline](css-pipeline.md) - PostCSS + per-bundle PurgeCSS, the site-wide token layer and its zero-delta promotion pattern, dual inline+file delivery, FL-Builder legacy CSS
 * [Blog Index / Listing Page](blog-list-page.md) - index AND tag-page templates, the shared row/filter/CTA partials, blog-list CSS bundle, and the term-kind / date-fallback traps
 * [Blog Cover Image Pipeline](cover-image-pipeline.md) - JetVelocity cover generation, og:image vs thumbnail rendering, and the responsive mobileWidth/mobileSizes params list covers need
 * [Enhanced SEO Meta Tags](seo-meta-tags.md) - per-section title/description generation partial, its own og:image path, and the site-default social fallback

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -50,29 +50,38 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
-## 2026-08-21 - CSS ships BOTH inline and as a file under css/
+## 2026-08-21 - CSS ships both inline and as a linked file; how to check what actually ships
 
-Recorded in [architecture/css-pipeline.md](architecture/css-pipeline.md). Found
-while verifying a codex finding on PR #536, and it corrects a belief this bundle
-was one commit away from recording as fact.
+Recorded in [architecture/css-pipeline.md](architecture/css-pipeline.md). The
+first draft of this entry was itself wrong in three ways, all caught by codex
+review of PR #537 and all verified before accepting.
 
-A built page uses both delivery paths - measured on `_dest/public-test/index.html`:
-3 `<style>` tags AND 3 `<link rel="stylesheet">`.
+The mechanism: `partials/assets/css-inline.html` emits `<style>` (production
+adds only `| minify`); `partials/assets/css-processor.html` emits preload +
+stylesheet links to `/css/<bundle>[.min].<hash>.css` (production adds `minify`,
+`resources.PostProcess`, and an `integrity` attribute on both links -
+`fingerprint "sha256"` runs in dev too). On the homepage: 3 `<style>` of which
+2 are pipeline bundles, and 2 `link[rel=stylesheet]` of which one is a
+`<noscript>` swiper fallback.
 
-* `partials/assets/css-inline.html` emits `<style>`; its only
-  `if hugo.IsProduction` branch wraps `| minify`.
-* `partials/assets/css-processor.html` emits `preload` + `stylesheet` links to
-  `/css/<bundle>[.min].<hash>.css`; production only adds the `.min` infix.
+What the draft got wrong, and what replaced it:
 
-So `_dest/*/css/*.css` is a real population - a class absent there really is
-absent from the file-served bundles (`blog-eyebrow` returns 13 files in
-`public-dev` as the control). But it is only HALF the shipped CSS: inline
-`<style>` content never lands under `css/`, so "does this ship at all" has to be
-asked of the rendered `*.html`.
+* Counted "3 and 3" by grepping raw HTML. A parser says 3 and **2** - the extra
+  `rel="stylesheet"` match is the preload polyfill's JavaScript
+  (`this.rel="stylesheet"`). Counting tags with `rg` is a false positive.
+* Said production "only adds the `.min` infix". It also runs
+  `resources.PostProcess` and adds `integrity` to both links.
+* Recommended grepping the rendered `*.html` to ask whether CSS ships. That
+  matches the `class="..."` attribute in markup: `c-nav` is on the homepage with
+  **zero** matching CSS in anything that page loads.
 
-The earlier claim that a `css/` grep is vacuous "because the CSS ships inline"
-was wrong in both directions - it ships inline AND as a file, and dev vs
-production changes filenames, not delivery.
+The check that does answer it: parse the page, concatenate every `<style>` text
+with the contents of every `link[rel=stylesheet]` href, search that blob, and
+control it in both directions (`.c-content-block__text` -> 1,
+`.zzz-not-a-class` -> 0). Ruby trap found while building it:
+`String#scan` with a String argument matches literally, so `'\.c-nav'` hunts for
+a backslash - the known-present control read 0 until it was wrapped in
+`Regexp.new`.
 
 ## 2026-08-21 - test the instrument, not just the result
 

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -56,7 +56,7 @@ Recorded in [architecture/css-pipeline.md](architecture/css-pipeline.md). Eleven
 findings across five codex review rounds on PR #537, every one verified against
 the tree before acceptance. The count is the finding.
 
-**The mechanism** (unchallenged across all three rounds):
+**The mechanism** (unchallenged across all five rounds):
 `partials/assets/css-inline.html` emits `<style>`, production adding only
 `| minify`; `partials/assets/css-processor.html` emits preload + stylesheet links
 to `/css/<bundle>[.min].<hash>.css`, production adding `minify`,

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -80,9 +80,17 @@ media/state rule, or an overridden declaration still counts, and a class added b
 JavaScript is invisible to any static read.
 
 So the concept no longer proposes a check. Text search can prove a string is
-ABSENT from what a page loads; it cannot prove a selector applies. That routes to
-the section this file already had - computed style, not source, proves the paint -
-which was written for colour and turns out to be the general answer.
+ABSENT from what a page loads, and that is the only question it settles.
+
+A fourth round then split the remainder three ways, because routing everything to
+`getComputedStyle` was itself imprecise: **shipped** (search the loaded CSS),
+**matched** (CSSOM + `el.matches(rule.selectorText)`), and **won the paint**
+(`getComputedStyle`) are three questions with three instruments. Computed style
+cannot name WHICH selector produced a value - another matching rule with the same
+value is indistinguishable - so a green computed style is not proof that a
+specific rule applies, though it is routinely quoted as such. Both browser-side
+techniques were already in this concept; the entry now points at the right one
+per question instead of collapsing them.
 
 The process lesson: four rounds of patching a home-grown analyzer, each patch
 exposing the next hole, is the signal to delete the tool rather than fix it

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -50,45 +50,44 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
-## 2026-08-21 - CSS ships both inline and as a linked file; how to check what actually ships
+## 2026-08-21 - CSS ships both inline and as a linked file; text search cannot prove a selector applies
 
-Recorded in [architecture/css-pipeline.md](architecture/css-pipeline.md). Five
-wrong claims were caught in this entry across two codex review rounds on PR
-#537, every one verified before acceptance. Recording that count because the
-subject IS measurement error.
+Recorded in [architecture/css-pipeline.md](architecture/css-pipeline.md). Seven
+findings across three codex review rounds on PR #537, every one verified against
+the tree before acceptance. The count is the finding.
 
-The mechanism: `partials/assets/css-inline.html` emits `<style>` (production
-adds only `| minify`); `partials/assets/css-processor.html` emits preload +
-stylesheet links to `/css/<bundle>[.min].<hash>.css` (production adds `minify`,
-`resources.PostProcess`, and `integrity` on both links - `fingerprint "sha256"`
-runs in dev too). On the homepage: 3 `<style>` of which 2 are pipeline bundles,
-and 2 `link[rel=stylesheet]` of which one is a `<noscript>` swiper fallback.
+**The mechanism** (unchallenged across all three rounds):
+`partials/assets/css-inline.html` emits `<style>`, production adding only
+`| minify`; `partials/assets/css-processor.html` emits preload + stylesheet links
+to `/css/<bundle>[.min].<hash>.css`, production adding `minify`,
+`resources.PostProcess`, and `integrity` on both links (`fingerprint "sha256"`
+runs in dev too). Homepage: 3 `<style>` of which 2 are pipeline bundles, 2
+`link[rel=stylesheet]` of which one is a `<noscript>` swiper fallback.
 
-What was wrong, in order:
+**Three naive greps that lie**, each verified: grepping rendered `*.html` for a
+class matches the `class="..."` attribute (`c-nav` is on the homepage with zero
+matching CSS); grepping `_dest/*/css/*.css` alone misses everything inlined;
+counting `rel="stylesheet"` with `rg` scores 3 where a parser says 2, because one
+match is inside `<noscript>` and one is the preload polyfill's JavaScript.
 
-1. "3 and 3", counted by grepping raw HTML. A parser says 3 and **2** - the
-   extra `rel="stylesheet"` is the preload polyfill's JS, `this.rel="stylesheet"`.
-2. "production only adds the `.min` infix". It also runs `resources.PostProcess`
-   and adds `integrity` to both links.
-3. "grep the rendered `*.html`" to ask whether CSS ships - that matches the
-   `class="..."` attribute. `c-nav` is on the homepage with zero matching CSS.
-4. The replacement check used `String#scan` with a String argument, which
-   matches LITERALLY, so `'\.c-nav'` hunted for a backslash. Its own
-   known-present control read 0 and caught it.
-5. The fixed check still matched substrings, so `\.c-content-block` scored 1
-   purely from `.c-content-block__text`. Needs an identifier boundary:
-   `Regexp.new('\.' + Regexp.escape(cls) + '(?![\w-])')`.
+**What I got wrong, and why it stopped mattering.** Four successive attempts at a
+text-search check were each refuted by the next round: literal `String#scan`
+(`'\.c-nav'` hunting a backslash), substring prefixes (`\.c-content-block`
+scoring on `.c-content-block__text`), comments and URLs (`idangero` scoring 1
+from `http://www.idangero.us/swiper/` in the shipped Swiper CSS), and finally the
+one no regex fixes - a token in an unmatched contextual selector, an inactive
+media/state rule, or an overridden declaration still counts, and a class added by
+JavaScript is invisible to any static read.
 
-And the control itself was mislabelled: `.c-content-block__text` was called a
-selector "the page paints", but the homepage DOM has zero such elements - the
-rule is present only because `baseof.html` inlines the global components bundle
-for every page. A `rules` count proves the rule SHIPS, not that the page paints
-it. The honest control for painted-on-this-page is `fl-button` (89 rules, 5 DOM
-elements).
+So the concept no longer proposes a check. Text search can prove a string is
+ABSENT from what a page loads; it cannot prove a selector applies. That routes to
+the section this file already had - computed style, not source, proves the paint -
+which was written for colour and turns out to be the general answer.
 
-Hence the check reports TWO numbers. `rules>0 dom=0` is a shipped-but-unused
-rule; `rules=0 dom>0` is markup with no CSS, which is usually the defect being
-hunted; `0 0` is absent.
+The process lesson: four rounds of patching a home-grown analyzer, each patch
+exposing the next hole, is the signal to delete the tool rather than fix it
+again. The mechanism table survived every round untouched; only the invented
+instrument kept failing.
 
 ## 2026-08-21 - test the instrument, not just the result
 

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -52,8 +52,8 @@ time, which is verifiable - never invented).
 
 ## 2026-08-21 - CSS ships both inline and as a linked file; text search cannot prove a selector applies
 
-Recorded in [architecture/css-pipeline.md](architecture/css-pipeline.md). Seven
-findings across three codex review rounds on PR #537, every one verified against
+Recorded in [architecture/css-pipeline.md](architecture/css-pipeline.md). Eleven
+findings across five codex review rounds on PR #537, every one verified against
 the tree before acceptance. The count is the finding.
 
 **The mechanism** (unchallenged across all three rounds):
@@ -82,20 +82,22 @@ JavaScript is invisible to any static read.
 So the concept no longer proposes a check. Text search can prove a string is
 ABSENT from what a page loads, and that is the only question it settles.
 
-A fourth round then split the remainder three ways, because routing everything to
-`getComputedStyle` was itself imprecise: **shipped** (search the loaded CSS),
-**matched** (CSSOM + `el.matches(rule.selectorText)`), and **won the paint**
-(`getComputedStyle`) are three questions with three instruments. Computed style
-cannot name WHICH selector produced a value - another matching rule with the same
-value is indistinguishable - so a green computed style is not proof that a
-specific rule applies, though it is routinely quoted as such. Both browser-side
-techniques were already in this concept; the entry now points at the right one
-per question instead of collapsing them.
+Rounds four and five then rebuilt what replaced it. Routing everything to
+`getComputedStyle` was imprecise, and so was the three-row table that followed:
+reviews showed each row still overclaiming. The honest version is a five-rung
+ladder where every rung states what it does NOT establish - text search proves
+ABSENCE only (a hit can be a comment, a URL, or a longer selector prefix); a
+CSSOM rule scan proves a rule shipped, not that it can apply inside an inactive
+`@media`; `el.matches` proves the SELECTOR matches, not the rule; `getComputedStyle`
+proves the value that won the cascade, not which selector produced it nor what is
+visible under an overlay; only a pixel sample is a fact about the rendered page.
+Every one of those limitations is demonstrated somewhere in this same concept.
 
-The process lesson: four rounds of patching a home-grown analyzer, each patch
-exposing the next hole, is the signal to delete the tool rather than fix it
-again. The mechanism table survived every round untouched; only the invented
-instrument kept failing.
+The process lesson: the factual mechanism table survived all five rounds
+untouched. Everything that failed was prescriptive - an instrument I invented, or
+a promise about what an instrument establishes. Describing what the code does is
+cheap to get right; telling a future reader what a measurement PROVES is where
+the overclaiming lives, and it took five adversarial rounds to stop doing it.
 
 ## 2026-08-21 - test the instrument, not just the result
 

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -50,6 +50,30 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
+## 2026-08-21 - CSS ships BOTH inline and as a file under css/
+
+Recorded in [architecture/css-pipeline.md](architecture/css-pipeline.md). Found
+while verifying a codex finding on PR #536, and it corrects a belief this bundle
+was one commit away from recording as fact.
+
+A built page uses both delivery paths - measured on `_dest/public-test/index.html`:
+3 `<style>` tags AND 3 `<link rel="stylesheet">`.
+
+* `partials/assets/css-inline.html` emits `<style>`; its only
+  `if hugo.IsProduction` branch wraps `| minify`.
+* `partials/assets/css-processor.html` emits `preload` + `stylesheet` links to
+  `/css/<bundle>[.min].<hash>.css`; production only adds the `.min` infix.
+
+So `_dest/*/css/*.css` is a real population - a class absent there really is
+absent from the file-served bundles (`blog-eyebrow` returns 13 files in
+`public-dev` as the control). But it is only HALF the shipped CSS: inline
+`<style>` content never lands under `css/`, so "does this ship at all" has to be
+asked of the rendered `*.html`.
+
+The earlier claim that a `css/` grep is vacuous "because the CSS ships inline"
+was wrong in both directions - it ships inline AND as a file, and dev vs
+production changes filenames, not delivery.
+
 ## 2026-08-21 - test the instrument, not just the result
 
 Recorded in [build/test-gates.md](build/test-gates.md), distinct from the NULL

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -52,36 +52,43 @@ time, which is verifiable - never invented).
 
 ## 2026-08-21 - CSS ships both inline and as a linked file; how to check what actually ships
 
-Recorded in [architecture/css-pipeline.md](architecture/css-pipeline.md). The
-first draft of this entry was itself wrong in three ways, all caught by codex
-review of PR #537 and all verified before accepting.
+Recorded in [architecture/css-pipeline.md](architecture/css-pipeline.md). Five
+wrong claims were caught in this entry across two codex review rounds on PR
+#537, every one verified before acceptance. Recording that count because the
+subject IS measurement error.
 
 The mechanism: `partials/assets/css-inline.html` emits `<style>` (production
 adds only `| minify`); `partials/assets/css-processor.html` emits preload +
 stylesheet links to `/css/<bundle>[.min].<hash>.css` (production adds `minify`,
-`resources.PostProcess`, and an `integrity` attribute on both links -
-`fingerprint "sha256"` runs in dev too). On the homepage: 3 `<style>` of which
-2 are pipeline bundles, and 2 `link[rel=stylesheet]` of which one is a
-`<noscript>` swiper fallback.
+`resources.PostProcess`, and `integrity` on both links - `fingerprint "sha256"`
+runs in dev too). On the homepage: 3 `<style>` of which 2 are pipeline bundles,
+and 2 `link[rel=stylesheet]` of which one is a `<noscript>` swiper fallback.
 
-What the draft got wrong, and what replaced it:
+What was wrong, in order:
 
-* Counted "3 and 3" by grepping raw HTML. A parser says 3 and **2** - the extra
-  `rel="stylesheet"` match is the preload polyfill's JavaScript
-  (`this.rel="stylesheet"`). Counting tags with `rg` is a false positive.
-* Said production "only adds the `.min` infix". It also runs
-  `resources.PostProcess` and adds `integrity` to both links.
-* Recommended grepping the rendered `*.html` to ask whether CSS ships. That
-  matches the `class="..."` attribute in markup: `c-nav` is on the homepage with
-  **zero** matching CSS in anything that page loads.
+1. "3 and 3", counted by grepping raw HTML. A parser says 3 and **2** - the
+   extra `rel="stylesheet"` is the preload polyfill's JS, `this.rel="stylesheet"`.
+2. "production only adds the `.min` infix". It also runs `resources.PostProcess`
+   and adds `integrity` to both links.
+3. "grep the rendered `*.html`" to ask whether CSS ships - that matches the
+   `class="..."` attribute. `c-nav` is on the homepage with zero matching CSS.
+4. The replacement check used `String#scan` with a String argument, which
+   matches LITERALLY, so `'\.c-nav'` hunted for a backslash. Its own
+   known-present control read 0 and caught it.
+5. The fixed check still matched substrings, so `\.c-content-block` scored 1
+   purely from `.c-content-block__text`. Needs an identifier boundary:
+   `Regexp.new('\.' + Regexp.escape(cls) + '(?![\w-])')`.
 
-The check that does answer it: parse the page, concatenate every `<style>` text
-with the contents of every `link[rel=stylesheet]` href, search that blob, and
-control it in both directions (`.c-content-block__text` -> 1,
-`.zzz-not-a-class` -> 0). Ruby trap found while building it:
-`String#scan` with a String argument matches literally, so `'\.c-nav'` hunts for
-a backslash - the known-present control read 0 until it was wrapped in
-`Regexp.new`.
+And the control itself was mislabelled: `.c-content-block__text` was called a
+selector "the page paints", but the homepage DOM has zero such elements - the
+rule is present only because `baseof.html` inlines the global components bundle
+for every page. A `rules` count proves the rule SHIPS, not that the page paints
+it. The honest control for painted-on-this-page is `fl-button` (89 rules, 5 DOM
+elements).
+
+Hence the check reports TWO numbers. `rules>0 dom=0` is a shipped-but-unused
+rule; `rules=0 dom>0` is markup with no CSS, which is usually the defect being
+hunted; `0 0` is absent.
 
 ## 2026-08-21 - test the instrument, not just the result
 


### PR DESCRIPTION
## Review disposition (6 codex rounds, 13 findings)

**12 accepted and fixed, 1 declined with evidence.** Every accepted finding was reproduced against the tree before acceptance.

| Round | Finding | Outcome |
|---|---|---|
| 1 | "3 `<style>` and 3 `<link>`" counted by grepping raw HTML | fixed — a parser says 3 and **2**; one match is `<noscript>`, one is the preload polyfill's `this.rel="stylesheet"` |
| 1 | "production only adds the `.min` infix" | fixed — also `resources.PostProcess` + `integrity` on both links |
| 1 | "grep the rendered `*.html`" to test whether CSS ships | fixed — matches the `class=` attribute; `c-nav` is on the homepage with **zero** matching CSS |
| 2 | check matched substrings | fixed — `\.c-content-block` scored 1 purely from `.c-content-block__text` |
| 2 | control mislabelled as "the page paints" | fixed — homepage DOM has **0** such elements; the rule ships via `baseof.html`'s global bundle |
| 3 | regexp counted comments and URLs | fixed — `idangero` scored 1 from `http://www.idangero.us/swiper/` |
| 3 | token counts ≠ paint | **check deleted** rather than patched a 4th time |
| 4 | `getComputedStyle` conflated with selector matching | fixed — split ship / match / win |
| 5 | text search can't prove a rule shipped | fixed — restated as **absence-only** evidence |
| 5 | `el.matches` true inside inactive `@media` | fixed — selector ≠ rule |
| 5 | computed style ≠ painted pixels | fixed — added the pixel-sample rung |
| 6 | stale "three rounds" vs the entry's five | fixed |
| 6 | rewrite `generated.by` to this session | **declined**, below |

### The declined finding

Asked to set `generated.by: claude/opus-5` on `css-pipeline.md`. The diagnosis is fair — new authorship recorded only under `verified` is imprecise — but the prescription makes a worse claim and breaks the bundle-wide convention:

```
architecture/hugo-site.md       generated: process:okf-migrate  2026-07-12
architecture/blog-list-page.md  generated: process:okf-migrate  2026-07-12
build/test-gates.md             generated: claude/opus-4-8      2026-08-12
                                + 7 later `verified` entries from sessions
                                  that added content
```

`generated` records who first produced the file; `verified` records who has touched it since. Setting it to me would claim I wrote the FL-Builder section, the token layer, and the white-wash trap. That's the overclaiming this PR spent five rounds removing from the body — it isn't going into the frontmatter. If the convention should change, that's a bundle-wide PR.

## What survived

The **mechanism table was unchallenged in all six rounds.** Everything that failed was *prescriptive* — an instrument I invented, or a promise about what an instrument establishes.

| Instrument | Establishes | Does NOT establish |
|---|---|---|
| text search over loaded CSS | **absence only** | presence — comments, URLs, selector prefixes |
| CSSOM rule scan | a rule with that `selectorText` shipped | that it can apply (inactive `@media`) |
| `el.matches(selectorText)` | the **selector** matches | the **rule** applies, or that it won |
| `getComputedStyle` | the value that won the cascade | which selector produced it, or what's visible under an overlay |
| screenshot + pixel sample | what was painted | why |

Only the last is a fact about the rendered page.

## Gates

`okf_validate .okf` exits **0**, conformant; `--strict` exits **1** by design. Every edit verified with positive *and* negative controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
