### PR TITLE
Visual gate: default tolerance 0.02 → 0.0001 (the gate was blind by 50x)

### DIFF
--- a/.okf/build/index.md
+++ b/.okf/build/index.md
@@ -1,6 +1,6 @@
 # Build & Test
 
 * [Hugo build pipeline](hugo-build.md) - bin/hugo-build with the 8 course validators; also the PurgeCSS cold-start race and the minified-unquoted-attribute audit-tool trap
-* [Test gates](test-gates.md) - the local suites, when each is a commit blocker, bin/record-baselines for accepting only the baselines you meant to move, and why a deleted source file still serves from every local _dest/ tree, plus the NULL CHANGE - a diff that passes every gate and alters nothing - and what `okf_validate` actually guards (shape, not truth; error-only conformance) with the two-spec trap
+* [Test gates](test-gates.md) - the local suites, when each is a commit blocker, the 0.0001 default tolerance, the SECTION_CONFIGS shield, why a green run never refreshes a baseline, and why below-fold content is invisible at any tolerance, bin/record-baselines for accepting only the baselines you meant to move, and why a deleted source file still serves from every local _dest/ tree, plus the NULL CHANGE - a diff that passes every gate and alters nothing - and what `okf_validate` actually guards (shape, not truth; error-only conformance) with the two-spec trap
 * [CI gates](ci-gates.md) - what GitHub Actions enforces: build, unit, path-scoped link check (visual regression is report-only), and what gates a PR never sees
 * [Template PDFs](pdf-templates.md) - regenerating the downloadable course PDFs

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -4,7 +4,7 @@ title: Test gates and when they block commits
 description: bin/qtest --changed is the routine gate; bin/rake test:critical at milestones; bin/test AND bin/dtest once at PR prep (or on explicit confirmation) for themes/, layouts/, or CSS changes.
 tags: [testing, visual-regression, gates]
 status: stable
-generated: { by: claude/opus-5, at: 2026-08-21T09:59:40Z }
+generated: { by: claude/opus-5, at: 2026-08-21T16:28:27Z }
 verified:
   - { by: claude/opus-5, at: 2026-08-21T09:59:40Z }
   - { by: claude/opus-5, at: 2026-08-21T07:42:17Z }
@@ -21,7 +21,7 @@ verified:
   - { by: claude/sonnet-5, at: 2026-08-20T00:00:00Z }
   - { by: claude/opus-5, at: 2026-08-20T21:43:35Z }
   - { by: claude/opus-5, at: 2026-08-20T21:47:30Z }
-timestamp: 2026-08-21T09:59:40Z
+timestamp: 2026-08-21T16:28:27Z
 ---
 
 # The suites
@@ -85,9 +85,91 @@ evidence is independent of baseline drift.
 
 **0.0 for refactors** (a refactor must move zero pixels), **<=0.03 for
 genuinely new features**. This is the policy for what you ACCEPT, distinct from
