### PR TITLE
OKF: what survives adversarial review, and when to stop patching

### DIFF
--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -6,6 +6,7 @@ tags: [testing, visual-regression, gates]
 status: stable
 generated: { by: claude/opus-4-8, at: 2026-08-12T20:20:00Z }
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T05:06:54Z }
   - { by: claude/opus-5, at: 2026-08-21T04:01:38Z }
   - { by: claude/opus-5, at: 2026-08-21T03:27:09Z }
   - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
@@ -13,7 +14,7 @@ verified:
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
   - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
-timestamp: 2026-08-21T04:01:38Z
+timestamp: 2026-08-21T05:06:54Z
 ---
 
 # The suites
@@ -298,8 +299,11 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
 
 A third instance, 2026-08-21: two identical `verified` entries looked like a
 duplication artifact, and `git log -S <timestamp>` returned exactly ONE
-commit - read as proof one commit emitted both. `-S` counts when a string
-first appears, not how many events a line represents. The parent commit held
+commit - read as proof one commit emitted both. `-S` selects every commit that
+CHANGES a string`s occurrence count - additions, removals, deduplications,
+reintroductions - so ONE hit means one net count change, not one event, and
+later edits change the answer (the same search now returns three commits, two
+of them mine). The parent commit held
 two DISTINCT entries that a timestamp-repair commit had normalised, so the
 "duplicate" was a real verification and deleting it destroyed provenance.
 Positive control that would have caught it in one command: read the file at

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -4,9 +4,9 @@ title: Test gates and when they block commits
 description: bin/qtest --changed is the routine gate; bin/rake test:critical at milestones; bin/test AND bin/dtest once at PR prep (or on explicit confirmation) for themes/, layouts/, or CSS changes.
 tags: [testing, visual-regression, gates]
 status: stable
-generated: { by: claude/opus-5, at: 2026-08-21T05:15:00Z }
+generated: { by: claude/opus-5, at: 2026-08-21T05:22:29Z }
 verified:
-  - { by: claude/opus-5, at: 2026-08-21T05:06:54Z }
+  - { by: claude/opus-5, at: 2026-08-21T05:22:29Z }
   - { by: claude/opus-5, at: 2026-08-21T04:01:38Z }
   - { by: claude/opus-5, at: 2026-08-21T03:27:09Z }
   - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
@@ -14,7 +14,7 @@ verified:
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
   - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
-timestamp: 2026-08-21T05:06:54Z
+timestamp: 2026-08-21T05:22:29Z
 ---
 
 # The suites

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -4,9 +4,9 @@ title: Test gates and when they block commits
 description: bin/qtest --changed is the routine gate; bin/rake test:critical at milestones; bin/test AND bin/dtest once at PR prep (or on explicit confirmation) for themes/, layouts/, or CSS changes.
 tags: [testing, visual-regression, gates]
 status: stable
-generated: { by: claude/opus-5, at: 2026-08-21T05:22:29Z }
+generated: { by: claude/opus-5, at: 2026-08-21T05:33:58Z }
 verified:
-  - { by: claude/opus-5, at: 2026-08-21T05:22:29Z }
+  - { by: claude/opus-5, at: 2026-08-21T05:33:58Z }
   - { by: claude/opus-5, at: 2026-08-21T04:01:38Z }
   - { by: claude/opus-5, at: 2026-08-21T03:27:09Z }
   - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
@@ -14,7 +14,7 @@ verified:
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
   - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
-timestamp: 2026-08-21T05:22:29Z
+timestamp: 2026-08-21T05:33:58Z
 ---
 
 # The suites

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -296,6 +296,15 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
     then grep; same reason `marketing_copy_test` misses banned phrases split
     across two template lines.
 
+A third instance, 2026-08-21: two identical `verified` entries looked like a
+duplication artifact, and `git log -S <timestamp>` returned exactly ONE
+commit - read as proof one commit emitted both. `-S` counts when a string
+first appears, not how many events a line represents. The parent commit held
+two DISTINCT entries that a timestamp-repair commit had normalised, so the
+"duplicate" was a real verification and deleting it destroyed provenance.
+Positive control that would have caught it in one command: read the file at
+the parent commit.
+
 - **An empty query result is not evidence of absence** (2026-08-21). Hunting a
   black band on `/services/`, `document.querySelectorAll('path.fl-shape')`
   returned `[]`. That read as "no shape layer on this page" and an entire

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -4,7 +4,7 @@ title: Test gates and when they block commits
 description: bin/qtest --changed is the routine gate; bin/rake test:critical at milestones; bin/test AND bin/dtest once at PR prep (or on explicit confirmation) for themes/, layouts/, or CSS changes.
 tags: [testing, visual-regression, gates]
 status: stable
-generated: { by: claude/opus-4-8, at: 2026-08-12T20:20:00Z }
+generated: { by: claude/opus-5, at: 2026-08-21T05:15:00Z }
 verified:
   - { by: claude/opus-5, at: 2026-08-21T05:06:54Z }
   - { by: claude/opus-5, at: 2026-08-21T04:01:38Z }

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -301,9 +301,10 @@ A third instance, 2026-08-21: two identical `verified` entries looked like a
 duplication artifact, and `git log -S <timestamp>` returned exactly ONE
 commit - read as proof one commit emitted both. `-S` selects every commit that
 CHANGES a string`s occurrence count - additions, removals, deduplications,
