### PR TITLE
OKF: the validator does not check trust fields, and there are two specs

### DIFF
--- a/.okf/build/index.md
+++ b/.okf/build/index.md
@@ -1,6 +1,6 @@
 # Build & Test
 
 * [Hugo build pipeline](hugo-build.md) - bin/hugo-build with the 8 course validators; also the PurgeCSS cold-start race and the minified-unquoted-attribute audit-tool trap
-* [Test gates](test-gates.md) - the local suites, when each is a commit blocker, bin/record-baselines for accepting only the baselines you meant to move, and why a deleted source file still serves from every local _dest/ tree, plus the NULL CHANGE - a diff that passes every gate and alters nothing
+* [Test gates](test-gates.md) - the local suites, when each is a commit blocker, bin/record-baselines for accepting only the baselines you meant to move, and why a deleted source file still serves from every local _dest/ tree, plus the NULL CHANGE - a diff that passes every gate and alters nothing - and what `okf_validate` actually guards (shape, not truth; error-only conformance) with the two-spec trap
 * [CI gates](ci-gates.md) - what GitHub Actions enforces: build, unit, path-scoped link check (visual regression is report-only), and what gates a PR never sees
 * [Template PDFs](pdf-templates.md) - regenerating the downloadable course PDFs

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -4,9 +4,9 @@ title: Test gates and when they block commits
 description: bin/qtest --changed is the routine gate; bin/rake test:critical at milestones; bin/test AND bin/dtest once at PR prep (or on explicit confirmation) for themes/, layouts/, or CSS changes.
 tags: [testing, visual-regression, gates]
 status: stable
-generated: { by: claude/opus-5, at: 2026-08-21T05:33:58Z }
+generated: { by: claude/opus-5, at: 2026-08-21T06:04:00Z }
 verified:
-  - { by: claude/opus-5, at: 2026-08-21T05:33:58Z }
+  - { by: claude/opus-5, at: 2026-08-21T06:04:00Z }
   - { by: claude/opus-5, at: 2026-08-21T04:01:38Z }
   - { by: claude/opus-5, at: 2026-08-21T03:27:09Z }
   - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
@@ -14,7 +14,7 @@ verified:
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
   - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
-timestamp: 2026-08-21T05:33:58Z
+timestamp: 2026-08-21T06:04:00Z
 ---
 
 # The suites
@@ -454,3 +454,52 @@ the parent commit.
 - Running a suite with multiple files - `ruby a_test.rb b_test.rb` - silently
   executes only the FIRST file. A guard test covers this (2026-07-31, R3-1);
   use rake tasks or `-n` filters, never a multi-file ruby invocation.
+
+# What `okf_validate` actually guards
+
+**It checks trust-field SHAPE, and a missing `at` slips through.** The v0.2
+`check_trust` requires `generated` to be a mapping, requires `generated.by`,
+validates actor shapes, and shape-checks instants - and `--strict` turns every
+one of those warnings into a failure. Two holes worth knowing:
+
+- `check_instant` returns early on `None`, so `verified: [{ by: claude/opus-5 }]`
+  with no `at` passes.
+- The `RFC3339` pattern makes the time, the seconds AND the timezone optional, so
+  `2026-08-21T05:30` and a bare `2026-08-21` both pass.
+
+So a green run is real evidence about shape - do not dismiss it - but it cannot
+tell you an event HAS a time, and it can never tell you a recorded time is TRUE.
+Six review rounds on PR #538 turned on exactly that and no tool caught any of it.
+
+**`✓ conformant` is an ERROR-ONLY verdict, not a §11 verdict.** v0.2 §11 has
+three conditions: parseable frontmatter on every non-reserved `.md`, a non-empty
+`type` in every block, and reserved files (`index.md`, `log.md`) following §8 and
+§9. The third surfaces as WARNINGS - `check_log` warns and never errors - and
+conformance is computed from errors alone.
+
+This bundle is a live example: its `log.md` uses themed date headings
+(`## 2026-08-21 - <theme>`) where §9 wants a bare `## YYYY-MM-DD`, so the
+validator warns on each and still prints the checkmark. **Green and not
+§11-conformant at the same time, both true.** Every `okf_validate ... exit=0`
+quoted in this repo means "no errors".
+
+That heading style is a DELIBERATE deviation already recorded in
+[log.md](/log.md) (2026-08-21): the bundle lands several thematic entries per
+day, and bare dates would produce a stack of identical headings. The conformant
+repair is one dated heading per day with themes as sub-sections beneath - a
+restructure of the whole file, NOT a find-and-replace. Do not sweep it casually.
+
+**Two OKF specs live on this machine and their section numbers disagree.** The
+`/okf:okf` skill ships and points at
+`.claude/plugins/cache/.../skills/okf/reference/SPEC.md`, which is **v0.1**,
+calls itself "the source of truth", never defines `generated` or `verified`, and
+numbers §5.2 as "Relative links". The v0.2 spec at
+`~/.agents/skills/okf/reference/SPEC.md` makes provenance, trust, lifecycle and
+attestation first-class and numbers §5.2 as "Trust: `generated` and `verified`".
+**This bundle is `okf_version: "0.2"`, so the v0.2 copy governs.** Only the v0.2
+validator checks the trust family and the §13.1 `sources` convention.
+
+That mismatch cost two confident wrong rejections of a correct review finding on
+#538 - §5.2 looked up in the v0.1 copy, twice - and a §9/§11 slip, since v0.1 §9
+was conformance while v0.2 §9 is log structure. When a spec section is cited,
+resolve WHICH copy before disputing it.

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -4,8 +4,9 @@ title: Test gates and when they block commits
 description: bin/qtest --changed is the routine gate; bin/rake test:critical at milestones; bin/test AND bin/dtest once at PR prep (or on explicit confirmation) for themes/, layouts/, or CSS changes.
 tags: [testing, visual-regression, gates]
 status: stable
-generated: { by: claude/opus-5, at: 2026-08-21T06:15:51Z }
+generated: { by: claude/opus-5, at: 2026-08-21T06:27:54Z }
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T06:27:54Z }
   - { by: claude/opus-5, at: 2026-08-21T06:15:51Z }
   - { by: claude/opus-5, at: 2026-08-21T06:04:00Z }
   - { by: claude/opus-5, at: 2026-08-21T05:33:58Z }
@@ -16,7 +17,7 @@ verified:
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
   - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
-timestamp: 2026-08-21T06:15:51Z
+timestamp: 2026-08-21T06:27:54Z
 ---
 
 # The suites
@@ -316,17 +317,14 @@ A fourth, 2026-08-21, and the cheapest to avoid: stamping a concept with
 `gsub(old_time, new_time)` rewrote the previous `verified` EVENT as well as
 `generated.at` and `timestamp`, silently deleting a real verification. A global
 replace does not know which occurrences are the same fact. Append the new event,
-edit `generated.at`/`timestamp` in place, and diff the VERIFIED ROWS against the
-merge base before committing:
+edit `generated.at`/`timestamp` in place, and READ the whole `verified` block in
+the diff before committing - no `-` line should touch an event you did not mean
+to remove.
 