-the mechanical defaults: `DEFAULT_SCREENSHOT_CONFIG` is 0.02
-(`test/application_system_test_case.rb:87`) and individual calls may pin their
-own (e.g. 0.03 at `test/system/blog_special_content_test.rb:136`).
+the mechanical default that decides whether the suite even reports a diff.
+
+That default is **0.0001** (`DEFAULT_SCREENSHOT_CONFIG`,
+`test/support/screenshot_section_config.rb:29`), lowered from 0.02 on 2026-08-21.
+Both halves still hold: the accept-policy is unchanged, and individual calls
+may still pin their own tolerance (~30 do, mostly 0.03 - e.g.
+`test/system/blog_special_content_test.rb:136`), which the default never
+overrides. What changed is the floor for calls that pin NOTHING.
+
+**`SECTION_CONFIGS` is now a deliberate temporary shield, not configuration.**
+Its 7 keys all held 0.02, which equalled the old default - so the table was a
+silent no-op for as long as it existed. Lowering the default made it
+load-bearing: it now holds ~22 section screenshots at the OLD tolerance while
+their drift is unmeasured. It is kept ON PURPOSE and deleted once those are
+measured and re-recorded. Its keys match the tail after `/_`, which is easy to
+misread: `services/_technologies` hits the `technologies` key (0.02), while
+`services/_testimonials-header` does NOT hit `testimonials` and gets the
+default - one string, not a prefix. Both the table and the rule live in
+`test/support/screenshot_section_config.rb`, apart from
+`ApplicationSystemTestCase` so they can be unit-tested without booting Hugo,
+Capybara, or that file's dirty-fixtures `abort`; the near-miss above is pinned
+in `test/unit/screenshot_section_config_test.rb`.
+
+Why 0.0001: on a 1920x1080 capture, 0.02 means ~41,472 pixels must differ
+before the assertion fails. A one-cell copy edit measures 0.0004 (844 px), so
+the gate was blind to it by 50x - and passed, which is worse than failing
+(see the fossilization bullet below). Measured run-to-run noise on a static
+page is 0.0, so the floor only has to clear zero; 0.0001 (~207 px) fails that
+copy edit and goes green again when it is reverted. The noise claim is
+checkable without re-running the copy edit: two independent runs of the same
+test reported difference_levels identical to 16 decimal places (0.6893909143518518
+for `services/_footer` every time), and 2 of the 7 screenshots stayed GREEN at
+0.0001 even with the shield removed - a floor that low is not tripping on
+render jitter.
+
+**What the change actually catches**, measured three ways on
+`DesktopSiteTest#test_services` at clean HEAD (macOS, 7 screenshots compared
+each run). The middle column is what shipped:
+
+| screenshot | difference_level | 0.02 | shipped | +deleting the shield |
+|---|---|---|---|---|
+| `services/_footer` | 0.689391 | FAIL | FAIL | FAIL |
+| `services/_cta-contact_us` | 0.457970 | FAIL | FAIL | FAIL |
+| `services/_testimonials-header` | 0.005923 | pass | **FAIL** | **FAIL** |
+| `services/_use-cases` | 0.017498 | pass | pass (shield) | **FAIL** |
+| `services/_technologies` | 0.013838 | pass | pass (shield) | **FAIL** |
+| totals | | 2 | **3** | 5 |
+
+**Measure the default change and the shield deletion SEPARATELY** - conflating
+them is a mistake that was actually made here. A first pass deleted
+`SECTION_CONFIGS` in the same commit, measured 5 failures, and reported the
+default change as costing +3 screenshots. It costs **+1**; the other +2 are the
+shield deletion, and they are exactly the two whose names happen to hit a
+SECTION_CONFIGS key. The two changes look like one line and one dead constant,
+but they move different screenshots.
+
+All of these are the #540 dark-surface recolour: real stale-baseline
+detections, not machine drift, and not caused by the tolerance change.
+
+# Below the fold is invisible to the gate at ANY tolerance
+
+Tolerance is the smaller of the two blind spots. Captures are **viewport-only,
+taken at scroll top**: 1920x1080 desktop, 360x800 mobile
+(`test/support/setup_capybara.rb:85-86`). Everything below that first fold is
+simply not in the image, so no tolerance can catch a change there - measured, a
+table-cell edit produced difference_level **exactly 0** on mobile even at
+tolerance 0. Corroborating tell in any failure payload: the reported `region`
+never exceeds the viewport height (e.g. `[0.0,42.0,1920.0,1080.0]` for
+`services/_footer`).
+
+There is a second tolerance-independent axis: `Capybara::Screenshot::Diff.perceptual_threshold = 2.0`
+(`test/support/setup_snap_diff.rb:25`) means the vips driver only counts a
+pixel as differing once it is more than CIE dE00 2.0 from the baseline pixel.
+A recolour that stays under that contributes ZERO differing pixels, so it
+passes at ANY tolerance including 0 - most relevant to palette and
+dark-surface work, where a shift can be deliberate, visible and still
+sub-threshold.
+
+This is why the suite leans on per-section screenshots - each one scrolls its
+section INTO the viewport first (`verify_section_for` →
+`scroll_to find(css)`), which is the existing workaround, not an accident.
+A page asserted only as one top-of-page shot is verified for its first fold and
+nothing else. Closing the gap properly means either more section shots or
+full-page capture; both are out of scope for the tolerance change and belong to
+the follow-up that re-records baselines.
 
 # Rake tasks and suite layout
 
@@ -107,15 +189,16 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
 
 # Hard-won caveats
 