-reintroductions - so ONE hit means one net count change, not one event, and
-later edits change the answer (the same search now returns three commits, two
-of them mine). The parent commit held
+reintroductions - so ONE hit means one net count change, not one event. Do not
+freeze such a count into prose either: the number this file first recorded was
+stale within the same PR, because the commits fixing the entry changed the
+occurrence count the entry was citing. The parent commit held
 two DISTINCT entries that a timestamp-repair commit had normalised, so the
 "duplicate" was a real verification and deleting it destroyed provenance.
 Positive control that would have caught it in one command: read the file at

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -90,14 +90,17 @@ two DISTINCT entries, `00:10:00Z` and `00:50:00Z`; e046 was a timestamp-repair
 commit that normalised both to one value. Deleting one destroyed a real
 verification event.
 
-`git log -S` answers "when did this string first appear", not "how many events
-does this line represent" - a neighbouring question accepted as the answer,
-which is exactly what this entry is about. Both entries are restored at their
-originally-recorded times. Those values are themselves suspect (round-number
-seconds mean they were composed, not measured, which is what e046 was repairing)
-but the number of events is the reliable fact, and the root index is explicit:
-keep BOTH, because dropping one falsifies the provenance the field exists to
-carry.
+`git log -S` selects every commit that CHANGES a string`s occurrence count, so
+one hit means one net count change, not one event - a neighbouring question accepted as the answer,
+which is exactly what this entry is about. Both entries are restored, and CONVERTED
+rather than restored verbatim: the recorded 00:10:00Z / 00:50:00Z were local time
+carrying a `Z`, and the offset in force then was +03:00 (recoverable from
+e046adc54`s own commit stamp), so they land at 2026-08-20T21:10:00Z and
+21:50:00Z. Restoring the future-dated originals would have re-created the exact
+harm the root index warns about - a stamp ~2h ahead silently outranks a genuinely
+newer concurrent edit, because conflicts resolve by taking the later timestamp.
+The root index is explicit that both events stay: dropping one falsifies the
+provenance the field exists to carry.
 
 ## 2026-08-21 - CSS ships both inline and as a linked file; text search cannot prove a selector applies
 

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -74,9 +74,11 @@ part. Prefer description; if a check must be documented, write what it does NOT
 establish in the same breath.
 
 Two companions recorded with it: round three on a home-grown instrument is the
-signal to DELETE it rather than patch it again (each of the four patches was
-individually correct and each exposed the next hole, while the honest version
-was far shorter and routed to a method the file already carried); and verify a citation
+signal to DELETE it rather than patch it again - which is what happened, in
+7ae28566e. Worth separating from what followed: the instrument died in round
+three, but the PROSE describing what instruments prove kept failing for two more
+rounds (88a87b322, d07cd3428). Deleting the tool does not end the problem it
+came from; and verify a citation
 against the artifact it CITES. The finding I declined twice was right twice: it
 asked to update `generated` for current content, citing canonical OKF §5.2. I read
 §5.2 as "Relative links" and called it miscited - but that was an older v0.1 copy
@@ -97,8 +99,10 @@ verification event.
 
 `git log -S` selects every commit that CHANGES a string`s occurrence count, so
 one hit means one net count change, not one event - a neighbouring question accepted as the answer,
-which is exactly what this entry is about. Both entries are restored, at the single MEASURED
-value e046adc54 chose - which is to say the pre-dedup state exactly.
+which is exactly what this entry is about. Both entries are restored, each ANCHORED to the
+commit that landed it: 8fa41494b (2026-08-20T22:27:35Z) and 86c2c91cc
+(23:11:35Z). Commit instants are measured facts, so this keeps two events, keeps
+their order, and invents nothing.
 
 A first repair attempt converted them by -3h, reading +03:00 off git commit
 stamps. Review refuted that too: e046adc54 records that the session clock was
@@ -109,10 +113,12 @@ fabricated precise-looking numbers out of invented ones. The root index allows
 exactly two moves - convert with a recoverable offset, or mark unknown - and only
 the second applies here.
 
-The two entries are therefore identical ON PURPOSE: two real checks whose
-individual times are unrecoverable. A YAML comment now sits above them saying so,
-because the identical pair is what made them look like an artifact in the first
-place - the note is the fix that stops the next session repeating my mistake.
+A second attempt then flattened both to one measured value, which review caught
+as the same order-destroying move under a new name. The resolution that actually
+holds was already in this repo`s history and I had to be walked back to it twice:
+anchor each entry to the commit that landed it. A YAML comment now records the
+anchors, because an identical-looking pair is what made me delete one in the
+first place.
 
 ## 2026-08-21 - CSS ships both inline and as a linked file; text search cannot prove a selector applies
 

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -61,9 +61,10 @@ The factual content - which partial emits what, what production adds - was
 corrected ONCE, in round one (a stylesheet-link count of three that a parser put
 at two; "production only adds `.min`" which also runs `resources.PostProcess`
 and adds `integrity`), and then stood unchallenged through rounds two to six.