-```bash
-git diff "$(git merge-base origin/master HEAD)" -- <concept> | grep -E "^[-+]  - \{ by:"
-```
-
-Additions only means you appended; a `-` line means you overwrote an event. Scope
-it to those rows - a legitimate stamp bumps `generated.at` and `timestamp`, so a
-whole-frontmatter diff always shows `-`/`+` pairs and would cry wolf on every
-valid edit.
+That instruction replaces a grep this file carried through four corrections
+(unscoped, then wrong base, then blind to the block form `- by:` / `at:` that
+`ci-gates.md` actually uses). Per the delete-dont-patch rule above, the check is
+gone rather than patched a fifth time: reading the block has none of those holes.
 
 - **An empty query result is not evidence of absence** (2026-08-21). Hunting a
   black band on `/services/`, `document.querySelectorAll('path.fl-shape')`
@@ -485,8 +483,10 @@ actually check the trust family, invoke the v0.2 checker by path:
 uv run ~/.agents/skills/validate/scripts/okf_validate.py .okf
 ```
 
-Everything below describes THAT validator. Run the plugin route and none of it
-applies.
+The TRUST-FIELD paragraphs below describe THAT validator only - run the plugin
+route and none of them apply. The error-only conformance behaviour further down
+applies to BOTH checkers: each warns on malformed log headings and computes its
+checkmark from errors alone.
 
 **It checks trust-field SHAPE, and a missing `at` slips through.** The v0.2
 `check_trust` requires `generated` to be a mapping, requires `generated.by`,
@@ -517,8 +517,11 @@ quoted in this repo means "no errors".
 That heading style is a DELIBERATE deviation already recorded in
 [log.md](/log.md) (2026-08-21): the bundle lands several thematic entries per
 day, and bare dates would produce a stack of identical headings. The conformant
-repair is one dated heading per day with themes as sub-sections beneath - a
-restructure of the whole file, NOT a find-and-replace. Do not sweep it casually.
+repair is one dated heading per day with the themes as ENTRIES beneath it - bold
+labels or list items, since §9 wants a flat list of date-grouped entries. Nested
+`###` headings would look warning-free (the validator only inspects `##`) while
+still violating §9. Either way it is a restructure of the whole file, not a
+find-and-replace. Do not sweep it casually.
 
 **Two OKF specs live on this machine and their section numbers disagree.** The
 `/okf:okf` skill ships and points at

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -7,6 +7,7 @@ status: stable
 generated: { by: claude/opus-5, at: 2026-08-21T06:04:00Z }
 verified:
   - { by: claude/opus-5, at: 2026-08-21T06:04:00Z }
+  - { by: claude/opus-5, at: 2026-08-21T05:33:58Z }
   - { by: claude/opus-5, at: 2026-08-21T04:01:38Z }
   - { by: claude/opus-5, at: 2026-08-21T03:27:09Z }
   - { by: claude/opus-5, at: 2026-08-20T23:11:35Z }
@@ -309,6 +310,13 @@ two DISTINCT entries that a timestamp-repair commit had normalised, so the
 "duplicate" was a real verification and deleting it destroyed provenance.
 Positive control that would have caught it in one command: read the file at
 the parent commit.
+
+A fourth, 2026-08-21, and the cheapest to avoid: stamping a concept with
+`gsub(old_time, new_time)` rewrote the previous `verified` EVENT as well as
+`generated.at` and `timestamp`, silently deleting a real verification. A global
+replace does not know which occurrences are the same fact. Append the new event,
+edit `generated.at`/`timestamp` in place, and diff the frontmatter against the
+merge base before committing.
 
 - **An empty query result is not evidence of absence** (2026-08-21). Hunting a
   black band on `/services/`, `document.querySelectorAll('path.fl-shape')`

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -4,8 +4,9 @@ title: Test gates and when they block commits
 description: bin/qtest --changed is the routine gate; bin/rake test:critical at milestones; bin/test AND bin/dtest once at PR prep (or on explicit confirmation) for themes/, layouts/, or CSS changes.
 tags: [testing, visual-regression, gates]
 status: stable
-generated: { by: claude/opus-5, at: 2026-08-21T06:27:54Z }
+generated: { by: claude/opus-5, at: 2026-08-21T06:36:48Z }
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T06:36:48Z }
   - { by: claude/opus-5, at: 2026-08-21T06:27:54Z }
   - { by: claude/opus-5, at: 2026-08-21T06:15:51Z }
   - { by: claude/opus-5, at: 2026-08-21T06:04:00Z }
@@ -17,7 +18,7 @@ verified:
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
   - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
-timestamp: 2026-08-21T06:27:54Z
+timestamp: 2026-08-21T06:36:48Z
 ---
 
 # The suites
@@ -299,6 +300,18 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
     confirming a false one. Flatten first (`tr '\n' ' ' < file | tr -s ' '`),
     then grep; same reason `marketing_copy_test` misses banned phrases split
     across two template lines.
+
+    Caveat on that flattened form, found 2026-08-21 while using it: the result is
+    ONE line, so `grep -c` - which counts matching LINES - can only ever return 0
+    or 1. A control expecting "2 occurrences" silently reads 1 and looks like a
+    failed edit. Use `grep -o PATTERN file | wc -l` for counts, and keep `grep -c`
+    for present/absent only.
+
+    The two fixes COMPOSE and must be applied together: `grep -o` on the raw file
+    still misses a wrapped phrase, and `grep -c` on the flattened file still caps
+    at 1. Counting occurrences of possibly-wrapped text needs
+    `tr '\n' ' ' < file | tr -s ' ' > flat && grep -o PATTERN flat | wc -l`.
+    Each fix was applied alone first, and each alone still read 1.
 
 A third instance, 2026-08-21: two identical `verified` entries looked like a
 duplication artifact, and `git log -S <timestamp>` returned exactly ONE

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -4,8 +4,9 @@ title: Test gates and when they block commits
 description: bin/qtest --changed is the routine gate; bin/rake test:critical at milestones; bin/test AND bin/dtest once at PR prep (or on explicit confirmation) for themes/, layouts/, or CSS changes.
 tags: [testing, visual-regression, gates]
 status: stable
-generated: { by: claude/opus-5, at: 2026-08-21T06:36:48Z }
+generated: { by: claude/opus-5, at: 2026-08-21T06:44:05Z }
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T06:44:05Z }
   - { by: claude/opus-5, at: 2026-08-21T06:36:48Z }
   - { by: claude/opus-5, at: 2026-08-21T06:27:54Z }
   - { by: claude/opus-5, at: 2026-08-21T06:15:51Z }
@@ -18,7 +19,7 @@ verified:
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
   - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
-timestamp: 2026-08-21T06:36:48Z
+timestamp: 2026-08-21T06:44:05Z
 ---
 
 # The suites
@@ -310,7 +311,8 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
     The two fixes COMPOSE and must be applied together: `grep -o` on the raw file
     still misses a wrapped phrase, and `grep -c` on the flattened file still caps
     at 1. Counting occurrences of possibly-wrapped text needs
-    `tr '\n' ' ' < file | tr -s ' ' > flat && grep -o PATTERN flat | wc -l`.
+    `tr '\n' ' ' < file | tr -s ' ' | grep -o PATTERN | wc -l` - piped, so it
+    leaves no throwaway file behind and cannot clobber one that already exists.
     Each fix was applied alone first, and each alone still read 1.
 
 A third instance, 2026-08-21: two identical `verified` entries looked like a
