### PR TITLE
The codeblocks drift is Debian vs Ubuntu, not arm vs amd

### DIFF
--- a/.okf/build/rendering-stack.md
+++ b/.okf/build/rendering-stack.md
@@ -1,0 +1,75 @@
+---
+type: build-concept
+title: A screenshot baseline is a recording of a rendering stack
+description: Which environment records the linux/ baselines, why local dtest differs from CI, and the four wrong explanations that cost a session
+tags: [testing, screenshots, docker, ci, rendering]
+timestamp: 2026-08-22T00:00:00Z
+---
+
+# A screenshot baseline is a recording of a rendering stack
+
+Not of a page. Change the stack and every baseline is stale, even though no
+code moved. So before calling a visual diff a defect, establish **which stack
+produced the baseline and which produced the candidate**.
+
+## The two stacks in this repo
+
+| | local `bin/dtest` | CI (records `linux/`) |
+|---|---|---|
+| arch | x86_64 | x86_64 |
+| Chrome | 152.0.7977.54, pinned by `.dev/cft-version` | same pin, cached by that file's hash |
+| `fonts.conf` + font packages | `.dev/fonts.conf`, noto-core / freefont-ttf / dejavu-core | same, via `bin/setup-test-env` |
+| **base OS** | **Debian 13 trixie** (freetype 2.13.3) | **ubuntu-latest** |
+
+Architecture, browser and fonts were deliberately pinned to match. The base OS
+was not, so freetype/harfbuzz differ - and that is enough to move dense
+monospace text. Measured 2026-08-22: 8 `mobile/blog/special/codeblocks/*`
+screenshots differ ~0.055-0.063 between the two, with no defect present.
+
+**macOS is a third stack.** `bin/test` records `macos/`; `bin/dtest` and CI
+record `linux/`. Neither OS's set is a subset of the other, and a candidate
+rendered on one must never be committed as a baseline for another.
+
+## Four wrong explanations, in the order they were believed
+
+Each sounded mechanical and each was asserted without measuring the thing it
+named. Listed because the *shape* recurs, not the specific causes:
+
+1. **"arm64 vs amd64 drift."** The container is x86_64. `.dev/compose.yml`
+   pins `platform: linux/amd64` on the `t` service and that DOES override
+   `bin/dc`'s `DOCKER_DEFAULT_PLATFORM=linux/arm64/v8` - which is a real
+   booby-trap in the tooling, since it makes the arm64 story look right. One
+   `uname -m` in the container ends the debate.
+2. **"The tolerance change (#560) regressed it."** That test pins its own
+   `tolerance: 0.03` inline, so the default never applied to it.
+3. **"The PR merge-commit checkout differs from the dispatch checkout."** True
+   of the workflow, but the failure reproduced identically on master where
+   both see the same tree.
+4. **"A date-gated post appeared."** Both candidate posts were dated before
+   the baseline was recorded.
+
+The measurement that actually resolved it took one command and should have
+been first: read the container's OS and library versions.
+
+## Rules
+
+- **Identical `difference_level` across two runs = stale baseline, not flake.**
+  Flake varies; a stack mismatch does not.
+- **Re-record where the tester runs.** An `update-baselines` dispatch on a
+  feature branch records the branch tree while PR runs test the merge commit;
+  dispatch on **master** so recorder and tester agree. That is what fixed
+  `mobile/blog/index/_pagination` (a real 0.0425 content difference).
+- **Never re-record `linux/` from a Mac**, whatever the container reports.
+- A green visual run that prints no `[snap_diff] N screenshots compared` line
+  compared nothing - see [test-gates](/build/test-gates.md).
+
+## The open decision: one rendering stack, or two?
+
+Running CI inside this same container makes local and CI identical by
+construction and lets `bin/dtest` be authoritative for visuals; CI is amd64
+native so there is no emulation, and the cost is image build/pull per job -
+**measure it before committing.** The alternative is to accept the split, let
+CI own pixel truth, and screen the divergent keys - free today, but an
+expected-red list is what rotted into "everything is expected red" before #566.
+Pinning font and library versions across two distros is a third option and not
+a serious one.

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -51,6 +51,28 @@ make it green: restructure same-day entries under one heading, and add
 `timestamp` to the 23 concepts missing it (anchored to each file's last commit
 time, which is verifiable - never invented).
 
