### PR TITLE
STATUS.md follow-up: peer clean-context review findings

### DIFF
--- a/.agents/skills/async-first-communication/SKILL.md
+++ b/.agents/skills/async-first-communication/SKILL.md
@@ -25,7 +25,7 @@ the work. A task is not done until its state is readable asynchronously.
 
 | What | Where |
 |---|---|
-| Current WIP + goals snapshot (cold-start entry) | `STATUS.md` at repo root — links only, updated in the same commit as the state change |
+| Current WIP + goals snapshot (cold-start entry) | `STATUS.md` at repo root — links only, updated in the same commit/PR as the state change |
 | Decision / groomed design / vote | the project's docs (`docs/projects/<id>/`), with rationale |
 | Task status + claims + handoffs | kanban board (`kanban-md`, local) AND the committed snapshot (project `backlog.md` State section) |
 | Operational state across sessions | the project runbook (statuses + handoff notes pasted VERBATIM) |

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -79,6 +79,22 @@ Also corrected: the ~1e-6 noise figure in test-gates and in the code comment
 was macOS-local and read as universal. Same overclaim shape the #566 reviewer
 caught one layer down.
 
+## 2026-08-22 - STATUS.md round two: the surface broke its own rule on commit one
+
+A clean-context peer reviewer (second, independent 4-eyes pass after the
+in-session reviewer's 5-round PASS) failed the merged surface: STATUS.md
+called 2509 "Phase D dormant" because it copied the tracker's line-6 header -
+which still said "Phase C complete" while line ~700 recorded PROJECT COMPLETE
+2026-07-19. The file violated its own "verify against the artifact, never a
+tracker line" header rule on its first commit, written by the rule's author.
+Lesson reinforced, not new: a stale header is a tracker line too - read the
+file's END (newest state) before quoting its top. Also fixed on the same pass:
+STATUS.md was absent from the two session-start docs (BASE_HANDBOOK,
+flow-router - the exact path meant to discover it), flow-router still called
+the LIVE ICP campaign "PAUSED", and the AGENTS.md read-order rewrite had
+dropped two resolvable pointers (PROJECT-INDEX.md, 40.10 health reports)
+under a note that only justified deleting the phantom `.agent/` ones.
+
 ## 2026-08-22 - STATUS.md is the repo's cold-start surface
 
 Paul asked for a way for anyone landing in the repo to know the goals and the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,10 @@ onboarding path:
 
 **First visit — read in this order:**
 1. `STATUS.md` (repo root) — cross-project view: what's in flight, goals, blockers
-2. The project's `README.md` or `GOAL-AT-A-GLANCE.md` — one-page status / exec summary (2608's README is the template: status paragraph, read-order table, open decisions, known reds)
+2. The project's one-page entry: `README.md`, `GOAL-AT-A-GLANCE.md`, or `PROJECT-INDEX.md` — whichever exists (2608's README is the template: status paragraph, read-order table, open decisions, known reds)
 3. `TASK-TRACKER.md` or `backlog.md` — live task queue, active phase
 
+**Project health** (where present): PM health reports in `40-49-review/40.10-*.md` (e.g. 2605).
 (The former `.agent/STATUS.md` / `.agent/prd/PRD.md` / `.agent/tasks.json` stack never existed in this repo — removed 2026-08-22; root `STATUS.md` is the cross-project dashboard.)
 
 **Skills:** Project-specific skills in `.skills/`. Global skills loaded via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 >
 > **Company FACTS are NOT vault-owned.** Every claim in `.okf/content/claims-canon.md` is canon HERE, enforced by `test/unit/marketing_copy_test.rb`. Never copy a company number out of a vault note into published copy (the vault itself carried two banned strings on 2026-08-17). The vault decides what we're doing; the canon decides what we're allowed to say.
 
-**What's in flight + goals**: `STATUS.md` at repo root — the cold-start surface; update it in the same commit as any WIP change (rule in §Behavioral Constraints).
+**What's in flight + goals**: `STATUS.md` at repo root — the cold-start surface; update it in the same commit/PR as any WIP change (rule in §Behavioral Constraints).
 
 **Type**: Hugo static site blog | **Build**: `bin/hugo-build`
 **Test**: `bin/qtest --changed` (per change — tests the pages your diff touches) / `bin/test --smoke` (fixed 17-test core net, ~50s / ~30s CI) / `bin/rake test:critical` (milestones) / `bin/test` + `bin/dtest` (PR prep). qtest and smoke are complementary: qtest follows your diff, smoke is a constant basics check.