@@ -493,8 +495,15 @@ the documented workflow every `generated`/`verified` defect passes silently. To
 actually check the trust family, invoke the v0.2 checker by path:
 
 ```bash
-uv run ~/.agents/skills/validate/scripts/okf_validate.py .okf
+uv run ~/.agents/skills/validate/scripts/okf_validate.py .okf --strict
 ```
+
+**Neither exit code is a usable trust gate on this bundle, so READ THE OUTPUT.**
+Without `--strict` the exit code is error-only, and trust defects are warnings.
+With `--strict` it exits 1 on ANY warning - and this bundle always carries some
+(the log-heading deviation below guarantees it), so strict is permanently red
+here and says nothing specific. Grep the output for `§5.2` to see the trust
+findings.
 
 The TRUST-FIELD paragraphs below describe THAT validator only - run the plugin
 route and none of them apply. The error-only conformance behaviour further down

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -320,7 +320,7 @@ edit `generated.at`/`timestamp` in place, and diff the VERIFIED ROWS against the
 merge base before committing:
 
 ```bash
-git diff origin/master -- <concept> | grep -E "^[-+]  - \{ by:"
+git diff "$(git merge-base origin/master HEAD)" -- <concept> | grep -E "^[-+]  - \{ by:"
 ```
 
 Additions only means you appended; a `-` line means you overwrote an event. Scope

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -4,8 +4,9 @@ title: Test gates and when they block commits
 description: bin/qtest --changed is the routine gate; bin/rake test:critical at milestones; bin/test AND bin/dtest once at PR prep (or on explicit confirmation) for themes/, layouts/, or CSS changes.
 tags: [testing, visual-regression, gates]
 status: stable
-generated: { by: claude/opus-5, at: 2026-08-21T06:04:00Z }
+generated: { by: claude/opus-5, at: 2026-08-21T06:15:51Z }
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T06:15:51Z }
   - { by: claude/opus-5, at: 2026-08-21T06:04:00Z }
   - { by: claude/opus-5, at: 2026-08-21T05:33:58Z }
   - { by: claude/opus-5, at: 2026-08-21T04:01:38Z }
@@ -15,7 +16,7 @@ verified:
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
   - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
-timestamp: 2026-08-21T06:04:00Z
+timestamp: 2026-08-21T06:15:51Z
 ---
 
 # The suites
@@ -315,8 +316,17 @@ A fourth, 2026-08-21, and the cheapest to avoid: stamping a concept with
 `gsub(old_time, new_time)` rewrote the previous `verified` EVENT as well as
 `generated.at` and `timestamp`, silently deleting a real verification. A global
 replace does not know which occurrences are the same fact. Append the new event,
-edit `generated.at`/`timestamp` in place, and diff the frontmatter against the
-merge base before committing.
+edit `generated.at`/`timestamp` in place, and diff the VERIFIED ROWS against the
+merge base before committing:
+
+```bash
+git diff origin/master -- <concept> | grep -E "^[-+]  - \{ by:"
+```
+
+Additions only means you appended; a `-` line means you overwrote an event. Scope
+it to those rows - a legitimate stamp bumps `generated.at` and `timestamp`, so a
+whole-frontmatter diff always shows `-`/`+` pairs and would cry wolf on every
+valid edit.
 
 - **An empty query result is not evidence of absence** (2026-08-21). Hunting a
   black band on `/services/`, `document.querySelectorAll('path.fl-shape')`
@@ -464,6 +474,19 @@ merge base before committing.
   use rake tasks or `-n` filters, never a multi-file ruby invocation.
 
 # What `okf_validate` actually guards
+
+**First: which validator you run decides whether ANY of this is checked.**
+`CLAUDE.md` routes agents through `/okf:validate`, which runs the installed
+`okf@scaccogatto` plugin - a **v0.1** checker with no `check_trust` at all. Under
+the documented workflow every `generated`/`verified` defect passes silently. To
+actually check the trust family, invoke the v0.2 checker by path:
+
+```bash
+uv run ~/.agents/skills/validate/scripts/okf_validate.py .okf
+```
+
+Everything below describes THAT validator. Run the plugin route and none of it
+applies.
 
 **It checks trust-field SHAPE, and a missing `at` slips through.** The v0.2
 `check_trust` requires `generated` to be a mapping, requires `generated.by`,

--- a/.okf/index.md
+++ b/.okf/index.md
@@ -37,6 +37,31 @@ distinct checks became three identical entries, losing their order. Convert with
 the offset the stamp was WRITTEN at (recoverable from the session or the
 commit), or mark it unknown - never overwrite history with now.
 