-Every failure after round one was a claim about what a MEASUREMENT establishes.
-Descriptive claims converge in about one round; prescriptive ones took five and
-then had to be deleted. Four successive text-search checks were
+Not every later finding was about measurement - round six caught a stale round
+count - but every finding that forced a REWRITE rather than a word was. Budget
+roughly one round for what the code does, and several for anything you claim a
+check proves. Four successive text-search checks were
 refuted in turn: literal `String#scan`, substring prefixes, comments and URLs,
 then semantics no regex fixes.
 
@@ -75,11 +76,15 @@ establish in the same breath.
 Two companions recorded with it: round three on a home-grown instrument is the
 signal to DELETE it rather than patch it again (each of the four patches was
 individually correct and each exposed the next hole, while the honest version
-was far shorter and routed to a method the file already carried); and a fair
-diagnosis can carry an overclaiming prescription, so check the two halves
-separately - the one finding declined on #537 correctly identified imprecise
-authorship recording but proposed a fix that would have claimed authorship of
-sections written by others.
+was far shorter and routed to a method the file already carried); and verify a citation
+against the artifact it CITES. The finding I declined twice was right twice: it
+asked to update `generated` for current content, citing canonical OKF §5.2. I read
+§5.2 as "Relative links" and called it miscited - but that was an older v0.1 copy
+in a plugin cache. In `~/.agents/skills/okf/reference/SPEC.md`, §5.2 IS "Trust:
+`generated` and `verified`", stating that `generated` records how the CURRENT
+content was produced and `generated.at` marks its last meaningful change. Two spec
+versions on one machine, section numbers disagreeing. `generated` is now updated
+on both concepts this PR rewrote.
 
 **A dedup in this same concept was wrong and has been reverted** - the sharpest
 instance yet of the rule above. Two byte-identical `verified` entries
@@ -92,15 +97,22 @@ verification event.
 
 `git log -S` selects every commit that CHANGES a string`s occurrence count, so
 one hit means one net count change, not one event - a neighbouring question accepted as the answer,
-which is exactly what this entry is about. Both entries are restored, and CONVERTED
-rather than restored verbatim: the recorded 00:10:00Z / 00:50:00Z were local time
-carrying a `Z`, and the offset in force then was +03:00 (recoverable from
-e046adc54`s own commit stamp), so they land at 2026-08-20T21:10:00Z and
-21:50:00Z. Restoring the future-dated originals would have re-created the exact
-harm the root index warns about - a stamp ~2h ahead silently outranks a genuinely
-newer concurrent edit, because conflicts resolve by taking the later timestamp.
-The root index is explicit that both events stay: dropping one falsifies the
-provenance the field exists to carry.
+which is exactly what this entry is about. Both entries are restored, at the single MEASURED
+value e046adc54 chose - which is to say the pre-dedup state exactly.
+
+A first repair attempt converted them by -3h, reading +03:00 off git commit
+stamps. Review refuted that too: e046adc54 records that the session clock was
++0200, that its own converted values `were never MEASURED - I derived them by
+subtracting two hours from times I had invented`, and that the originating
+offsets are not uniform. So no offset recovers those times, and converting
+fabricated precise-looking numbers out of invented ones. The root index allows
+exactly two moves - convert with a recoverable offset, or mark unknown - and only
+the second applies here.
+
+The two entries are therefore identical ON PURPOSE: two real checks whose
+individual times are unrecoverable. A YAML comment now sits above them saying so,
+because the identical pair is what made them look like an artifact in the first
+place - the note is the fix that stops the next session repeating my mistake.
 
 ## 2026-08-21 - CSS ships both inline and as a linked file; text search cannot prove a selector applies
 

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -57,9 +57,13 @@ failure modes, extending the existing "docs review converges slowly" entry with
 WHICH sentences converge slowly.
 
 Six codex rounds on the bundle-only PR #537 returned 13 findings, 12 accepted.
-The split was clean: the factual content - which partial emits what, what
-production adds - was unchallenged in all six rounds. Every failure was a claim
-about what a MEASUREMENT establishes. Four successive text-search checks were
+The factual content - which partial emits what, what production adds - was
+corrected ONCE, in round one (a stylesheet-link count of three that a parser put
+at two; "production only adds `.min`" which also runs `resources.PostProcess`
+and adds `integrity`), and then stood unchallenged through rounds two to six.
+Every failure after round one was a claim about what a MEASUREMENT establishes.
+Descriptive claims converge in about one round; prescriptive ones took five and
+then had to be deleted. Four successive text-search checks were
 refuted in turn: literal `String#scan`, substring prefixes, comments and URLs,
 then semantics no regex fixes.
 
@@ -77,11 +81,23 @@ separately - the one finding declined on #537 correctly identified imprecise
 authorship recording but proposed a fix that would have claimed authorship of
 sections written by others.
 