-- **The 2% default tolerance hides small text/colour changes** (2026-08-14).
-  `DEFAULT_SCREENSHOT_CONFIG = {tolerance: 0.02}`
-  (`test/application_system_test_case.rb:87`). Turning a four-word phrase into
-  a link on the homepage changed ~0.24% of the frame, so the gate PASSED and
-  the baseline was never re-recorded - it still shows the pre-change render.
-  Consequence: a green visual suite does NOT mean "no visual change", only "no
-  change larger than 2% of the frame". For link/colour/short-text edits,
-  verify by reading the built HTML or the render, not by trusting green. This
-  is the false-green class documented in
+- **The 2% default tolerance hid small text/colour changes** (2026-08-14,
+  FIXED 2026-08-21 by lowering the default to 0.0001 - see Tolerance policy).
+  Turning a four-word phrase into a link on the homepage changed ~0.24% of the
+  frame, so the gate PASSED and the baseline was never re-recorded - it still
+  showed the pre-change render. The residual rule outlives the fix, because
+  ~30 calls still pin 0.03 of their own: a green visual suite does NOT mean
+  "no visual change", only "no change larger than THAT call's tolerance". For
+  link/colour/short-text edits on a page whose call pins a tolerance, verify by
+  reading the built HTML or the render, not by trusting green. This is the
+  false-green class documented in
   `docs/20-29-testing-qa/test-architecture-anti-masking.md`.
 - **Flat-file posts are invisible to the visuals ratchet** (2026-08-20).
   `bin/check-post-visuals` globs `content/blog/*/index.md`, so a post living as
@@ -130,6 +213,14 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
   normally discards sub-tolerance Rosetta drift, so a run rewrites all 45
   Linux baselines rather than the few your change moved. On `bin/qtest`
   the flag appears to be ignored entirely - the suite still compares.
+
+  **The two readers disagree on what counts as set** (identified 2026-08-21,
+  NOT fixed - known wart): `bin/qtest:209` skips its restore on ANY truthy
+  value, while `test/support/setup_snap_diff.rb:28` enters record mode only
+  on the literal string `"true"`. So `FORCE_SCREENSHOT_UPDATE=1` on qtest
+  gets the worst of both - the suite still compares and fails, and the
+  restore that would have cleaned up is skipped. Spell it `=true`, or better,
+  use `bin/record-baselines`.
 
   **Use `bin/record-baselines <glob>...` instead of doing this by hand**
   (shipped 2026-08-20, PR #489; the manual dance had been done 3x). It runs
@@ -179,8 +270,8 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
   the re-record was never needed at all. Full suite green after the CI
   record: 356 runs, 6329 assertions, 0 failures (run 32347402944). Note the
   governing tolerance for these is **0.03**, set per-call at
-  `test/system/blog_special_content_test.rb:136` - NOT the 0.02
-  `DEFAULT_SCREENSHOT_CONFIG` in `test/application_system_test_case.rb:87`,
+  `test/system/blog_special_content_test.rb:136` - NOT the
+  `DEFAULT_SCREENSHOT_CONFIG` in `test/support/screenshot_section_config.rb:29`,
   which only applies when a call omits an explicit tolerance.
 
 - **Content-only diffs skip the visual suites entirely** (Paul 2026-07-31).
@@ -199,8 +290,11 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
   every later local run red until someone re-records (2026-07-31: #405's
   28px mobile hero gap shipped with a commit-message note instead of updated
   baselines - cost a full false "bistable render" investigation). Re-record =
-  run the suite, keep the rewritten PNG, COMMIT it; only then can a rerun go
-  green.
+  run the suite so the FAILING run leaves its candidate on disk, keep that
+  rewritten PNG, COMMIT it; only then can a rerun go green. Deleting the PNG
+  first does nothing - the base is read from git HEAD, not from the file - and
+  a run that PASSES restores the HEAD image over the fresh capture, so there
+  is nothing to keep. Only a red run produces a committable baseline.
 - **A local visual red cannot condemn a branch until you have run the same
   thing on master** (2026-08-21). Verifying PR #511 (template/CSS class),
   `bin/qtest --changed` went red pointing at `services/fractional-cto`
@@ -242,7 +336,16 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
   in one checkout; skipped under `FORCE_SCREENSHOT_UPDATE`),
   so passing runs no longer leave the tree dirty or arm the dirty-fixture
   guard against the next run. A RED run still keeps candidates + diff
