### PR TITLE
OKF: close the gap #541/#543 left, and correct one rule they disproved

### DIFF
--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -4,8 +4,9 @@ title: Test gates and when they block commits
 description: bin/qtest --changed is the routine gate; bin/rake test:critical at milestones; bin/test AND bin/dtest once at PR prep (or on explicit confirmation) for themes/, layouts/, or CSS changes.
 tags: [testing, visual-regression, gates]
 status: stable
-generated: { by: claude/opus-5, at: 2026-08-21T07:42:17Z }
+generated: { by: claude/opus-5, at: 2026-08-21T09:59:40Z }
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T09:59:40Z }
   - { by: claude/opus-5, at: 2026-08-21T07:42:17Z }
   - { by: claude/opus-5, at: 2026-08-21T06:44:05Z }
   - { by: claude/opus-5, at: 2026-08-21T06:36:48Z }
@@ -20,7 +21,7 @@ verified:
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
   - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
-timestamp: 2026-08-21T07:42:17Z
+timestamp: 2026-08-21T09:59:40Z
 ---
 
 # The suites
@@ -41,7 +42,7 @@ is `simple-page`); the changed-file→page map lives in the script itself -
 extend it when adding components or critical files. The macOS full suite remains the only dedup-trap catcher
 (Linux font resolution masks it) - never finish a component on qtest alone.
 
-# Run the suite on PRISTINE master before trusting a green screenshot run
+# Run the suite at the MERGE BASE before trusting a green screenshot run
 
 A green screenshot run proves nothing until you know the suite is green with NO
 change in the tree. Measured in a worktree on 2026-08-21:
@@ -62,8 +63,15 @@ article body VERTICALLY SHIFTED. A `background-color` change cannot move layout,
 and it nearly got accepted anyway because it arrived batched with diffs that
 genuinely were the intended recolour.
 