--- a/STATUS.md
+++ b/STATUS.md
@@ -10,7 +10,7 @@
 ## Goals
 
 - **Company goals / OKR / weekly numbers**: vault `~/Documents/pkm/jt-operations.md` (host-only — vault owns operations; this repo carries growth/marketing execution).
-- **Bet of record**: Vibe Code Rescue — status is vault-owned (`jt-vcr-runbook.md`; repo mirror [`docs/business/index.md`](docs/business/index.md)); campaign artifacts in [`docs/projects/2607-vibe-code-rescue/`](docs/projects/2607-vibe-code-rescue/backlog.md).
+- **Bet of record**: Vibe Code Rescue — **Parked until Sept 2026** per the repo mirror [`docs/business/index.md`](docs/business/index.md) (vault `jt-vcr-runbook.md` is authoritative); campaign artifacts in [`docs/projects/2607-vibe-code-rescue/`](docs/projects/2607-vibe-code-rescue/backlog.md).
 - **Content plan of record**: [`20.09 (Aug 2026)`](docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md) — its §1 governing constraint: **outreach outranks new posts**.
 
 ## Now / WIP
@@ -18,20 +18,20 @@
 | Workstream | State | Next step | Entry point |
 |---|---|---|---|
 | LinkedIn (primary demand lane) | **LIVE** — 3 posts published (2026-08-13/18/19), first metrics read 2026-08-20; ICP-E lane on disk: 1 posted + 4 approved (of 10 planned), validation clock running | Post an approved draft (week1-tue / week1-wed) at Stream 0 cadence (3-4/wk) | [`metrics-ledger`](linkedin-posts/metrics-ledger.md) · [`plan`](docs/workflows/linkedin-icp-validation-plan.md) |