-  artifacts for inspection. Never edit CSS while a suite is running - a
+  artifacts for inspection.
+
+  **This is why a sub-tolerance change FOSSILIZES the baseline.** The two
+  behaviours compose: the capture overwrites the PNG, then the pass restores
+  the git-HEAD image back over it. So a green run never refreshes anything,
+  and any real change small enough to pass leaves the baseline showing the
+  OLD render - permanently, until something large enough to fail arrives and
+  the accumulated drift gets accepted in one lump nobody can attribute. The
+  lower the tolerance, the less can accumulate; it does not remove the
+  mechanic, which is inherent to the gem's design. Never edit CSS while a suite is running - a
   raced run once saved a corrupt baseline missing its hero image.
 - Test builds MUST use `baseURL "/"` - enforced as `bin/build-if-stale`'s
   default, which all four runners build through (CI's setup-hugo action

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -51,6 +51,101 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
+## 2026-08-21 - the visual gate was blind by 50x, and green runs never refresh a baseline
+
+`DEFAULT_SCREENSHOT_CONFIG` tolerance 0.02 -> **0.0001**
+(`test/support/screenshot_section_config.rb:29`). On a 1920x1080 capture 0.02 means
+~41,472 pixels must differ before the assertion fails; a real one-cell copy
+change measures **0.0004 (844 px)** and passed silently. Measured run-to-run
+noise on a static page is **0.0**, so the floor only has to clear zero -
+acceptance was double-checked both ways: at 0.0001 the copy edit FAILS
+(0.000454) and goes green again when reverted.
+
+**Why passing quietly is worse than failing.** capybara-screenshot-diff writes
+the fresh capture over the baseline PNG, and on a PASS the runner restores the
+git-HEAD image back over it. The two compose into fossilization: a green run
+never refreshes a baseline, so every sub-tolerance change leaves the committed
+PNG showing the OLD render until something big enough to fail arrives and the
+accumulated drift is accepted in one unattributable lump. Corollary for
+re-recording: only a RED run leaves a committable candidate on disk. Deleting
+the PNG first does nothing - the base is read from git HEAD, not the file.
+
+**`SECTION_CONFIGS` was a no-op and is now a shield - do not delete it in this
+commit.** Its 7 keys all held 0.02, identical to the old default, so it did
+nothing for as long as it existed. Lowering the default INVERTED that: it now
+holds ~22 section screenshots at the old tolerance while their drift is
+unmeasured. Kept deliberately, with a comment saying so, and deleted by the
+follow-up that measures and re-records them.
+
+**A measurement error worth remembering: the default change and the shield
+deletion move DIFFERENT screenshots, and I conflated them.** The first pass
+deleted `SECTION_CONFIGS` in the same commit, measured `test_services` at 5
+failures vs 2, and reported the default change as costing +3 screenshots -
+contradicting an earlier +1 estimate and asserting the estimate had failed to
+reproduce. Re-measured three ways on the same test (7 screenshots compared):
+**0.02 → 2 failures, shipped config → 3, shield also deleted → 5.** The default
+change costs exactly **+1** (`services/_testimonials-header`, 0.005923); the
+other +2 (`services/_use-cases` 0.017498, `services/_technologies` 0.013838)
+are the shield deletion, and they are precisely the two whose names hit a
+SECTION_CONFIGS key - `/_technologies` matches `technologies`, while
+`/_testimonials-header` does NOT match `testimonials`. Two changes that look
+like one line plus one dead constant were never one measurement. The reds are
+the #540 dark-surface recolour - the macOS twin of the Linux list in the entry
+"PR #540 hands 16 stale Linux baselines to the parallel PR" - not machine drift
+and not caused by this change, and NOT re-recorded here.
+
+**Tolerance is the smaller blind spot; the bigger one is the fold.** Captures
+are viewport-only at scroll top (1920x1080 desktop, 360x800 mobile,
+`test/support/setup_capybara.rb:85-86`), so below-fold content is invisible at
+ANY tolerance - a table-cell edit measured difference_level exactly 0 on mobile
+even at tolerance 0. The tell is in every failure payload: `region` never
+exceeds the viewport height. Per-section screenshots scroll their section into
+view first, which is why the suite leans on them. Out of scope here.
+
+**The shield went from inert to safety-critical with zero coverage**, so the
+mapping moved to `test/support/screenshot_section_config.rb` and is pinned by
+`test/unit/screenshot_section_config_test.rb` (5 cases, no browser). It had to
+move: requiring `application_system_test_case.rb` from a unit test boots Hugo,
+Capybara AND that file's dirty-fixtures `abort` - a unit suite that dies when
+screenshots are dirty is worse than no test. The guard was verified by mutation
+(make `extract_section_key` split on `-` so `_testimonials-header` matches the
+`testimonials` shield → 1 failure; revert → 289 runs green). The dead
+`|| name.to_s.split("/").last` fallback went with it - unreachable, since
+`String#split.last` is nil only for `""`, where the fallback is nil too.
+
+**A third blind spot, tolerance-independent like the fold:**
+`perceptual_threshold = 2.0` (`test/support/setup_snap_diff.rb:25`) means vips
+only counts a pixel as differing above CIE dE00 2.0 from the baseline. A
+recolour staying under that contributes ZERO differing pixels and passes at ANY
+tolerance including 0 - which is precisely the palette/dark-surface work this
+repo keeps doing.
+
+**Live doctrine still taught the old world**, swept truthful per the
+canon-sweeps-the-instruction-layer rule:
+`20.02-screenshot-testing-workflow-tutorial.md` documented a
+`SCREENSHOT_TOLERANCE` env var that exists NOWHERE in the codebase (fiction
+predating this change, and it claimed a 1% default the code never had) plus a
+0.02 example; `visual-qa-criteria.md:120` pinned 0.02. Removed/corrected. The
+archived SCREENSHOT_GUARDIAN_PROTOCOL is left alone - it is an archive.
+Two MORE fictions surfaced in the same tutorial and were swept too:
+`assert_stable_problematic_screenshot` (a helper with its own documented
+section, defaults and three call sites - the real aliases are
+`assert_stable_screenshot` / `assert_cta_screenshot` / `assert_quick_screenshot`)
+and the per-OS "tolerance multiplier" table (0.8x/1.2x/1.3x). Neither matches
+anything in `test/`, `bin/` or `lib/`. **A doctrine file names its own
+mechanisms, so its fiction is executable-looking and gets copied** - the
+tutorial's fake helper had already propagated into three "recommendations"
+elsewhere in the same file.
+
+Concept updated: [build/test-gates.md](build/test-gates.md).
+
+**Known wart, identified and NOT fixed:** the two `FORCE_SCREENSHOT_UPDATE`
+readers disagree on what counts as set - `bin/qtest:209` skips its restore on
+any truthy value, `test/support/setup_snap_diff.rb:28` enters record mode only
+on the literal `"true"`. `=1` on qtest therefore gets the worst of both: the
+suite still compares and fails, and the cleanup is skipped. That is the
+mechanism behind the older "the flag appears to be ignored on qtest" note.
+
 ## 2026-08-21 - anatomy settled, register under test: the pilots flow
 
 Paul's PR-2 review ("looks like a blog, not a presentation") exposed that we

--- a/docs/20-29-testing-qa/20.10-test-coverage-gap-analysis-reference.md
+++ b/docs/20-29-testing-qa/20.10-test-coverage-gap-analysis-reference.md
@@ -425,10 +425,10 @@ with any content ratchet - assert structure, per 20.05.
    density); those are the only rules still enforced by review alone. Measured
    worth of review in this cycle: it under-counted by ~18 violations against a
    test holding the same list.