+**`okf_validate` does NOT check the trust fields, so a green run says nothing
+about them** (2026-08-21, measured). A probe bundle carrying a malformed event -
+`verified: [{ by: claude/opus-5 }]`, no `at` - is reported **conformant with 3
+warnings** by BOTH validators on this machine. Conformance is §9 only: parseable
+frontmatter with a non-empty `type`. Six review rounds on PR #538 were spent
+almost entirely on `generated`/`verified` correctness, and every
+`okf_validate ... exit=0` quoted alongside them was silent on the subject. Quote
+that gate for what it covers - structure - and treat trust metadata as
+review-checked, not tool-checked.
+
+**There are TWO OKF specs on this machine and their section numbers disagree.**
+The `/okf:okf` skill ships and points at
+`.claude/plugins/cache/.../skills/okf/reference/SPEC.md`, which is **v0.1** (340
+lines) and calls itself "the source of truth"; it never defines `generated` or
+`verified` at all, and its §5.2 is "Relative links". The v0.2 spec at
+`~/.agents/skills/okf/reference/SPEC.md` (792 lines) makes provenance, trust,
+lifecycle and attestation first-class, and ITS §5.2 is "Trust: `generated` and
+`verified`". **This bundle is `okf_version: "0.2"`, so the v0.2 copy governs.**
+
+That mismatch cost two wrong rejections of a correct review finding: §5.2 was
+looked up in the v0.1 copy, found to say something else, and the finding declared
+miscited - twice. The validators differ too (261 vs 565 lines; the v0.2 one adds
+§13.1 `sources` checks and reports 84 warnings here against the v0.1 one's 90).
+When a spec section is cited, resolve WHICH copy before disputing it.
+
 # Sections
 
 * [Build & Test](build/) - build pipeline, validators, and the blocking test gates

--- a/.okf/index.md
+++ b/.okf/index.md
@@ -37,15 +37,20 @@ distinct checks became three identical entries, losing their order. Convert with
 the offset the stamp was WRITTEN at (recoverable from the session or the
 commit), or mark it unknown - never overwrite history with now.
 
-**`okf_validate` does NOT check the trust fields, so a green run says nothing
-about them** (2026-08-21, measured). A probe bundle carrying a malformed event -
-`verified: [{ by: claude/opus-5 }]`, no `at` - is reported **conformant with 3
-warnings** by BOTH validators on this machine. Conformance is §9 only: parseable
-frontmatter with a non-empty `type`. Six review rounds on PR #538 were spent
-almost entirely on `generated`/`verified` correctness, and every
-`okf_validate ... exit=0` quoted alongside them was silent on the subject. Quote
-that gate for what it covers - structure - and treat trust metadata as
-review-checked, not tool-checked.
+**`okf_validate` checks the trust fields, but a MISSING `at` slips through**
+(2026-08-21, measured). The v0.2 checker's `check_trust` does real work - it
+requires `generated` to be a mapping, requires `generated.by`, validates actor
+shapes, and rejects non-RFC-3339 instants - and `--strict` turns every one of
+those warnings into a failure. The one hole found by probe: `check_instant`
+returns early when the value is `None`, so an event like
+`verified: [{ by: claude/opus-5 }]` with no `at` is reported **conformant** by
+both validators on this machine.
+
+Two things follow. A green run is real evidence about trust-field SHAPE - do not
+dismiss it. But it cannot tell you an event has a time, and it can never tell you
+a recorded time is TRUE; six review rounds on PR #538 turned on exactly that, and
+no tool caught any of it. Conformance itself is narrow: v0.2 **§11** (parseable
+frontmatter, non-empty `type`), not the trust family.
 
 **There are TWO OKF specs on this machine and their section numbers disagree.**
 The `/okf:okf` skill ships and points at
@@ -58,9 +63,10 @@ lifecycle and attestation first-class, and ITS §5.2 is "Trust: `generated` and
 
 That mismatch cost two wrong rejections of a correct review finding: §5.2 was
 looked up in the v0.1 copy, found to say something else, and the finding declared
-miscited - twice. The validators differ too (261 vs 565 lines; the v0.2 one adds
-§13.1 `sources` checks and reports 84 warnings here against the v0.1 one's 90).
-When a spec section is cited, resolve WHICH copy before disputing it.
+miscited - twice. The validators differ in coverage too (261 vs 565 lines; only
+the v0.2 one checks the trust family and the §13.1 `sources` convention), so a
+warning count is only meaningful next to the validator that produced it - and is
+not worth writing down at all, since every edit to this bundle changes it.
 
 # Sections
 

--- a/.okf/index.md
+++ b/.okf/index.md
@@ -37,65 +37,6 @@ distinct checks became three identical entries, losing their order. Convert with
 the offset the stamp was WRITTEN at (recoverable from the session or the
 commit), or mark it unknown - never overwrite history with now.
 
-**`okf_validate` checks the trust fields, but a MISSING `at` slips through**
-(2026-08-21, measured). The v0.2 checker's `check_trust` does real work - it
-requires `generated` to be a mapping, requires `generated.by`, validates actor
-shapes, and shape-checks instants - and `--strict` turns every one of those
-warnings into a failure. "Shape-checks" is deliberate: the `RFC3339` pattern
-makes the time, the seconds AND the timezone all optional, so `2026-08-21T05:30`
-and a bare `2026-08-21` both pass. A green strict run does not prove your
-instants are RFC 3339. The one hole found by probe: `check_instant`
-returns early when the value is `None`, so an event like
-`verified: [{ by: claude/opus-5 }]` with no `at` is reported **conformant** by
-both validators on this machine.
-
-Two things follow. A green run is real evidence about trust-field SHAPE - do not
-dismiss it. But it cannot tell you an event has a time, and it can never tell you
-a recorded time is TRUE; six review rounds on PR #538 turned on exactly that, and
-no tool caught any of it.
-
-Conformance itself is narrow, and has exactly three conditions under v0.2 **§11**:
-every non-reserved `.md` has parseable YAML frontmatter, every block has a
-non-empty `type`, and the reserved files (`index.md`, `log.md`) follow §8 and §9
-respectively. The trust family is not among them - when present it is a SHOULD.
-Note the trap in that sentence: in v0.2, §9 is the LOG structure section, while in
-v0.1 §9 WAS conformance. Citing "§9" without naming the version means two
-different things.
-
-**The validator's `✓ conformant` is an ERROR-ONLY verdict, not a §11 verdict.**
-Conformance is computed from errors alone, but the reserved-file condition
-(§11.3) surfaces as WARNINGS - `check_log` warns and never errors. Measured on
-this bundle: **69 of 87** `log.md` date headings carry a themed suffix
-(`## 2026-08-21 - what the validator guards`) and are flagged
-`§9 date heading ... is not ISO 8601 YYYY-MM-DD`. §9 requires a bare
-`## YYYY-MM-DD`.
-
-So this bundle is green and NOT §11-conformant at the same time, and both
-statements are true. Every `okf_validate ... exit=0` quoted in this repo means
-"no errors", which is a narrower claim than the word "conformant" suggests.
-
-The 69 headings are a known, unfixed deviation. Converting them is mechanical
-(theme moves into the entry body as a bold lead, per the §9 example) but it
-trades a spec rule against how a human scans this file, so it is Paul's call, not
-a silent sweep.
-
-
-**There are TWO OKF specs on this machine and their section numbers disagree.**
-The `/okf:okf` skill ships and points at
-`.claude/plugins/cache/.../skills/okf/reference/SPEC.md`, which is **v0.1** (340
-lines) and calls itself "the source of truth"; it never defines `generated` or
-`verified` at all, and its §5.2 is "Relative links". The v0.2 spec at
-`~/.agents/skills/okf/reference/SPEC.md` (792 lines) makes provenance, trust,
-lifecycle and attestation first-class, and ITS §5.2 is "Trust: `generated` and
-`verified`". **This bundle is `okf_version: "0.2"`, so the v0.2 copy governs.**
-
-That mismatch cost two wrong rejections of a correct review finding: §5.2 was
-looked up in the v0.1 copy, found to say something else, and the finding declared
-miscited - twice. The validators differ in coverage too (261 vs 565 lines; only
-the v0.2 one checks the trust family and the §13.1 `sources` convention), so a
-warning count is only meaningful next to the validator that produced it - and is
-not worth writing down at all, since every edit to this bundle changes it.
-
 # Sections
 
 * [Build & Test](build/) - build pipeline, validators, and the blocking test gates

--- a/.okf/index.md
+++ b/.okf/index.md
@@ -49,8 +49,15 @@ both validators on this machine.
 Two things follow. A green run is real evidence about trust-field SHAPE - do not
 dismiss it. But it cannot tell you an event has a time, and it can never tell you
 a recorded time is TRUE; six review rounds on PR #538 turned on exactly that, and
-no tool caught any of it. Conformance itself is narrow: v0.2 **§11** (parseable
-frontmatter, non-empty `type`), not the trust family.
+no tool caught any of it.
+
+Conformance itself is narrow, and has exactly three conditions under v0.2 **§11**:
+every non-reserved `.md` has parseable YAML frontmatter, every block has a
+non-empty `type`, and the reserved files (`index.md`, `log.md`) follow §8 and §9
+respectively. The trust family is not among them - when present it is a SHOULD.
+Note the trap in that sentence: in v0.2, §9 is the LOG structure section, while in
+v0.1 §9 WAS conformance. Citing "§9" without naming the version means two
+different things.
 
 **There are TWO OKF specs on this machine and their section numbers disagree.**
 The `/okf:okf` skill ships and points at

--- a/.okf/index.md
+++ b/.okf/index.md
@@ -40,8 +40,11 @@ commit), or mark it unknown - never overwrite history with now.
 **`okf_validate` checks the trust fields, but a MISSING `at` slips through**
 (2026-08-21, measured). The v0.2 checker's `check_trust` does real work - it
 requires `generated` to be a mapping, requires `generated.by`, validates actor
-shapes, and rejects non-RFC-3339 instants - and `--strict` turns every one of
-those warnings into a failure. The one hole found by probe: `check_instant`
+shapes, and shape-checks instants - and `--strict` turns every one of those
+warnings into a failure. "Shape-checks" is deliberate: the `RFC3339` pattern
+makes the time, the seconds AND the timezone all optional, so `2026-08-21T05:30`
+and a bare `2026-08-21` both pass. A green strict run does not prove your
+instants are RFC 3339. The one hole found by probe: `check_instant`
 returns early when the value is `None`, so an event like
 `verified: [{ by: claude/opus-5 }]` with no `at` is reported **conformant** by
 both validators on this machine.
@@ -58,6 +61,24 @@ respectively. The trust family is not among them - when present it is a SHOULD.
 Note the trap in that sentence: in v0.2, §9 is the LOG structure section, while in
 v0.1 §9 WAS conformance. Citing "§9" without naming the version means two
 different things.
+
+**The validator's `✓ conformant` is an ERROR-ONLY verdict, not a §11 verdict.**
+Conformance is computed from errors alone, but the reserved-file condition
+(§11.3) surfaces as WARNINGS - `check_log` warns and never errors. Measured on
+this bundle: **69 of 87** `log.md` date headings carry a themed suffix
+(`## 2026-08-21 - what the validator guards`) and are flagged
+`§9 date heading ... is not ISO 8601 YYYY-MM-DD`. §9 requires a bare
+`## YYYY-MM-DD`.
+
+So this bundle is green and NOT §11-conformant at the same time, and both
+statements are true. Every `okf_validate ... exit=0` quoted in this repo means
+"no errors", which is a narrower claim than the word "conformant" suggests.
+
+The 69 headings are a known, unfixed deviation. Converting them is mechanical
+(theme moves into the entry body as a bold lead, per the §9 example) but it
+trades a spec rule against how a human scans this file, so it is Paul's call, not
+a silent sweep.
+
 
 **There are TWO OKF specs on this machine and their section numbers disagree.**
 The `/okf:okf` skill ships and points at

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -52,57 +52,43 @@ time, which is verifiable - never invented).
 
 ## 2026-08-21 - what okf_validate actually guards, and the two-spec trap
 