-Also deduplicated a `verified` entry in the same concept. Two byte-identical
-entries (`claude/opus-5`, `2026-08-20T23:11:35Z`) were added by a SINGLE commit
-(e046adc54), so they cannot be the concurrent-verification case the root index
-protects with "keep BOTH entries" - that rule covers two sessions producing
-DIFFERENT entries. One commit is one verification.
+**A dedup in this same concept was wrong and has been reverted** - the sharpest
+instance yet of the rule above. Two byte-identical `verified` entries
+(`claude/opus-5`, `2026-08-20T23:11:35Z`) looked like a duplication artifact, and
+`git log -S` on that timestamp returned exactly one commit (`e046adc54`), which
+read as proof that one commit had emitted both. It was not. `e046adc54^` carries
+two DISTINCT entries, `00:10:00Z` and `00:50:00Z`; e046 was a timestamp-repair
+commit that normalised both to one value. Deleting one destroyed a real
+verification event.
+
+`git log -S` answers "when did this string first appear", not "how many events
+does this line represent" - a neighbouring question accepted as the answer,
+which is exactly what this entry is about. Both entries are restored at their
+originally-recorded times. Those values are themselves suspect (round-number
+seconds mean they were composed, not measured, which is what e046 was repairing)
+but the number of events is the reliable fact, and the root index is explicit:
+keep BOTH, because dropping one falsifies the provenance the field exists to
+carry.
 
 ## 2026-08-21 - CSS ships both inline and as a linked file; text search cannot prove a selector applies
 

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -99,8 +99,8 @@ verification event.
 
 `git log -S` selects every commit that CHANGES a string`s occurrence count, so
 one hit means one net count change, not one event - a neighbouring question accepted as the answer,
-which is exactly what this entry is about. Both entries are restored with their times marked
-UNKNOWN - `at` omitted rather than guessed.
+which is exactly what this entry is about. Neither entry is restored to the frontmatter, and
+that is the honest end of it.
 
 A first repair attempt converted them by -3h, reading +03:00 off git commit
 stamps. Review refuted that too: e046adc54 records that the session clock was
@@ -118,11 +118,22 @@ last is the closest, and still wrong for a reason worth keeping: a commit instan
 records when TEXT LANDED, not when the check ran. Every attempt was an effort to
 produce a number, and the honest answer was that there isn`t one.
 