+## 2026-08-22 - the codeblocks drift was Debian vs Ubuntu, after four wrong answers
+
+The 8 `mobile/blog/special/codeblocks/*` failures in `bin/dtest` were blamed on
+arm64-vs-amd64 three separate times, and on the tolerance change, the PR
+merge-commit checkout, and a date-gated post once each. All wrong, and each
+asserted without measuring the thing it named.
+
+Measured: the container is **x86_64** (`.dev/compose.yml` pins
+`platform: linux/amd64` on `t`, which overrides `bin/dc`'s
+`DOCKER_DEFAULT_PLATFORM=linux/arm64/v8` - a booby-trap that made the arch
+story look right), runs the **same** pinned Chrome 152.0.7977.54 as CI, and the
+same `fonts.conf` and font packages. What differs is the base OS: **Debian 13
+trixie** locally against **ubuntu-latest** in CI, so freetype/harfbuzz differ.
+Dense monospace is where that surfaces. One `uname -m` plus `/etc/os-release`
+would have ended it in a minute.
+
+New concept: [rendering-stack](build/rendering-stack.md) - a baseline is a
+recording OF a stack, not of a page; the two-stack table; the four wrong
+answers kept deliberately, because the SHAPE recurs; and the open decision
+(run CI in the same container vs accept the split). STATUS.md and the 2608
+README carried the wrong arch explanation for an hour and are corrected.
+
 ## 2026-08-22 - the Linux visual gate was green because it was not testing
 
 `bin/dtest` run from a git worktree compared NOTHING. A worktree's `.git` is a

--- a/STATUS.md
+++ b/STATUS.md
@@ -32,7 +32,7 @@
 | What | Where the full ask lives |
 |---|---|
 | Five 2608 decisions (register pick, 3 claims, first page, legacy CTO sweep, Sept measurement gate) | [`2608 README`](docs/projects/2608-site-design-system/README.md) |