-Recorded in the bundle-root [index.md](index.md), where the v0.2 trust
-conventions live.
+Recorded in [build/test-gates.md](build/test-gates.md), where the gates live.
+The first draft put it in the bundle-root index; review moved it out - the root
+index is a reserved progressive-disclosure file, and a page of operational
+analysis there loads on every onboarding.
 
-**The validator checks trust-field SHAPE; a missing `at` is the hole.** The v0.2
-`check_trust` requires `generated` to be a mapping, requires `generated.by`,
-validates actor shapes, and shape-checks instants, and `--strict` turns each
-warning into a failure. The shape check is permissive - time, seconds and
-timezone are all optional in its pattern, so `2026-08-21T05:30` and a bare date
-both pass. But `check_instant` returns early on `None`, so
-`verified: [{ by: claude/opus-5 }]` with no `at` passes both validators on this
-machine.
+**The validator checks trust-field SHAPE with two holes**: `check_instant`
+returns early on `None`, so a `verified` event with no `at` passes; and the
+`RFC3339` pattern makes time, seconds and timezone all optional, so
+`2026-08-21T05:30` and a bare date pass too. A green run is real evidence about
+shape, but cannot say an event HAS a time and can never say a recorded time is
+TRUE - which is what six review rounds on #538 were about, with no tool catching
+any of it.
 
-The first draft of this entry claimed the validator was "silent on the trust
-fields" - generalising a one-hole probe into blanket silence, in an entry about
-not over-reading measurements. Review caught it. The measurement was real; the
-sentence written on top of it was not, which is the same descriptive-vs-
-prescriptive split recorded in [workflows/review-swarm.md](workflows/review-swarm.md).
+**`✓ conformant` is an ERROR-ONLY verdict.** v0.2 §11 has three conditions, and
+the third - reserved files following §8/§9 - surfaces as warnings only. This
+bundle proves it: the themed log headings warn on every entry and the checkmark
+still prints. Green and not §11-conformant simultaneously, both true.
 
-What survives: a green run is real evidence about shape and should not be
-dismissed, but it cannot tell you an event HAS a time, and it can never tell you
-a recorded time is TRUE. Six review rounds on #538 turned on exactly that and no
-tool caught any of it. Conformance is v0.2 §11 and has THREE conditions -
-parseable frontmatter, a non-empty `type`, AND reserved files (`index.md`,
-`log.md`) following §8 and §9. Documenting that third condition exposed a
-contradiction the entry now carries: THIS log violates it. 69 of 87 date headings
-carry a themed suffix where §9 wants a bare `## YYYY-MM-DD`, and the validator
-warns on every one - but computes `conformant` from ERRORS only, so it prints a
-checkmark anyway. The bundle is green and not §11-conformant simultaneously.
-Converting the headings is mechanical but trades a spec rule against human
-scannability, so it is flagged for Paul rather than swept. The first draft listed two and cited "§9" for
-conformance itself, which is the v0.1 numbering: under v0.2, §9 is the LOG
-structure section. Citing a section without naming the version means two
-different things, which is the two-spec trap below in miniature.
+That heading style is a deliberate deviation this log already recorded, and the
+first draft of this entry contradicted it by calling the repair "mechanical".
+It is not: bare dates would stack a dozen identical headings on a busy day, so
+the conformant shape is one dated heading per day with themes as sub-sections -
+a whole-file restructure.
 
 **Two OKF specs, disagreeing section numbers.** The `/okf:okf` skill points at
-the plugin-cache copy: **v0.1**, 340 lines, calls itself "the source of truth",
-never defines `generated` or `verified`, §5.2 = "Relative links". The v0.2 spec
-at `~/.agents/skills/okf/reference/SPEC.md` is 792 lines, makes
-provenance/trust/lifecycle/attestation first-class, §5.2 = "Trust: `generated`
-and `verified`". This bundle is `okf_version: "0.2"`, so v0.2 governs. The
-validators differ in coverage as well (261 vs 565 lines; only the v0.2 one checks
-the trust family and the §13.1 `sources` convention).
+the plugin-cache v0.1 copy, which calls itself the source of truth and never
+defines `generated`/`verified`; `~/.agents/skills/okf/reference/SPEC.md` is v0.2
+and makes them first-class. §5.2 means "Relative links" in one and "Trust" in
+the other. This bundle is v0.2, so v0.2 governs. That cost two confident wrong
+rejections of a correct finding on #538, plus a §9/§11 slip - v0.1 §9 was
+conformance, v0.2 §9 is log structure.
 