-The root index already said it - convert with a recoverable offset, or mark
-unknown - and only the second branch ever applied. `at` is optional in the spec
-and consumers must tolerate its absence, so omitting it IS the encoding for
-unknown. A YAML comment carries the reasoning and the bounding commits, because
-an identical-looking pair is what made me delete one in the first place.
+Omitting `at` was the fifth attempt and also failed: OKF v0.2 defines a
+`verified` event as `{ by, at }`, so an entry without a time is malformed, not
+unknown. The trust family as a whole is optional; the fields inside an event are
+not.
+
+So the two checks are recorded HERE, in prose, and not in the frontmatter: they
+happened, they landed in 8fa41494b and 86c2c91cc, and their times are
+unrecoverable. A schema that requires a timestamp cannot represent an event
+without one, and the correct response to that is to stop trying to encode it
+rather than to encode it falsely. A YAML comment in the concept points here so
+the absence reads as deliberate.
+
+The whole sub-thread cost six attempts over two metadata entries on one concept.
+Worth naming as its own lesson: when a fix has failed five times, the question to
+ask is not "what is the sixth encoding" but "does this belong in this field at
+all".
 
 ## 2026-08-21 - CSS ships both inline and as a linked file; text search cannot prove a selector applies
 

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -50,6 +50,39 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
+## 2026-08-21 - what survives adversarial review, and when to stop patching
+
+Added to [workflows/review-swarm.md](workflows/review-swarm.md) under Known
+failure modes, extending the existing "docs review converges slowly" entry with
+WHICH sentences converge slowly.
+
+Six codex rounds on the bundle-only PR #537 returned 13 findings, 12 accepted.
+The split was clean: the factual content - which partial emits what, what
+production adds - was unchallenged in all six rounds. Every failure was a claim
+about what a MEASUREMENT establishes. Four successive text-search checks were
+refuted in turn: literal `String#scan`, substring prefixes, comments and URLs,
+then semantics no regex fixes.
+
+"X emits Y" is checkable against X. "Run Z to prove Y" smuggles in an unstated
+universal - no other path produces this result - and that is the falsifiable
+part. Prefer description; if a check must be documented, write what it does NOT
+establish in the same breath.
+
+Two companions recorded with it: round three on a home-grown instrument is the
+signal to DELETE it rather than patch it again (each of the four patches was
+individually correct and each exposed the next hole, while the honest version
+was far shorter and routed to a method the file already carried); and a fair
+diagnosis can carry an overclaiming prescription, so check the two halves
+separately - the one finding declined on #537 correctly identified imprecise
+authorship recording but proposed a fix that would have claimed authorship of
+sections written by others.
+
+Also deduplicated a `verified` entry in the same concept. Two byte-identical
+entries (`claude/opus-5`, `2026-08-20T23:11:35Z`) were added by a SINGLE commit
+(e046adc54), so they cannot be the concurrent-verification case the root index
+protects with "keep BOTH entries" - that rule covers two sessions producing
+DIFFERENT entries. One commit is one verification.
+
 ## 2026-08-21 - CSS ships both inline and as a linked file; text search cannot prove a selector applies
 
 Recorded in [architecture/css-pipeline.md](architecture/css-pipeline.md). Eleven

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -99,10 +99,8 @@ verification event.
 
 `git log -S` selects every commit that CHANGES a string`s occurrence count, so
 one hit means one net count change, not one event - a neighbouring question accepted as the answer,
-which is exactly what this entry is about. Both entries are restored, each ANCHORED to the
-commit that landed it: 8fa41494b (2026-08-20T22:27:35Z) and 86c2c91cc
-(23:11:35Z). Commit instants are measured facts, so this keeps two events, keeps
-their order, and invents nothing.
+which is exactly what this entry is about. Both entries are restored with their times marked
+UNKNOWN - `at` omitted rather than guessed.
 
 A first repair attempt converted them by -3h, reading +03:00 off git commit
 stamps. Review refuted that too: e046adc54 records that the session clock was
@@ -113,12 +111,18 @@ fabricated precise-looking numbers out of invented ones. The root index allows
 exactly two moves - convert with a recoverable offset, or mark unknown - and only
 the second applies here.
 
-A second attempt then flattened both to one measured value, which review caught
-as the same order-destroying move under a new name. The resolution that actually
-holds was already in this repo`s history and I had to be walked back to it twice:
-anchor each entry to the commit that landed it. A YAML comment now records the
-anchors, because an identical-looking pair is what made me delete one in the
-first place.
+It took four wrong answers to get there. Delete one as a duplicate; convert by an
+offset read off the wrong commits; flatten both to one measured value (the same
+order-destroying move under a new name); anchor each to its landing commit. The
+last is the closest, and still wrong for a reason worth keeping: a commit instant
+records when TEXT LANDED, not when the check ran. Every attempt was an effort to
+produce a number, and the honest answer was that there isn`t one.
+
+The root index already said it - convert with a recoverable offset, or mark
+unknown - and only the second branch ever applied. `at` is optional in the spec
+and consumers must tolerate its absence, so omitting it IS the encoding for
+unknown. A YAML comment carries the reasoning and the bounding commits, because
+an identical-looking pair is what made me delete one in the first place.
 
 ## 2026-08-21 - CSS ships both inline and as a linked file; text search cannot prove a selector applies
 

--- a/.okf/workflows/index.md
+++ b/.okf/workflows/index.md
@@ -3,7 +3,7 @@
 * [Company-layer ownership](company-layer-ownership.md) - vault owns ALL operations (loop, pipeline, runbook; re-settled 2026-08-20), repo owns growth/marketing campaigns, claims canon owns the facts
 * [Render verification](render-verification.md) - headless Chrome + slicing recipes for the visual scroll gate
 * [Autonomous loops](autonomous-loops.md) - ralph-loop fits verifiable work with known-correct scope; it can iterate but cannot re-scope, and only a true promise or the human ends it
-* [Review swarm](review-swarm.md) - the two-critic review pattern, its failure modes, and the /stitch-design design-review route with the surface-to-design-source table
+* [Review swarm](review-swarm.md) - the two-critic review pattern, its failure modes, and the `/impeccable critique` design-review route with the surface-to-design-source table (stitch GENERATES, it does not review)
 * [Blog Post Pipeline](blog-pipeline.md) - mandatory end-to-end workflow for writing/publishing blog posts, plus the execute-don't-read claims gate, the frontmatter claims check, and the `## Sources` citation convention
 * [LinkedIn Post Pipeline](linkedin-post-pipeline.md) - Paul Keen voice rules and posting workflow
 * [CSS Maintainability Redesign](css-maintainability-plan.md) - approved plan for hand-editable CSS + FL-Builder retirement

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -8,10 +8,12 @@ generated:
   at: 2026-08-21T05:22:29Z
 verified:
   - { by: claude/opus-5, at: 2026-08-21T05:22:29Z }
-  # The two below are anchored to the commits that LANDED them (8fa41494b and
-  # 86c2c91cc) - measured instants, not the invented originals. Two real checks.
-  - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
-  - { by: claude/opus-5, at: 2026-08-20T22:27:35Z }
+  # Two real checks whose times are UNKNOWN. The originals were invented, no
+  # offset recovers them, and a commit instant records when text landed, not
+  # when the check ran - so `at` is omitted rather than guessed. They landed in
+  # 8fa41494b and 86c2c91cc if a bound is ever needed. Do NOT dedup them.
+  - { by: claude/opus-5 }
+  - { by: claude/opus-5 }
 timestamp: 2026-08-21T05:22:29Z
 ---
 

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -8,7 +8,8 @@ generated:
   at: 2026-07-24T00:00:00Z
 verified:
   - { by: claude/opus-5, at: 2026-08-21T04:52:57Z }
-  - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
+  - { by: claude/opus-5, at: 2026-08-21T00:50:00Z }
+  - { by: claude/opus-5, at: 2026-08-21T00:10:00Z }
 timestamp: 2026-08-21T04:52:57Z
 ---
 
@@ -264,11 +265,17 @@ verdict format, and the two or three specific things to attack.
   compiler and no test, so the ONLY gate is a reader who checks claims against
   the tree. One clean round is the signal to stop; one round is not.
 