-| **dtest arch policy**: on an ARM Mac dtest now legitimately fails 8 codeblocks screenshots (arm64 container vs amd64 CI baselines) — screen those keys / pin the container to amd64 / let CI own the Linux leg | [`2608 README §Known red`](docs/projects/2608-site-design-system/README.md) |
+| **One rendering stack, or two?** dtest fails 8 codeblocks screenshots because local renders on **Debian 13** and CI on **ubuntu-latest** — same arch, same pinned Chrome, same fonts.conf, different distro libraries. Run CI in the same container (one stack, dtest becomes authoritative) or accept the split and let CI own pixels | [`2608 README §Known red`](docs/projects/2608-site-design-system/README.md) |
 | **Joy Adamson override** (1 min; Paul's one override candidate from outreach batch 1, still publicly unanswered) | [`20.09 §1`](docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md) desk table + 2607 backlog card #12 |
 | Three 2605 fabricated-fact findings (five-tech-words client claim, $78K/$400 story, SVG chart stats) | [`2605 TASK-TRACKER`](docs/projects/2605-tech-for-non-technical-founders/TASK-TRACKER.md) §Aug-20 sweep |
 | 2607 T3 (Gmail warm-source consent) + T10 (split strategy docs, [#449](https://github.com/jetthoughts/jetthoughts.github.io/issues/449)) | [`2607 backlog`](docs/projects/2607-vibe-code-rescue/backlog.md) |

--- a/docs/projects/2608-site-design-system/README.md
+++ b/docs/projects/2608-site-design-system/README.md
@@ -59,22 +59,50 @@ dispatch **on master**, where the recorder and the tester see the same tree -
 recording on a feature branch is what had produced a baseline the PR run never
 matched. Verified green: CI screenshot run 32565008850, zero failing keys.
 
-**The open one is different.** `bin/dtest` on an ARM Mac now fails 8
-`mobile/blog/special/codeblocks/*` screenshots at ~0.055-0.063, because the
-container renders arm64 while the committed `linux/` baselines come from CI on
-amd64. This only became visible once #578 fixed dtest comparing nothing at all
-from a worktree - it is pre-existing, not a regression. Three options, none
-free, and the choice is a speed-versus-fidelity call:
+**The open one is different, and it is NOT architecture.** `bin/dtest` on a Mac
+fails 8 `mobile/blog/special/codeblocks/*` screenshots at ~0.055-0.063. The
+first three explanations offered for this were wrong, including "arm64 vs
+amd64" - measured 2026-08-22, the test container is **x86_64** already
+(`.dev/compose.yml` pins `platform: linux/amd64` on the `t` service, and that
+does override `bin/dc`'s `DOCKER_DEFAULT_PLATFORM=linux/arm64/v8`).
 
-1. screen those keys as known-arch and keep dtest fast,
-2. pin the container to `linux/amd64` so local matches CI (correct, slower
-   under emulation - note `.dev/compose.yml` already declares
-   `platform: linux/amd64` on the `t` service while `bin/dc` exports
-   `DOCKER_DEFAULT_PLATFORM=linux/arm64/v8`; reconcile those before deciding),
-3. let CI own the Linux leg entirely.
+What actually differs is the base OS:
 
-Do not re-record them from a Mac either way: an arm64 candidate must never
-overwrite the amd64 set (`.okf/build/test-gates.md`).
+| | local container | CI |
+|---|---|---|
+| arch | x86_64 | x86_64 |
+| Chrome | 152.0.7977.54 (`.dev/cft-version`) | same pin, cached by its hash |
+| `fonts.conf` + font packages | same | same |
+| **base OS** | **Debian 13 trixie**, freetype 2.13.3 | **ubuntu-latest** |
+
+Same architecture, same browser, same fonts by name - different distro, so
+different freetype/harfbuzz builds. Dense monospace (syntax-highlighted code)
+is where that shows first. The `linux/` baselines are a recording OF a
+rendering stack; two stacks means they are only valid for one of them.
+
+**The decision, then, is not arm-vs-amd. It is one rendering stack or two:**
+
+1. **Run CI in this same container.** Local and CI become identical by
+   construction, dtest becomes authoritative for visuals, and the "is this
+   drift or a defect?" question disappears. CI is amd64 native, so the image
+   runs without emulation; the cost is image build/pull per job, cacheable.
+   **Measure that cost before committing** - it is the only real argument
+   against.
+2. **Accept the split**: CI owns pixel truth, dtest is a behavioural gate, and
+   those 8 keys are screened as known-divergent. Free today, but an
+   expected-red list is exactly what rotted into "everything is expected red"
+   before #566.
+
+Chasing parity by pinning font/library versions across two distros is a third
+option and not a serious one - Debian and Ubuntu drift independently, forever.
+
+Either way: never re-record `linux/` baselines from a Mac. The container is a
+different stack from the recorder (`.okf/build/test-gates.md`).
+
+Also worth cleaning up regardless: `bin/dc` exports
+`DOCKER_DEFAULT_PLATFORM=linux/arm64/v8`, which the `t` service overrides but
+the `hugo` dev service does not - and it is what made three separate arch
+explanations look plausible today.
 
 ## What the sprint shipped (PRs #560-#578, 2026-08-21/22)
 


### PR DESCRIPTION
Measured instead of assumed, finally: the test container is x86_64 already -
.dev/compose.yml pins platform: linux/amd64 on the `t` service and that DOES
override bin/dc's DOCKER_DEFAULT_PLATFORM=linux/arm64/v8. It runs the same
pinned Chrome 152.0.7977.54 as CI, the same fonts.conf, the same font
packages. What differs is the base OS: Debian 13 trixie locally against
ubuntu-latest in CI, so freetype/harfbuzz differ - and dense monospace is
where that shows.

STATUS.md and the 2608 README had shipped the wrong arch explanation an hour
earlier; both corrected. The arm/amd question is closed: it was already
decided correctly in compose, and it was never the cause.

New OKF concept, build/rendering-stack.md, because this will confuse the next
person exactly as it confused this session: a baseline is a recording OF a
rendering stack, not of a page; the two-stack comparison table; the four wrong
explanations kept deliberately (arm/amd, the tolerance change, the merge-commit
checkout, a date-gated post) because the SHAPE recurs - each sounded mechanical
and none measured the thing it named; and the real open decision, which is one
rendering stack or two, not which chip.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011SP5gaqXEgUie8pdFrmbeJ