-4. **Screenshot tolerance is 2%** (`application_system_test_case.rb:87`), so a
-   four-word link change (~0.24% of frame) passes and never re-records the
-   baseline. A green visual suite means "no change over 2%", not "no change".
-   Left as-is deliberately; documented in `.okf/build/test-gates.md`.
+4. **FIXED 2026-08-21 — screenshot tolerance was 2%**, so a four-word link
+   change (~0.24% of frame) passed and never re-recorded the baseline. Default
+   is now 0.0001 (`test/support/screenshot_section_config.rb`); mechanism,
+   remaining blind axes, and the section-shield are in `.okf/build/test-gates.md`.
 5. **`content/clients/**` is not covered** by the marketing ratchet and still
    carries "to the next level" in two case-study excerpts. The exclusion is
    commented in the test rather than implied.

--- a/docs/20-29-testing-qa/screenshot-testing/20.02-screenshot-testing-workflow-tutorial.md
+++ b/docs/20-29-testing-qa/screenshot-testing/20.02-screenshot-testing-workflow-tutorial.md
@@ -40,7 +40,7 @@ def test_homepage_sections
   
   sections.each do |section_id|
     scroll_to find("##{section_id}")
-    assert_stable_screenshot "homepage/_#{section_id}", tolerance: 0.02
+    assert_stable_screenshot "homepage/_#{section_id}"
   end
 end
 ```
@@ -59,25 +59,6 @@ end
 def test_navigation
   visit "/"
   assert_quick_screenshot "navigation"
-end
-```
-
-### 3. `assert_stable_problematic_screenshot(name, **options)`
-
-**Use Case**: Flaky areas with dynamic content or animations  
-**Default Settings:**
-
-- Wait time: 5 seconds
-- Stability time: 2.0 seconds
-- Tolerance: 2.5%
-- Median filtering enabled (reduces noise)
-
-```ruby
-# Example usage - for dynamic content areas
-def test_blog_pagination
-  visit "/blog/"
-  scroll_to find("#pagination")
-  assert_stable_problematic_screenshot "blog/index/_pagination", skip_area: [".blog-post"]
 end
 ```
 