-- **Descriptive claims survive review; PRESCRIPTIVE ones fail** (2026-08-21).
+- **Descriptive claims converge fast; PRESCRIPTIVE ones fail for rounds** (2026-08-21).
   Six codex rounds on one bundle-only PR (#537) returned 13 findings, 12
-  accepted. The split was clean: the *factual* content - which partial emits
-  what, what production adds - was unchallenged in all six rounds. Every single
-  failure was a claim about what a MEASUREMENT establishes. Four successive
+  accepted. The factual content - which partial emits what, what production
+  adds - was corrected ONCE, in round one (a stylesheet-link count of three that
+  a parser put at two; "production only adds `.min`" that also runs
+  `resources.PostProcess` and adds `integrity`), and then stood unchallenged
+  through rounds two to six. Every failure after round one was a claim about
+  what a MEASUREMENT establishes.
+
+  That is the shape worth planning around: descriptive claims converge in about
+  one round, prescriptive ones took five and then had to be deleted. Four successive
   text-search checks were each refuted in turn: literal `String#scan`
   (`'\.c-nav'` hunting a backslash), substring prefixes (`\.c-content-block`
   scoring on `.c-content-block__text`), comments and URLs (`idangero` scoring 1

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -4,12 +4,15 @@ title: Two-critic review swarm
 description: The proven module-review loop - a design critic (full render walk) plus a content-canon critic, followed by verified fixer waves.
 tags: [swarm, review, process]
 generated:
-  by: process:okf-migrate
-  at: 2026-07-24T00:00:00Z
+  by: claude/opus-5
+  at: 2026-08-21T05:15:00Z
 verified:
   - { by: claude/opus-5, at: 2026-08-21T04:52:57Z }
-  - { by: claude/opus-5, at: 2026-08-20T21:50:00Z }
-  - { by: claude/opus-5, at: 2026-08-20T21:10:00Z }
+  # The pair below is TWO real checks whose individual times are unrecoverable
+  # (e046adc54: the originals were invented, offsets not uniform). They are
+  # identical on purpose - do NOT dedup them. See log 2026-08-21.
+  - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
+  - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
 timestamp: 2026-08-21T04:52:57Z
 ---
 
@@ -271,11 +274,15 @@ verdict format, and the two or three specific things to attack.
   adds - was corrected ONCE, in round one (a stylesheet-link count of three that
   a parser put at two; "production only adds `.min`" that also runs
   `resources.PostProcess` and adds `integrity`), and then stood unchallenged
-  through rounds two to six. Every failure after round one was a claim about
-  what a MEASUREMENT establishes.
+  through rounds two to six, while the INVENTED INSTRUMENT in the same file was
+  refuted five times running and finally deleted. Not every later finding was
+  about measurement - round six caught a stale round count - but every finding
+  that forced a rewrite rather than a word was.
 
-  That is the shape worth planning around: descriptive claims converge in about
-  one round, prescriptive ones took five and then had to be deleted. Four successive
+  The planning shape: budget roughly one round for what the code does, and
+  several for anything you claim a check PROVES. If you are on round three of
+  patching an instrument you invented, delete it and route to a method that
+  already exists. Four successive
   text-search checks were each refuted in turn: literal `String#scan`
   (`'\.c-nav'` hunting a backslash), substring prefixes (`\.c-content-block`
   scoring on `.c-content-block__text`), comments and URLs (`idangero` scoring 1
@@ -296,11 +303,23 @@ verdict format, and the two or three specific things to attack.
   this hard to stop. If the tool is invented rather than the subject, the third
   round is the signal.
 
-- **A fair diagnosis can carry an overclaiming prescription - decline that half**
-  (2026-08-21). The one finding rejected on #537 asked to rewrite
-  `generated.by` to the editing session. The diagnosis (new authorship recorded
-  only under `verified` is imprecise) was fair; the fix would have claimed
-  authorship of sections written by others, and contradicted the convention
-  every other concept follows - `generated` = who first produced the file,
-  `verified` = who actually REVALIDATED its content (an ordinary edit is not a verification). Check the prescription against the tree
-  separately from the diagnosis, and record the disposition with its evidence.
+- **Verify a citation against the artifact it CITES, not a copy you happen to
+  have** (2026-08-21). The same finding was declined twice on #537/#538 and was
+  right both times. It asked to update `generated` for current content; I
+  checked "canonical OKF §5.2", found "Relative links", and declined it as
+  miscited. The reviewer was reading `~/.agents/skills/okf/reference/SPEC.md`,
+  where §5.2 IS "Trust: `generated` and `verified`" and states plainly that
+  `generated` records how the CURRENT content was produced and `generated.at`
+  marks its last meaningful change. I was reading an older v0.1 copy in a plugin
+  cache that never defines the fields at all.
+
+  Two versions of a spec on one machine, and the section numbers do not agree.
+  "Not reproducible as cited" is a claim about the reviewer that needs the same
+  evidence as any other - resolve the path first. The correct semantics are now
+  applied: `generated` = how the current content was produced, `verified` = who
+  actually REVALIDATED it (an ordinary edit is not a verification).
+
+  The general form still holds - a fair diagnosis can carry an overclaiming
+  prescription, so check the halves separately - but this was not an instance of
+  it. It was an instance of checking the wrong file twice and calling it
+  evidence.

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -7,9 +7,9 @@ generated:
   by: process:okf-migrate
   at: 2026-07-24T00:00:00Z
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T04:52:57Z }
   - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
-  - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
-timestamp: 2026-08-21T00:41:51Z
+timestamp: 2026-08-21T04:52:57Z
 ---
 
 # The loop
@@ -263,3 +263,37 @@ verdict format, and the two or three specific things to attack.
   error in a measurement plan, an overstated bot multiplier. Prose has no
   compiler and no test, so the ONLY gate is a reader who checks claims against
   the tree. One clean round is the signal to stop; one round is not.
+
+- **Descriptive claims survive review; PRESCRIPTIVE ones fail** (2026-08-21).
+  Six codex rounds on one bundle-only PR (#537) returned 13 findings, 12
+  accepted. The split was clean: the *factual* content - which partial emits
+  what, what production adds - was unchallenged in all six rounds. Every single
+  failure was a claim about what a MEASUREMENT establishes. Four successive
+  text-search checks were each refuted in turn: literal `String#scan`
+  (`'\.c-nav'` hunting a backslash), substring prefixes (`\.c-content-block`
+  scoring on `.c-content-block__text`), comments and URLs (`idangero` scoring 1
+  from a Swiper URL), then semantics no regex fixes.
+
+  "X emits Y" is checkable against X. "Run Z to prove Y" smuggles in an unstated
+  universal - *no other path produces this result* - and that is the falsifiable
+  part. So when writing durable guidance, prefer description; if a check must be
+  documented, write what it does NOT establish in the same breath. Extends
+  "docs review converges slowly" above by saying WHICH sentences will converge
+  slowly.
+
+- **Round three on a home-grown instrument means DELETE it, not patch it**
+  (2026-08-21). Each of the four patches above was individually correct and each
+  exposed the next hole; the honest version turned out to be much shorter than
+  the one being defended, and routed to a method the same file already carried.
+  A patch that fixes a real finding still reads as progress, which is what makes
+  this hard to stop. If the tool is invented rather than the subject, the third
+  round is the signal.
+
+- **A fair diagnosis can carry an overclaiming prescription - decline that half**
+  (2026-08-21). The one finding rejected on #537 asked to rewrite
+  `generated.by` to the editing session. The diagnosis (new authorship recorded
+  only under `verified` is imprecise) was fair; the fix would have claimed
+  authorship of sections written by others, and contradicted the convention
+  every other concept follows - `generated` = who first produced the file,
+  `verified` = who touched it since. Check the prescription against the tree
+  separately from the diagnosis, and record the disposition with its evidence.

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -5,15 +5,14 @@ description: The proven module-review loop - a design critic (full render walk) 
 tags: [swarm, review, process]
 generated:
   by: claude/opus-5
-  at: 2026-08-21T05:15:00Z
+  at: 2026-08-21T05:22:29Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-21T04:52:57Z }
-  # The pair below is TWO real checks whose individual times are unrecoverable
-  # (e046adc54: the originals were invented, offsets not uniform). They are
-  # identical on purpose - do NOT dedup them. See log 2026-08-21.
+  - { by: claude/opus-5, at: 2026-08-21T05:22:29Z }
+  # The two below are anchored to the commits that LANDED them (8fa41494b and
+  # 86c2c91cc) - measured instants, not the invented originals. Two real checks.
   - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
-  - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
-timestamp: 2026-08-21T04:52:57Z
+  - { by: claude/opus-5, at: 2026-08-20T22:27:35Z }
+timestamp: 2026-08-21T05:22:29Z
 ---
 
 # The loop
@@ -274,10 +273,12 @@ verdict format, and the two or three specific things to attack.
   adds - was corrected ONCE, in round one (a stylesheet-link count of three that
   a parser put at two; "production only adds `.min`" that also runs
   `resources.PostProcess` and adds `integrity`), and then stood unchallenged
-  through rounds two to six, while the INVENTED INSTRUMENT in the same file was
-  refuted five times running and finally deleted. Not every later finding was
-  about measurement - round six caught a stale round count - but every finding
-  that forced a rewrite rather than a word was.
+  through rounds two to six. What kept failing came in two distinct waves: the
+  invented INSTRUMENT was refuted three times and deleted in round three
+  (7ae28566e), and then the PROSE describing what instruments prove failed twice
+  more (88a87b322, d07cd3428) after the instrument itself was gone. Not every
+  later finding was about measurement - round six caught a stale round count -
+  but every finding that forced a rewrite rather than a word was.
 
   The planning shape: budget roughly one round for what the code does, and
   several for anything you claim a check PROVES. If you are on round three of

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -5,16 +5,14 @@ description: The proven module-review loop - a design critic (full render walk) 
 tags: [swarm, review, process]
 generated:
   by: claude/opus-5
-  at: 2026-08-21T05:22:29Z
+  at: 2026-08-21T05:33:58Z
 verified:
-  - { by: claude/opus-5, at: 2026-08-21T05:22:29Z }
-  # Two real checks whose times are UNKNOWN. The originals were invented, no
-  # offset recovers them, and a commit instant records when text landed, not
-  # when the check ran - so `at` is omitted rather than guessed. They landed in
-  # 8fa41494b and 86c2c91cc if a bound is ever needed. Do NOT dedup them.
-  - { by: claude/opus-5 }
-  - { by: claude/opus-5 }
-timestamp: 2026-08-21T05:22:29Z
+  - { by: claude/opus-5, at: 2026-08-21T05:33:58Z }
+  # Two earlier checks are NOT listed here: their times were invented, no offset
+  # recovers them, and a `verified` event requires `at`. They are recorded in
+  # log.md 2026-08-21 with their bounding commits (8fa41494b, 86c2c91cc) - prose
+  # can say "time unknown", this schema cannot.
+timestamp: 2026-08-21T05:33:58Z
 ---
 
 # The loop

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -8,8 +8,8 @@ generated:
   at: 2026-07-24T00:00:00Z
 verified:
   - { by: claude/opus-5, at: 2026-08-21T04:52:57Z }
-  - { by: claude/opus-5, at: 2026-08-21T00:50:00Z }
-  - { by: claude/opus-5, at: 2026-08-21T00:10:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T21:50:00Z }
+  - { by: claude/opus-5, at: 2026-08-20T21:10:00Z }
 timestamp: 2026-08-21T04:52:57Z
 ---
 
@@ -302,5 +302,5 @@ verdict format, and the two or three specific things to attack.
   only under `verified` is imprecise) was fair; the fix would have claimed
   authorship of sections written by others, and contradicted the convention
   every other concept follows - `generated` = who first produced the file,
-  `verified` = who touched it since. Check the prescription against the tree
+  `verified` = who actually REVALIDATED its content (an ordinary edit is not a verification). Check the prescription against the tree
   separately from the diagnosis, and record the disposition with its evidence.


### PR DESCRIPTION
Bundle only. Consolidated into `workflows/review-swarm.md` under Known failure modes — it extends the existing *"docs review converges slowly"* entry by saying **which** sentences converge slowly.

## The finding

Six codex rounds on PR #537 returned 13 findings. The factual content — which partial emits what, what production adds — was corrected **once**, in round one, then stood through rounds two to six. What kept failing came in two waves:

- the invented **instrument** was refuted three times and deleted in round three (`7ae28566e`);
- the **prose about what instruments prove** failed twice more (`88a87b322`, `d07cd3428`) *after the instrument was gone*.

> Deleting the tool does not end the problem the tool came from. Claims about measurement outlive the measurement.

**Planning shape:** budget ~1 round for what the code does, several for anything you claim a check *proves*. On round three of patching an instrument you invented, delete it and route to a method that already exists.

## This PR then took 7 rounds of its own

**11 findings, 10 accepted.** The ones worth naming:

**I declined the same finding twice and was wrong twice.** It asked to update `generated` for current content, citing canonical OKF §5.2. I looked up §5.2, found *"Relative links"*, and declined it as miscited — twice, confidently, in commit messages. The reviewer was reading `~/.agents/skills/okf/reference/SPEC.md`, where §5.2 **is** *"Trust: `generated` and `verified`"*. I was reading an older v0.1 copy in a plugin cache that never defines the fields. Two spec versions on one machine, section numbers disagreeing.

*"Not reproducible as cited"* is a claim about the reviewer, and needs the same evidence as any other. **Resolve the path before disputing the citation.**

**Six attempts at two metadata entries.** Two identical `verified` entries looked like a duplication artifact. `git log -S` returned one commit — read as proof one commit emitted both. It wasn't: the parent held two *distinct* entries that a repair commit had normalised. Deleting one destroyed a real verification.

Then: convert by an offset (read off the wrong commits — the source commit says the times were *invented* and no offset recovers them) → flatten to one measured value (the same order-destroying move renamed) → anchor to landing commits (a commit records when text *landed*, not when the check *ran*) → omit `at` (malformed — v0.2 requires `{by, at}`) → **remove them**, recording both checks in `log.md` with their bounding commits.

> After five failed encodings the question isn't *"what's the sixth"* — it's *"does this belong in this field at all?"* Prose can say "time unknown"; a schema requiring a timestamp cannot.

**A count that invalidated itself.** A `git log -S` result frozen into prose was stale within the same PR, because the commits *fixing that entry* changed the occurrence count it cited.

## Also fixed

- `workflows/index.md` still routed design review through `/stitch-design`, retracted by Paul on 2026-08-21 for `/impeccable critique`. The concept body was already correct — only the **pointer** was stale, which is exactly the *"sweep a corrected metric through the canonical summaries"* rule this same file carries. Swept the rest; every other hit is either framed as superseded or is stitch used for cover **generation**, which is correct.
- `generated` updated per canonical spec on both rewritten concepts; stamps applied as the **last** edit, since stamping before content settles guarantees a wrong stamp.

## Gates

**Round 7 came back clean** — no actionable regression. `okf_validate .okf` exits **0**, conformant; `--strict` exits **1** by design. Every edit verified with positive *and* negative controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