-| 2608 site design system (v2 `/next/` rail) | Paused 2026-08-22 mid-flight; 3 pilots built + voted | Apply 20.09 repositioned copy; then Paul's 5 decisions | [`2608 README`](docs/projects/2608-site-design-system/README.md) |
+| 2608 site design system (v2 `/next/` rail) | Paused 2026-08-22 mid-flight; 3 pilots built + voted | Apply the [repositioned pilot copy](docs/projects/2608-site-design-system/20-29-strategy/20.09-repositioned-pilot-copy.md) (2608's own 20.09 — not the content plan); then Paul's 5 decisions | [`2608 README`](docs/projects/2608-site-design-system/README.md) |
 | Blog / SEO (2510) | Constrained by 20.09 §1 (outreach first). R-queue empty/retired; replacement queue is §13 (restocked 2026-08-21) | Per §1: LinkedIn cadence + sourcing outrank a new post; when drafting, take §13 N-queue | [`20.09 §13`](docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md) |
-| 2605 course | v2 live; measuring. Diagnosis: **arrival, not content** (GSC/GA/Clarity triple-read 2026-08-20) | Arrival/discovery actions per 50.05; no new funnel posts on the unproven bridge | [`TASK-TRACKER`](docs/projects/2605-tech-for-non-technical-founders/TASK-TRACKER.md) |
+| 2605 course | v2 live; measuring. Diagnosis: **arrival, not content**; course SEO/AEO **closed** (Paul 2026-08-21) | LinkedIn arrival-test cards **LI-0…LI-D** in [`content-plan`](linkedin-posts/content-plan.md); no new funnel posts on the unproven bridge | [`TASK-TRACKER`](docs/projects/2605-tech-for-non-technical-founders/TASK-TRACKER.md) |
 | 2607 campaign tasks | Cold-public-sourcing premise tested and **failed** (3 sweeps, 4 venues, 0 verified-fresh rows; Reddit still un-openable) | Sept-restart Paul decision: retire the cold lane or buy Reddit API access (backlog §c) | [`2607 backlog`](docs/projects/2607-vibe-code-rescue/backlog.md) |
-| Test/CI hygiene | One known red (stale linux baseline, see 2608 README §Known red) | Diff record-vs-test build paths before re-recording | [`test-gates`](.okf/build/test-gates.md) |
+| Test/CI hygiene | One known red (stale linux baseline) | Diff record-vs-test build paths before re-recording | [`2608 README §Known red`](docs/projects/2608-site-design-system/README.md) |
 
-**Not in flight**: 2604 typography — closed 2026-08-08 (P2 leftovers re-homed). 2509 CSS migration — Phase C complete 2026-07-19, Phase D backlog dormant; the 2608 clean-slate rail is the live CSS strategy ([ADR-0006](docs/adr/0006-clean-slate-dual-run.md)).
+**Not in flight**: 2604 typography — closed 2026-08-08 (P2 leftovers re-homed). 2509 CSS migration — **project complete 2026-07-19** (tracker in maintenance mode; the dormant remainder is the Phase-E groomed backlog + trigger-conditioned items); the 2608 clean-slate rail is the live CSS strategy ([ADR-0006](docs/adr/0006-clean-slate-dual-run.md)).
 
 ## Blocked on Paul
 
 | What | Where the full ask lives |
 |---|---|
 | Five 2608 decisions (register pick, 3 claims, first page, legacy CTO sweep, Sept measurement gate) | [`2608 README`](docs/projects/2608-site-design-system/README.md) |
-| **Joy Adamson override** (1 min; only survivor of outreach batch 1, still publicly unanswered) | [`20.09 §1`](docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md) desk table + 2607 backlog card #12 |
+| **Joy Adamson override** (1 min; Paul's one override candidate from outreach batch 1, still publicly unanswered) | [`20.09 §1`](docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md) desk table + 2607 backlog card #12 |
 | Three 2605 fabricated-fact findings (five-tech-words client claim, $78K/$400 story, SVG chart stats) | [`2605 TASK-TRACKER`](docs/projects/2605-tech-for-non-technical-founders/TASK-TRACKER.md) §Aug-20 sweep |
 | 2607 T3 (Gmail warm-source consent) + T10 (split strategy docs, [#449](https://github.com/jetthoughts/jetthoughts.github.io/issues/449)) | [`2607 backlog`](docs/projects/2607-vibe-code-rescue/backlog.md) |
 

--- a/docs/projects/2509-css-migration/TASK-TRACKER.md
+++ b/docs/projects/2509-css-migration/TASK-TRACKER.md
@@ -3,7 +3,7 @@
 **Purpose**: Status tracking for the CSS maintainability goal — FL-Builder export CSS retired page-by-page (strangler rewrites)
 **Update Frequency**: After each sprint or status change
 **Last Updated**: 2026-07-19
-**Current Phase**: ✅ PHASE C COMPLETE (2026-07-19) - C1 #371 · C2 #372 · C3 #374 · C4 #375 · C5 dedup. Phase D backlog defined below.
+**Current Phase**: ✅ **PROJECT COMPLETE (2026-07-19)** — see §PHASE D COMPLETE below; tracker in maintenance mode, Phase-E groomed backlog + trigger-conditioned items dormant. *(Header corrected 2026-08-22 — it still said "Phase C complete, Phase D backlog defined" long after line ~700 recorded Phase D done; the stale header was copied into STATUS.md's first commit, exactly the failure the artifact-not-tracker-line rule exists for.)*
 
 ---
 

--- a/docs/workflows/BASE_HANDBOOK.md
+++ b/docs/workflows/BASE_HANDBOOK.md
@@ -17,6 +17,9 @@ Use this as the shared boilerplate for agents and skills. Keep agent/skill files
 2. `Search the codebase at <repo root>/knowledge for: "[topic]"`
 3. `Get library docs for "[framework]"`
 
+## Current WIP + goals (repo state)
+**Read `STATUS.md` at the repo root at session start** — the cross-project cold-start surface (goals, WIP, blocked-on-Paul, links only). Any session that changes what's in flight updates it in the same commit/PR.
+
 ## Business layer (company state)
 **All operations live in the vault** (`~/Documents/pkm`, host-only; Paul 2026-08-20): goal/OKR/rocks/weekly numbers in `jt-operations.md`, identity/positioning/bet status in `jt-business-os.md`, the bet's execution entry point in `jt-vcr-runbook.md` **▶ START HERE**. This repo carries growth/marketing campaigns only; `docs/business/` holds pointer stubs.
 

--- a/docs/workflows/flow-router.md
+++ b/docs/workflows/flow-router.md
@@ -3,10 +3,11 @@
 Read this at session start to route tasks to the right workflow without explicit user notice.
 
 ## Routing Rules
+- **"What's in flight / current WIP / goals / project status?"** → repo root `STATUS.md` (cross-project cold-start surface; update it in the same commit/PR as any WIP change)
 - **Outbound / sales / pipeline / prospect / discovery-call work (2607)** → vault `~/Documents/pkm/jt-vcr-runbook.md` **▶ START HERE** (moved 2026-08-20; bet PARKED until Sep 2026; campaign artifacts stay in `docs/projects/2607-vibe-code-rescue/`)
 - **Weekly loop (goal, OKR, rocks, weekly numbers)** → vault `~/Documents/pkm/jt-operations.md` (moved 2026-08-20; vault = operations, repo = growth/marketing). Host-only — out of scope in container/CI sessions.
 - **Identity, positioning, bet status** → the vault note `jt-business-os` (`~/Documents/pkm`) FIRST, then reflect into the `docs/business/` mirror
-- LinkedIn post creation or edits, especially `linkedin-posts/**` → `@docs/workflows/linkedin-post-pipeline.md` (it routes to the active campaign plan — check the campaign's status banner; the ICP campaign is currently PAUSED)
+- LinkedIn post creation or edits, especially `linkedin-posts/**` → `@docs/workflows/linkedin-post-pipeline.md` (it routes to the active campaign plan — check the campaign's status banner; the ICP campaign is LIVE since 2026-08-18, see `linkedin-posts/metrics-ledger.md`)
 - Content creation or edits → `@docs/workflows/blog-pipeline.md` (mandatory; its P0 gate can halt content entirely)
 - Cover image work → `docs/workflows/cover-images.md` and `.stitch/design.md`
 - Image/cover requests (even without content) → `@docs/workflows/cover-images.md` and `@.stitch/design.md`

--- a/docs/workflows/linkedin-icp-validation-plan.md
+++ b/docs/workflows/linkedin-icp-validation-plan.md
@@ -2,7 +2,7 @@
 
 > **Status: READY TO ACTIVATE (2026-08-08)** — 3 of 10 posts drafted, zero posted; the 2-week window starts when **Paul posts #1 from [`linkedin-posts/icp-validation/POSTING-PACKET.md`](../../linkedin-posts/icp-validation/POSTING-PACKET.md)** (copy, paste, post — nothing else). This campaign is now the **PRIMARY demand lane** (OS Rock 1, re-weighted 2026-08-08 after the warm-names premise fell). When live, cadence fits inside 20.09 §7's **Stream 0 total of 3-4 posts/week** (shared with course-promo) — not the original 5/week. The hypotheses, hooks, and reply-keyword CTAs below remain the campaign design of record.
 
-> **Update 2026-08-22:** posting is LIVE — the status line above ("zero posted") is superseded. `linkedin-posts/metrics-ledger.md` carries three posted rows (2026-08-13, 08-18, 08-19; first metrics read 2026-08-20), including `week1-mon-jira-not-progress` from this campaign's own lane, so the validation clock is running.
+> **Update 2026-08-22:** posting is LIVE — the status line above is superseded on both counts: "zero posted" (three posted rows in `linkedin-posts/metrics-ledger.md`: 2026-08-13, 08-18, 08-19, first metrics read 2026-08-20, including `week1-mon-jira-not-progress` from this campaign's own lane — the validation clock is running) and "3 of 10 posts drafted" (lane on disk: 1 posted + 4 approved, measured from frontmatter `status:` fields).
 
 **Purpose:** Validate whether LinkedIn can surface and qualify ICP-E: non-technical founders who feel stuck with a dev shop, freelancer, offshore team, or AI-heavy build they cannot evaluate.
 **Window:** 2 weeks from first post (clock starts when Paul posts #1)


### PR DESCRIPTION
## Summary

Follow-up to #571 per its written review contract: the peer session's clean-context reviewer returned FAIL (1 P0, 4 P1, 5 P2) after the merge. All ten findings fixed with artifact verification; one bonus same-class fix (flow-router called the LIVE ICP campaign "PAUSED").

Highlight: the P0 was STATUS.md violating its own "verify against the artifact, never a tracker line" header rule on its first commit — it copied 2509's stale line-6 header ("Phase D backlog defined") when line ~700 of the same file records PROJECT COMPLETE 2026-07-19. Both the copy and the source header are fixed, and the OKF log records the sharpened lesson: a stale header is a tracker line too — read the file's end before quoting its top.

Full per-finding detail in the commit message. Discoverability fix worth noting: STATUS.md is now referenced from BASE_HANDBOOK.md and flow-router.md — the two docs the session-start protocol actually mandates reading — closing the loop the reviewer called "invisible to the sessions it exists for".

## Gates

- `bin/hugo-build` exit 0. Docs-only diff — CI skips by design; local gates are the gates of record.
- All new link targets resolve (`ls` batch); STATUS.md stays at 38 lines (≤50 cap).
- Review provenance: findings authored by the peer session's read-only reviewer (author ≠ verifier by construction); fixes verified line-by-line against the cited artifacts before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)