@@ -179,10 +160,7 @@ bin/test # Re-run to generate new baseline
 ### Key Environment Variables
 
 ```bash
-# Global tolerance (default: 1%)
-SCREENSHOT_TOLERANCE=0.02
-
-# Stability wait time (default: 1.0s)  
+# Stability wait time (default: 0.1s)
 SCREENSHOT_STABILITY_TIME=2.0
 
 # Force regeneration of all baselines
@@ -192,12 +170,6 @@ FORCE_SCREENSHOT_UPDATE=true
 CAPYBARA_SCREENSHOT_DIFF_FAIL_ON_DIFFERENCE=false
 ```
 
-### OS-Specific Tolerance Adjustments
-
-- **macOS**: 0.8x tolerance multiplier (more consistent rendering)
-- **Linux**: 1.2x tolerance multiplier (font rendering variations)  
-- **Windows**: 1.3x tolerance multiplier (highest rendering variations)
-
 ## Current Test Analysis & Recommendations
 
 ### Failure 1: `desktop/clients/_clients` (3.06% difference)
@@ -205,14 +177,12 @@ CAPYBARA_SCREENSHOT_DIFF_FAIL_ON_DIFFERENCE=false
 **Status**: ⚠️ **Review Required**
 
 - Large area affected (1.7M pixels)
-- Above problematic screenshot threshold (2.5%)
 - **Recommendation**: Manual review required, likely acceptable change
 
 ### Failure 2: `desktop/blog/index/_pagination` (2.75% difference)  
 
 **Status**: ✅ **Likely Acceptable**
 
-- Already using `assert_stable_problematic_screenshot` (2.5% tolerance)
 - Dynamic content area with blog posts
 - **Recommendation**: Review and likely accept change
 
@@ -221,8 +191,6 @@ CAPYBARA_SCREENSHOT_DIFF_FAIL_ON_DIFFERENCE=false
 **Status**: ⚠️ **Review Required**
 
 - Large area affected (2.0M pixels)
-- Above standard tolerance but below problematic threshold
-- **Recommendation**: Consider switching to `assert_stable_problematic_screenshot`
 
 ## Maintenance Best Practices
 
@@ -264,10 +232,10 @@ ls test/fixtures/screenshots/macos/desktop/
 
 ### Issue: Flaky Screenshots
 
-**Solution**: Use `assert_stable_problematic_screenshot` with higher tolerance
+**Solution**: Pin a higher tolerance on the call
 
 ```ruby
-assert_stable_problematic_screenshot "flaky_component", tolerance: 0.035
+assert_stable_screenshot "flaky_component", tolerance: 0.035
 ```
 
 ### Issue: Dynamic Content Failures
@@ -283,7 +251,6 @@ assert_stable_screenshot "page", skip_area: [".timestamp", ".dynamic-content"]
 ### Strengths ✅
 
 - Comprehensive helper method coverage
-- OS-specific tolerance handling
 - Excellent diff file generation
 - Well-organized directory structure
 - Environmental configuration flexibility