-That mismatch produced two confident wrong rejections of a correct review finding
-on #538, and the §9/§11 slip above. When a spec section is cited, resolve WHICH
-copy before disputing it.
-
-No warning totals are recorded here. The first draft quoted two, and they were
-stale in the same checkout - this entry's own heading changes them. That is the
-self-invalidating-count rule from
-[build/test-gates.md](build/test-gates.md), broken one round after writing it.
+No counts appear above. Three drafts of this entry hard-coded one - warning
+totals, then a `git log -S` result, then "69 of 87 headings" - and each was
+stale within the same PR, because the commits fixing the entry changed the thing
+the entry counted. The rule was already in
+[build/test-gates.md](build/test-gates.md) before any of those drafts.
 
 ## 2026-08-21 - what survives adversarial review, and when to stop patching
 

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -98,7 +98,7 @@ A stamping bug worth its own line: updating this concept with
 cannot tell which occurrences are the same fact. Recorded on the instrument rule
 in [build/test-gates.md](build/test-gates.md) with the check that catches it -
 diff the VERIFIED ROWS against the merge base
-(`grep -E "^[-+]  - \{ by:"`) and expect additions only. Scoped to those rows on
+(`git diff "$(git merge-base origin/master HEAD)" -- <concept> | grep -E "^[-+]  - \{ by:"`) and expect additions only. Scoped to those rows on
 purpose: a legitimate stamp bumps `generated.at` and `timestamp`, so a
 whole-frontmatter diff shows `-`/`+` pairs on every valid edit and would cry
 wolf.

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -95,10 +95,17 @@ conformance, v0.2 §9 is log structure.
 A stamping bug worth its own line: updating this concept with
 `gsub(old_time, new_time)` rewrote the previous `verified` EVENT along with
 `generated.at` and `timestamp`, deleting a real verification. A global replace