-So establish the baseline-of-the-baseline first - `git checkout origin/master --
-themes/ test/fixtures/screenshots/`, build, run. If master is not green here,
+So establish the baseline-of-the-baseline first - `git checkout "$(git merge-base
+origin/master HEAD)" -- themes/ test/fixtures/screenshots/`, build, run.
+
+**The merge base, NOT current `origin/master`** (corrected 2026-08-21 by review of
+PR #543). Master moves after a branch is cut, so comparing against its current
+tip smuggles unrelated upstream failures into your delta and attributes them to
+your change. Rebase immediately before measuring and run both sides in the same
+environment. Same correction this bundle already made for `git diff` when
+checking `verified` rows. If master is not green here,
 this machine cannot produce trustworthy baselines: record them where the
 canonical ones came from (`gh workflow run test.yml --ref <branch> -f
 screenshots=true -f update-baselines=true`), which is the rule

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -51,6 +51,46 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
+## 2026-08-21 - what 15 review findings on one document taught, and one rule reversed
+
+Closing the OKF gap on PRs #541/#543: the delivery prompt shipped and was then
+corrected 15 times, but the durable learnings from those corrections never
+reached the bundle. #543 changed durable process rules without an `.okf/` update
+- the same-commit gate failing on the PR that documents the gate.
+
+**A correction, not an addition.** `build/test-gates.md` said to run the suite on
+PRISTINE master. That is wrong once a branch is a few hours old: master moves
+after the branch is cut, so its current tip is not the branch's counterfactual
+baseline and unrelated upstream failures land in your delta attributed to your
+change. Corrected to the MERGE BASE, rebased immediately before measuring, both
+sides in one environment. Same correction this bundle already made for `git diff`
+when checking `verified` rows - I made it there and did not carry it here.
+
+**The reversal, recorded in [workflows/review-swarm.md](workflows/review-swarm.md).**
+The delivery prompt originally said to brief a verifier with the goal and
+artifact but NEVER the author's reasoning. A verifier overturned that and proved
+it by method: it read the document's own argument, attacked it, and produced 10
+findings - two logical contradictions and a conflict with `CLAUDE.md` among them
+- that the blind version would have forbidden it to look for. A blind verifier
+re-derives from scratch, which means running the same command on the same
+instrument and reproducing the instrument error at double cost. The defects that
+ship here are reasoning-shaped, and the reasoning is where the assumptions are.
+The original fear was real but misdiagnosed - handing over a VERDICT is what
+contaminates, and that is already handled by demanding measurements.
+
+**Two reviewers catch different GENERATIONS of defect.** The internal sub-agent
+reviewed the original and found 10. The external companion then reviewed the
+REPAIR and found 5 more, two of them introduced by the fixes for the first set: a
+WIP rule that deadlocked the appendix it had just corrected, and a docs-only
+exception that contradicted the instruction layer written an hour earlier.
+Neither would have found the other's set. That is the concrete form of "round N's
+fixes introduce round N+1's defects" - cheap internal reviewer on every stage,
+expensive external one reading what the repairs did.
+
+Also recorded: a dissent satisfied by a manufactured nitpick is worse than none.
+Ask for the strongest finding AGAINST shipping with evidence; permit "no
+objection" only when it names the check that ran.
+
 ## 2026-08-21 - the autonomous delivery prompt, and what its own review caught
 
 Added `docs/workflows/autonomous-delivery-prompt.md` - the operating prompt for

--- a/.okf/workflows/review-swarm.md
+++ b/.okf/workflows/review-swarm.md
@@ -5,14 +5,15 @@ description: The proven module-review loop - a design critic (full render walk) 
 tags: [swarm, review, process]
 generated:
   by: claude/opus-5
-  at: 2026-08-21T05:33:58Z
+  at: 2026-08-21T09:59:40Z
 verified:
+  - { by: claude/opus-5, at: 2026-08-21T09:59:40Z }
   - { by: claude/opus-5, at: 2026-08-21T05:33:58Z }
   # Two earlier checks are NOT listed here: their times were invented, no offset
   # recovers them, and a `verified` event requires `at`. They are recorded in
   # log.md 2026-08-21 with their bounding commits (8fa41494b, 86c2c91cc) - prose
   # can say "time unknown", this schema cannot.
-timestamp: 2026-08-21T05:33:58Z
+timestamp: 2026-08-21T09:59:40Z
 ---
 
 # The loop
@@ -258,6 +259,46 @@ verdict format, and the two or three specific things to attack.
   A number lives in more places than the document that owns it. `grep -rn` the
   old value across docs and the bundle, and treat every surviving hit as stale
   unless it is explicitly framed as retracted history.
+
+- **Brief verifiers WITH the author's reasoning - the blind version reproduces
+  the author's error** (2026-08-21, reversal). An earlier rule said to give a
+  verifier the goal and artifact but never the reasoning, on the theory that
+  exposure contaminates. A verifier overturned it and proved the point by method:
+  it read the document's own argument, attacked it, and returned 10 findings -
+  including two logical contradictions and a conflict with `CLAUDE.md` - that the
+  blind version would have forbidden it to look for.
+
+  A blind verifier re-derives from scratch, which in practice means running the
+  same command on the same instrument and reproducing the instrument error at
+  double cost. The defects that actually ship here are reasoning-shaped - stale
+  premises, prescriptive claims, flattering denominators - and those live in the
+  ASSUMPTIONS, which is exactly what withholding the reasoning hides.
+
+  The original fear was real but misdiagnosed: handing over a **verdict** gets it
+  back wearing independent confidence. That is verdict contamination, already
+  handled by demanding measurements rather than verdicts. Exposing HOW you
+  reasoned is not telling them WHAT to conclude. Ask the verifier to attack the
+  assumptions and produce one measurement the author did not run.
+
+- **Two reviewers are not redundant - they catch different GENERATIONS of defect**
+  (2026-08-21, measured on PRs #541/#543). An internal sub-agent reviewed the
+  original document and found 10 defects. The external companion then reviewed
+  the REPAIR and found 5 more, two of which were introduced by the fixes for the
+  first set: a WIP rule that deadlocked the appendix it had just corrected, and a
+  docs-only exception that contradicted the instruction layer written an hour
+  earlier.
+
+  Neither reviewer would have found the other's set. This is the concrete form of
+  "round N's fixes introduce round N+1's defects" above: the cheap internal
+  reviewer belongs on every stage, and the expensive external one earns its cost
+  by reading what the repairs did.
+
+- **A dissent satisfied by a nitpick is worse than none** (2026-08-21). "Require
+  a dissent" is compliable by instructing a reviewer to disagree about anything.
+  Ask instead for the strongest finding AGAINST shipping with its evidence, and
+  permit "no objection" only when it names the check that was run. Independent
+  agreement is a valid outcome; manufactured disagreement buys the appearance of
+  friction and none of its value.
 
 - **Docs review converges slowly - budget more than one round** (2026-08-21).
   Three rounds returned 8, 7 and 9 findings on a documentation-only PR, and


### PR DESCRIPTION
Closes the OKF gap left by #541/#543. **#543 changed durable process rules and shipped without a bundle update** — the same-commit gate failing on the PR that documents the gate.

One item is a **correction**, not an addition.

## Correction: `PRISTINE master` → `MERGE BASE`

`build/test-gates.md` told you to run the suite on pristine `master` before trusting a green run. That's wrong once a branch is a few hours old — master moves after the branch is cut, so its current tip isn't the branch's counterfactual baseline. Unrelated upstream failures land in your delta and get attributed to your change.

```bash
git checkout "$(git merge-base origin/master HEAD)" -- themes/ test/fixtures/screenshots/
```

Plus rebase-immediately-before-measuring, both sides in one environment.

This bundle had **already made this exact correction** for `git diff` when checking `verified` rows — I made it there yesterday and didn't carry it across. Sweep-it-everywhere failing between two concepts in the same tree.

## The reversal → `workflows/review-swarm.md`

The delivery prompt originally told verifiers to work blind: goal and artifact, **never** the author's reasoning.

A verifier overturned it and proved the point by method — it read the document's own argument, attacked it, and returned **10 findings** the blind version would have forbidden it to look for, including two logical contradictions and a conflict with `CLAUDE.md`.

> A blind verifier re-derives from scratch, which in practice means running the same command on the same instrument and **reproducing the instrument error at double cost.** The defects that ship here are reasoning-shaped — stale premises, prescriptive claims, flattering denominators — and those live in the *assumptions*, which is exactly what withholding the reasoning hides.

The original fear was real but misdiagnosed: handing over a **verdict** is what contaminates, and that's already handled by demanding measurements rather than verdicts.

## Why two reviewers aren't redundant

Measured on #541/#543:

| Reviewer | Read | Found |
|---|---|---|
| internal sub-agent | the original | 10 |
| external companion | **the repair** | 5 more — **2 created by the first set's fixes** |

Those two: a WIP rule that deadlocked the appendix it had just corrected, and a docs-only exception that contradicted the instruction layer written an hour earlier. **Neither reviewer would have found the other's set.**

That's the concrete form of *"round N's fixes introduce round N+1's defects"* — cheap internal reviewer on every stage, expensive external one reading what the repairs did.

## Also

A dissent satisfied by a manufactured nitpick is worse than none — ask for the strongest finding *against shipping* with its evidence, and permit "no objection" only when it names the check that ran. Independent agreement is a valid outcome.

## Gates

`okf_validate .okf` exits **0**. Both concepts stamped with measured UTC; `verified` rows diffed against the merge base — additions only, no overwritten events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