--- a/docs/20-29-testing-qa/screenshot-testing/visual-qa-criteria.md
+++ b/docs/20-29-testing-qa/screenshot-testing/visual-qa-criteria.md
@@ -117,7 +117,7 @@ required_pattern: /section_[a-z_]+_\d{8}_\d{6}\.png/
 
 ### Production Deployment
 ```yaml
-tolerance_threshold: 0.02  # 2% maximum difference
+tolerance_threshold: 0.0001  # default since 2026-08-21; was 0.02
 minimum_score: 9.0         # Grade A- minimum
 requires_manual_review: false
 auto_deployment: true

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -10,6 +10,7 @@ require "puma"
 require "support/setup_capybara"
 require "support/setup_snap_diff"
 require "support/hugo_helpers"
+require "support/screenshot_section_config"
 
 # Every system-test run REWRITES the committed baseline PNGs in place
 # (snap_diff design: working tree = candidate, git HEAD = baseline). Starting
@@ -73,18 +74,7 @@ class ApplicationSystemTestCase < Minitest::Test
   include CapybaraScreenshotDiff::Minitest::Assertions
   include NavigationHelpers
 
-  # Ruby hash-based configuration for screenshot sections
-  SECTION_CONFIGS = {
-    "cta" => {tolerance: 0.02},
-    "cta-contact_us" => {tolerance: 0.02},
-    "clients" => {tolerance: 0.02},
-    "use-cases" => {tolerance: 0.02},
-    "technologies" => {tolerance: 0.02},
-    "testimonials" => {tolerance: 0.02},
-    "why-us" => {tolerance: 0.02}
-  }.freeze
-
-  DEFAULT_SCREENSHOT_CONFIG = {tolerance: 0.02}.freeze
+  include ScreenshotSectionConfig
 
   private
 
@@ -120,15 +110,6 @@ class ApplicationSystemTestCase < Minitest::Test
     Capybara.using_wait_time(0) do
       assert_matches_screenshot(name, **final_options)
     end
-  end
-
-  def screenshot_config_for(name)
-    section_key = extract_section_key(name)
-    SECTION_CONFIGS.fetch(section_key, DEFAULT_SCREENSHOT_CONFIG)
-  end
-
-  def extract_section_key(name)
-    name.to_s.split("/_").last || name.to_s.split("/").last
   end
 
   # Backward compatibility aliases - will be deprecated once all tests updated

--- a/test/support/screenshot_section_config.rb
+++ b/test/support/screenshot_section_config.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Which tolerance a screenshot assertion gets, by name.
+#
+# Lives apart from ApplicationSystemTestCase so it can be unit-tested without
+# booting Hugo, Capybara or the dirty-fixtures guard that file runs on load.
+module ScreenshotSectionConfig
+  # TEMPORARY SHIELD, not configuration. Every value here equalled the old 0.02
+  # default, so this table did nothing; now that the default is 0.0001 it is
+  # load-bearing - it holds ~22 section screenshots at the OLD tolerance while
+  # their drift is still unmeasured. Delete it once they are measured and
+  # re-recorded; that is the whole point of keeping it.
+  SECTION_CONFIGS = {
+    "cta" => {tolerance: 0.02},
+    "cta-contact_us" => {tolerance: 0.02},
+    "clients" => {tolerance: 0.02},
+    "use-cases" => {tolerance: 0.02},
+    "technologies" => {tolerance: 0.02},
+    "testimonials" => {tolerance: 0.02},
+    "why-us" => {tolerance: 0.02}
+  }.freeze
+
+  # 0.02 let ~41,472 pixels of a 1920x1080 frame change before failing, so real
+  # diffs passed green - services/_testimonials-header sat at 0.005923 for a
+  # whole recolour and reported no change. Repeat runs report IDENTICAL
+  # difference_levels, i.e. run-to-run noise is 0.0, so the floor only has to
+  # clear zero: 0.0001 is ~207 px. Calls that need real slack (font-swap,
+  # animation) still pin their own tolerance.
+  DEFAULT_SCREENSHOT_CONFIG = {tolerance: 0.0001}.freeze
+
+  def screenshot_config_for(name)
+    SECTION_CONFIGS.fetch(extract_section_key(name), DEFAULT_SCREENSHOT_CONFIG)
+  end
+
+  # The key is the tail after "/_", so "services/_technologies" matches the
+  # "technologies" key but "services/_testimonials-header" does NOT match
+  # "testimonials" - it is one string, not a prefix.
+  def extract_section_key(name)
+    name.to_s.split("/_").last
+  end
+end

--- a/test/unit/screenshot_section_config_test.rb
+++ b/test/unit/screenshot_section_config_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "support/screenshot_section_config"
+
+# The shield mapping was inert while its values equalled the default. Lowering
+# the default made it decide which screenshots keep the OLD tolerance, so the
+# "/_" tail rule is now behaviour worth pinning - a near-miss like
+# "_testimonials-header" silently inheriting the "testimonials" shield would
+# re-blind the gate on that section.
+class ScreenshotSectionConfigTest < Minitest::Test
+  include ScreenshotSectionConfig
+
+  def test_section_name_matching_a_key_is_shielded
+    assert_equal 0.02, screenshot_config_for("services/_technologies")[:tolerance]
+  end
+
+  def test_longer_section_name_does_not_match_a_shorter_key
+    refute_equal 0.02, screenshot_config_for("services/_testimonials-header")[:tolerance]
+    assert_equal DEFAULT_SCREENSHOT_CONFIG, screenshot_config_for("services/_testimonials-header")
+  end
+
+  def test_name_without_a_section_gets_the_default
+    assert_equal DEFAULT_SCREENSHOT_CONFIG, screenshot_config_for("homepage")
+    assert_equal DEFAULT_SCREENSHOT_CONFIG, screenshot_config_for("blog/post")
+  end
+
+  def test_key_is_the_tail_after_the_last_section_separator
+    assert_equal "footer", extract_section_key("services/_footer")
+    assert_equal "homepage", extract_section_key("homepage")
+  end
+
+  def test_every_shielded_section_is_looser_than_the_default
+    ScreenshotSectionConfig::SECTION_CONFIGS.each do |key, config|
+      assert_operator config[:tolerance], :>, DEFAULT_SCREENSHOT_CONFIG[:tolerance],
+        "#{key} shields nothing - drop it from SECTION_CONFIGS"
+    end
+  end
+end


### PR DESCRIPTION
## What
One constant + its first test coverage + a truthful doc layer. The visual gate's default tolerance let ~41,472 pixels of a 1920×1080 frame change before failing — a real recolour sat at difference_level 0.0059 and reported green — and on every PASS the capybara-screenshot-diff gem restores the git-HEAD image over the fresh capture, so baselines fossilize. Diagnosed end-to-end today (three agents: probe → mechanism → measurement); every number below reproduced independently by an adversarial reviewer to 16 decimal places.

- `DEFAULT_SCREENSHOT_CONFIG` tolerance **0.02 → 0.0001** (noise floor measured 0.0 — repeat runs return identical difference_levels; ~30 call sites pin their own tolerance and are unaffected)
- **SECTION_CONFIGS deliberately KEPT at 0.02** as a documented temporary shield (~22 section screenshots, drift unmeasured; deletion belongs to the re-record follow-up). Was inert while it equalled the default; now load-bearing — so it got its first unit coverage: `test/support/screenshot_section_config.rb` (pure module) + 5-case test, mutation-verified twice (author and reviewer, different mutations)
- **Measured blast radius**: +1 screenshot vs today (three-way table in `.okf/build/test-gates.md`: 0.02 → 2 fails, shipped → 3, shield-deleted → 5 on the services page)
- **Docs made true**: fossilization mechanic + correct re-record sequence; two further blind axes documented (viewport-only capture — below-fold edits invisible at any tolerance; perceptual floor CIE dE00 2.0 — sub-threshold recolours invisible at any tolerance); fictional API swept from the 20.02 tutorial (`SCREENSHOT_TOLERANCE` env var, `assert_stable_problematic_screenshot` + its 2.5% threshold recommendations, per-OS multiplier table — all grep-verified absent from code); 20.10 §4 marked FIXED

## Why now
The register-pilot lane (design comparison on /next/) is gated on a trustworthy visual instrument: pilot A's author proved a text change invisible to the desktop gate, which triggered the diagnosis.

## Evidence
- Unit: **289 runs, 6090 assertions, 0 failures** (284 → 289 = the 5 new cases)
- The discriminating red now fires: `desktop/services/_testimonials-header` fails at 0.005923 (was green at 0.02)
- Known/expected red: the full visual suite is red on ~36 screenshots that are **stale since #540's recolour** (real changes, never re-recorded because of the fossilizing gate) — re-record is the tracked follow-up, deliberately NOT mixed into this PR; zero baselines touched here
- Machine exonerated: the '13-red on pristine master' was stale baselines, not drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SP5gaqXEgUie8pdFrmbeJ