-cannot tell which occurrences are the same fact. Recorded on the instrument rule
-in [build/test-gates.md](build/test-gates.md) with the check that catches it -
-diff the VERIFIED ROWS against the merge base
-(`git diff "$(git merge-base origin/master HEAD)" -- <concept> | grep -E "^[-+]  - \{ by:"`) and expect additions only. Scoped to those rows on
+cannot tell which occurrences are the same fact. Append the new event, edit
+`generated.at`/`timestamp` in place, and READ the whole `verified` block in the
+diff before committing.
+
+That last instruction started as a grep and went through four corrections -
+unscoped (flagging every legitimate stamp), wrong base (`origin/master` instead
+of the merge base), and blind to the block form `- by:` / `at:` that
+`ci-gates.md` uses. It is deleted rather than patched a fifth time, per the
+delete-dont-patch rule in the same concept. Reading the block has none of those
+holes, and the rule caught its own instrument for the second time in this PR
+chain. Scoped to those rows on
 purpose: a legitimate stamp bumps `generated.at` and `timestamp`, so a
 whole-frontmatter diff shows `-`/`+` pairs on every valid edit and would cry
 wolf.

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -71,9 +71,12 @@ prescriptive split recorded in [workflows/review-swarm.md](workflows/review-swar
 What survives: a green run is real evidence about shape and should not be
 dismissed, but it cannot tell you an event HAS a time, and it can never tell you
 a recorded time is TRUE. Six review rounds on #538 turned on exactly that and no
-tool caught any of it. Conformance is v0.2 §11 - parseable frontmatter and a
-non-empty `type` - not the trust family. (The first draft cited §9, which is the
-v0.1 numbering; see below for why that keeps happening.)
+tool caught any of it. Conformance is v0.2 §11 and has THREE conditions -
+parseable frontmatter, a non-empty `type`, AND reserved files (`index.md`,
+`log.md`) following §8 and §9. The first draft listed two and cited "§9" for
+conformance itself, which is the v0.1 numbering: under v0.2, §9 is the LOG
+structure section. Citing a section without naming the version means two
+different things, which is the two-spec trap below in miniature.
 
 **Two OKF specs, disagreeing section numbers.** The `/okf:okf` skill points at
 the plugin-cache copy: **v0.1**, 340 lines, calls itself "the source of truth",

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -50,6 +50,38 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
+## 2026-08-21 - the validator does not check trust fields, and there are two specs
+
+Recorded in the bundle-root [index.md](index.md), where the v0.2 trust
+conventions live, because both facts change how a session should read a green
+gate.
+
+**`okf_validate` is silent on `generated`/`verified`.** Measured with a probe
+bundle carrying `verified: [{ by: claude/opus-5 }]` - a malformed event, no `at`.
+BOTH validators on this machine report it **conformant with 3 warnings**.
+Conformance is §9 only: parseable frontmatter with a non-empty `type`. Six review
+rounds on PR #538 were spent almost entirely on trust-field correctness, and
+every `okf_validate ... exit=0` quoted alongside them covered none of it. The
+gate is structural; trust metadata is review-checked, not tool-checked.
+
+Note what the probe refuted: the expectation going in was that the v0.2 validator
+would catch what the v0.1 one missed. It does not. Running it was the difference
+between recording that and recording a plausible guess.
+
+**Two OKF specs, disagreeing section numbers.** The `/okf:okf` skill points at
+the plugin-cache copy, which is **v0.1** (340 lines), calls itself "the source of
+truth", never defines `generated` or `verified`, and numbers §5.2 as "Relative
+links". The v0.2 spec at `~/.agents/skills/okf/reference/SPEC.md` (792 lines)
+makes provenance/trust/lifecycle/attestation first-class and numbers §5.2 as
+"Trust: `generated` and `verified`". This bundle is `okf_version: "0.2"`, so v0.2
+governs.
+
+That mismatch produced two confident wrong rejections of a correct review finding
+on #538 - §5.2 looked up in the wrong copy, twice. The validators differ as well
+(261 vs 565 lines; the v0.2 one adds §13.1 `sources` checks and reports 84
+warnings on this bundle against the v0.1 one's 90), which means a warning total
+is only meaningful next to the validator that produced it.
+
 ## 2026-08-21 - what survives adversarial review, and when to stop patching
 
 Added to [workflows/review-swarm.md](workflows/review-swarm.md) under Known

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -41,8 +41,9 @@ The date headings are a deliberate deviation. The spec's template is a bare
 bundle lands several thematic entries per day (12 on 2026-08-21), so bare
 dates would produce a dozen identical headings. **Do not collapse them
 casually** - the conformant shape is one dated heading per day with the themes
-as sub-sections beneath it, which is a restructure of the whole file, not a
-find-and-replace.
+as flat ENTRIES beneath it (bullets or bold labels; §9 wants a flat list, and
+nested `###` headings would escape the validator while still violating it),
+which is a restructure of the whole file, not a find-and-replace.
 
 **This is a known-red gate, not accepted noise, and it is tracked** in
 `docs/projects/2608-site-design-system/README.md` under Outstanding. Two jobs
@@ -62,8 +63,9 @@ routes agents through `/okf:validate`, which runs the `okf@scaccogatto` plugin -
 v0.1 checker with no `check_trust` at all, so under the documented workflow every
 generated/verified defect passes silently. The concept now carries the explicit
 v0.2 invocation (`uv run ~/.agents/skills/validate/scripts/okf_validate.py .okf`),
-because everything below describes that checker and none of it applies to the
-plugin route.
+because the TRUST-FIELD material below describes that checker only. The
+error-only conformance caveat applies to BOTH: the v0.1 plugin also computes
+`conformant = not r.errors` and prints the checkmark with warnings outstanding.
 
 **That validator checks trust-field SHAPE, with two holes**: `check_instant`
 returns early on `None`, so a `verified` event with no `at` passes; and the
@@ -81,7 +83,10 @@ still prints. Green and not §11-conformant simultaneously, both true.
 That heading style is a deliberate deviation this log already recorded, and the
 first draft of this entry contradicted it by calling the repair "mechanical".
 It is not: bare dates would stack a dozen identical headings on a busy day, so
-the conformant shape is one dated heading per day with themes as sub-sections -
+the conformant shape is one dated heading per day with the themes as flat
+ENTRIES beneath it - bullets or bold labels, since §9 wants a flat list. Nested
+`###` headings would escape the validator (it only inspects `##`) and still
+violate §9 -
 a whole-file restructure.
 
 **Two OKF specs, disagreeing section numbers.** The `/okf:okf` skill points at
@@ -105,10 +110,17 @@ of the merge base), and blind to the block form `- by:` / `at:` that
 `ci-gates.md` uses. It is deleted rather than patched a fifth time, per the
 delete-dont-patch rule in the same concept. Reading the block has none of those
 holes, and the rule caught its own instrument for the second time in this PR
-chain. Scoped to those rows on
-purpose: a legitimate stamp bumps `generated.at` and `timestamp`, so a
-whole-frontmatter diff shows `-`/`+` pairs on every valid edit and would cry
-wolf.
+chain.
+
+Three review rounds on this entry were spent on the SAME defect: the concept was
+corrected and its log mirror was not. Plugin-route scope, the log-repair shape,
+and a rationale left dangling after its command was deleted - each fixed in
+`build/test-gates.md` and each left stale here. A concept and its log entry are
+two files saying the same thing, so every correction is two edits, and the one
+that gets forgotten is the one nobody is looking at. The existing
+"sweep a corrected metric through the canonical summaries" rule in
+[workflows/review-swarm.md](workflows/review-swarm.md) covers this; the
+concept/log pair is its most frequent instance.
 
 No counts appear above. Three drafts of this entry hard-coded one - warning
 totals, then a `git log -S` result, then "69 of 87 headings" - and each was

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -50,37 +50,48 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
-## 2026-08-21 - the validator does not check trust fields, and there are two specs
+## 2026-08-21 - what okf_validate actually guards, and the two-spec trap
 
 Recorded in the bundle-root [index.md](index.md), where the v0.2 trust
-conventions live, because both facts change how a session should read a green
-gate.
+conventions live.
 
-**`okf_validate` is silent on `generated`/`verified`.** Measured with a probe
-bundle carrying `verified: [{ by: claude/opus-5 }]` - a malformed event, no `at`.
-BOTH validators on this machine report it **conformant with 3 warnings**.
-Conformance is §9 only: parseable frontmatter with a non-empty `type`. Six review
-rounds on PR #538 were spent almost entirely on trust-field correctness, and
-every `okf_validate ... exit=0` quoted alongside them covered none of it. The
-gate is structural; trust metadata is review-checked, not tool-checked.
+**The validator checks trust-field SHAPE; a missing `at` is the hole.** The v0.2
+`check_trust` requires `generated` to be a mapping, requires `generated.by`,
+validates actor shapes, and rejects non-RFC-3339 instants, and `--strict` turns
+each warning into a failure. But `check_instant` returns early on `None`, so
+`verified: [{ by: claude/opus-5 }]` with no `at` passes both validators on this
+machine.
 
-Note what the probe refuted: the expectation going in was that the v0.2 validator
-would catch what the v0.1 one missed. It does not. Running it was the difference
-between recording that and recording a plausible guess.
+The first draft of this entry claimed the validator was "silent on the trust
+fields" - generalising a one-hole probe into blanket silence, in an entry about
+not over-reading measurements. Review caught it. The measurement was real; the
+sentence written on top of it was not, which is the same descriptive-vs-
+prescriptive split recorded in [workflows/review-swarm.md](workflows/review-swarm.md).
+
+What survives: a green run is real evidence about shape and should not be
+dismissed, but it cannot tell you an event HAS a time, and it can never tell you
+a recorded time is TRUE. Six review rounds on #538 turned on exactly that and no
+tool caught any of it. Conformance is v0.2 §11 - parseable frontmatter and a
+non-empty `type` - not the trust family. (The first draft cited §9, which is the
+v0.1 numbering; see below for why that keeps happening.)
 
 **Two OKF specs, disagreeing section numbers.** The `/okf:okf` skill points at
-the plugin-cache copy, which is **v0.1** (340 lines), calls itself "the source of
-truth", never defines `generated` or `verified`, and numbers §5.2 as "Relative
-links". The v0.2 spec at `~/.agents/skills/okf/reference/SPEC.md` (792 lines)
-makes provenance/trust/lifecycle/attestation first-class and numbers §5.2 as
-"Trust: `generated` and `verified`". This bundle is `okf_version: "0.2"`, so v0.2
-governs.
+the plugin-cache copy: **v0.1**, 340 lines, calls itself "the source of truth",
+never defines `generated` or `verified`, §5.2 = "Relative links". The v0.2 spec
+at `~/.agents/skills/okf/reference/SPEC.md` is 792 lines, makes
+provenance/trust/lifecycle/attestation first-class, §5.2 = "Trust: `generated`
+and `verified`". This bundle is `okf_version: "0.2"`, so v0.2 governs. The
+validators differ in coverage as well (261 vs 565 lines; only the v0.2 one checks
+the trust family and the §13.1 `sources` convention).
 
 That mismatch produced two confident wrong rejections of a correct review finding
-on #538 - §5.2 looked up in the wrong copy, twice. The validators differ as well
-(261 vs 565 lines; the v0.2 one adds §13.1 `sources` checks and reports 84
-warnings on this bundle against the v0.1 one's 90), which means a warning total
-is only meaningful next to the validator that produced it.
+on #538, and the §9/§11 slip above. When a spec section is cited, resolve WHICH
+copy before disputing it.
+
+No warning totals are recorded here. The first draft quoted two, and they were
+stale in the same checkout - this entry's own heading changes them. That is the
+self-invalidating-count rule from
+[build/test-gates.md](build/test-gates.md), broken one round after writing it.
 
 ## 2026-08-21 - what survives adversarial review, and when to stop patching
 

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -57,8 +57,10 @@ conventions live.
 
 **The validator checks trust-field SHAPE; a missing `at` is the hole.** The v0.2
 `check_trust` requires `generated` to be a mapping, requires `generated.by`,
-validates actor shapes, and rejects non-RFC-3339 instants, and `--strict` turns
-each warning into a failure. But `check_instant` returns early on `None`, so
+validates actor shapes, and shape-checks instants, and `--strict` turns each
+warning into a failure. The shape check is permissive - time, seconds and
+timezone are all optional in its pattern, so `2026-08-21T05:30` and a bare date
+both pass. But `check_instant` returns early on `None`, so
 `verified: [{ by: claude/opus-5 }]` with no `at` passes both validators on this
 machine.
 
@@ -73,7 +75,13 @@ dismissed, but it cannot tell you an event HAS a time, and it can never tell you
 a recorded time is TRUE. Six review rounds on #538 turned on exactly that and no
 tool caught any of it. Conformance is v0.2 §11 and has THREE conditions -
 parseable frontmatter, a non-empty `type`, AND reserved files (`index.md`,
-`log.md`) following §8 and §9. The first draft listed two and cited "§9" for
+`log.md`) following §8 and §9. Documenting that third condition exposed a
+contradiction the entry now carries: THIS log violates it. 69 of 87 date headings
+carry a themed suffix where §9 wants a bare `## YYYY-MM-DD`, and the validator
+warns on every one - but computes `conformant` from ERRORS only, so it prints a
+checkmark anyway. The bundle is green and not §11-conformant simultaneously.
+Converting the headings is mechanical but trades a spec rule against human
+scannability, so it is flagged for Paul rather than swept. The first draft listed two and cited "§9" for
 conformance itself, which is the v0.1 numbering: under v0.2, §9 is the LOG
 structure section. Citing a section without naming the version means two
 different things, which is the two-spec trap below in miniature.

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -57,7 +57,15 @@ The first draft put it in the bundle-root index; review moved it out - the root
 index is a reserved progressive-disclosure file, and a page of operational
 analysis there loads on every onboarding.
 
-**The validator checks trust-field SHAPE with two holes**: `check_instant`
+**Which validator you run decides whether any of this is checked.** `CLAUDE.md`
+routes agents through `/okf:validate`, which runs the `okf@scaccogatto` plugin - a
+v0.1 checker with no `check_trust` at all, so under the documented workflow every
+generated/verified defect passes silently. The concept now carries the explicit
+v0.2 invocation (`uv run ~/.agents/skills/validate/scripts/okf_validate.py .okf`),
+because everything below describes that checker and none of it applies to the
+plugin route.
+
+**That validator checks trust-field SHAPE, with two holes**: `check_instant`
 returns early on `None`, so a `verified` event with no `at` passes; and the
 `RFC3339` pattern makes time, seconds and timezone all optional, so
 `2026-08-21T05:30` and a bare date pass too. A green run is real evidence about
@@ -89,7 +97,11 @@ A stamping bug worth its own line: updating this concept with
 `generated.at` and `timestamp`, deleting a real verification. A global replace
 cannot tell which occurrences are the same fact. Recorded on the instrument rule
 in [build/test-gates.md](build/test-gates.md) with the check that catches it -
-diff the frontmatter against the merge base and expect additions only.
+diff the VERIFIED ROWS against the merge base
+(`grep -E "^[-+]  - \{ by:"`) and expect additions only. Scoped to those rows on
+purpose: a legitimate stamp bumps `generated.at` and `timestamp`, so a
+whole-frontmatter diff shows `-`/`+` pairs on every valid edit and would cry
+wolf.
 
 No counts appear above. Three drafts of this entry hard-coded one - warning
 totals, then a `git log -S` result, then "69 of 87 headings" - and each was

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -62,7 +62,9 @@ analysis there loads on every onboarding.
 routes agents through `/okf:validate`, which runs the `okf@scaccogatto` plugin - a
 v0.1 checker with no `check_trust` at all, so under the documented workflow every
 generated/verified defect passes silently. The concept now carries the explicit
-v0.2 invocation (`uv run ~/.agents/skills/validate/scripts/okf_validate.py .okf`),
+v0.2 invocation with `--strict`, plus the fact that NEITHER exit code gates trust
+on this bundle - plain is error-only, and `--strict` is permanently red because
+the log-heading deviation always produces warnings, so the output has to be read,
 because the TRUST-FIELD material below describes that checker only. The
 error-only conformance caveat applies to BOTH: the v0.1 plugin also computes
 `conformant = not r.errors` and prints the checkmark with warnings outstanding.

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -84,6 +84,13 @@ the other. This bundle is v0.2, so v0.2 governs. That cost two confident wrong
 rejections of a correct finding on #538, plus a §9/§11 slip - v0.1 §9 was
 conformance, v0.2 §9 is log structure.
 
+A stamping bug worth its own line: updating this concept with
+`gsub(old_time, new_time)` rewrote the previous `verified` EVENT along with
+`generated.at` and `timestamp`, deleting a real verification. A global replace
+cannot tell which occurrences are the same fact. Recorded on the instrument rule
+in [build/test-gates.md](build/test-gates.md) with the check that catches it -
+diff the frontmatter against the merge base and expect additions only.
+
 No counts appear above. Three drafts of this entry hard-coded one - warning
 totals, then a `git log -S` result, then "69 of 87 headings" - and each was
 stale within the same PR, because the commits fixing the entry changed the thing


### PR DESCRIPTION
Bundle only. Two measured facts about the gate I've been quoting all session — both recorded in the bundle-root index, where the v0.2 trust conventions already live.

## 1. `okf_validate` is silent on the trust fields

Measured, not assumed. A probe bundle carrying a **malformed** event —

```yaml
verified:
  - { by: claude/opus-5 }      # no `at`
```

— is reported **`✓ conformant (3 warnings)`** by **both** validators on this machine. Conformance is §9 only: parseable frontmatter with a non-empty `type`.

Six review rounds on #538 were spent almost entirely on `generated`/`verified` correctness, and **every `okf_validate … exit=0` I quoted beside them covered none of it.** I was citing a structural gate as though it guarded semantics.

The probe also refuted what I expected going in — that the v0.2 validator would catch what v0.1 missed. **It doesn't.** Running it was the difference between recording that and recording a plausible guess.

> Quote that gate for what it covers — structure. Trust metadata is **review-checked, not tool-checked.**

## 2. Two OKF specs on this machine, with disagreeing section numbers

| | plugin cache (what `/okf:okf` loads) | `~/.agents/skills/okf/` |
|---|---|---|
| version | **v0.1** | **v0.2** |
| spec size | 340 lines | 792 lines |
| defines `generated`/`verified`? | **no — never mentions them** | yes, first-class |
| **§5.2 is…** | *"Relative links"* | *"Trust: `generated` and `verified`"* |
| validator | 261 lines | 565 lines, adds §13.1 `sources` checks |
| warnings on this bundle | 90 | 84 |

**This bundle is `okf_version: "0.2"`, so the v0.2 copy governs.**

That mismatch is what produced two confident wrong rejections of a correct review finding on #538 — §5.2 looked up in the wrong copy, twice, and the reviewer told miscited. It also means a warning total is only meaningful next to the validator that produced it.

## For Paul — a tooling decision, not a bundle edit

`CLAUDE.md` routes sessions to `/okf:validate`, and the skill's own instruction is to read **its bundled spec** as canonical. On this machine that points at **v0.1** while the bundle is **v0.2**, so the next session inherits the same trap unless the skill is repointed. Flagged rather than changed.

## Gates

v0.2 `okf_validate .okf` exits **0**, conformant (84 warnings). Root index frontmatter unchanged (`okf_version` only, per the reserved-file rule). Verified with positive *and* negative controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
