### PR TITLE
ARM on Linux is a dead end: Chrome for Testing has no linux-arm64 build

### DIFF
--- a/.okf/build/rendering-stack.md
+++ b/.okf/build/rendering-stack.md
@@ -63,13 +63,41 @@ been first: read the container's OS and library versions.
 - A green visual run that prints no `[snap_diff] N screenshots compared` line
   compared nothing - see [test-gates](/build/test-gates.md).
 
+## ARM on Linux is a dead end, and that is why compose pins amd64
+
+Verified 2026-08-22 against the Chrome for Testing manifest: version
+152.0.7977.54 publishes `linux64, mac-arm64, mac-x64, win32, win64` - **there is
+no `linux-arm64` build**. So an arm64 Linux container cannot run the pinned
+Chrome natively; it can only emulate the amd64 one, which is both slower and
+pixel-divergent. GitHub's `ubuntu-24.04-arm` runners are free for this public
+repo, so runner availability is NOT the constraint - the browser is.
+
+That makes `platform: linux/amd64` on the `t` service a forced choice rather
+than a preference, and `bin/dc`'s `DOCKER_DEFAULT_PLATFORM=linux/arm64/v8`
+straightforwardly wrong for anything that renders. Do not "try ARM" again
+without first re-checking that manifest.
+
 ## The open decision: one rendering stack, or two?
 
 Running CI inside this same container makes local and CI identical by
 construction and lets `bin/dtest` be authoritative for visuals; CI is amd64
 native so there is no emulation, and the cost is image build/pull per job -
-**measure it before committing.** The alternative is to accept the split, let
-CI own pixel truth, and screen the divergent keys - free today, but an
-expected-red list is what rotted into "everything is expected red" before #566.
-Pinning font and library versions across two distros is a third option and not
-a serious one.
+**measure it before committing.** Feasibility checked 2026-08-22: the repo is
+PUBLIC so GHCR is free, the image is 2.54 GB uncompressed, and GitHub Actions
+can run a whole job inside it via the job-level `container:` key. Publish on
+changes to `.dev/Dockerfile` or `.dev/cft-version` only - the same hash that
+already keys the Chrome cache. Note the honest comparison is not "pull vs
+nothing": CI already spends the same class of time on
+`setup-ruby-and-dependencies`, the Chrome-for-Testing download and the font
+packages, all of which the container replaces.
+
+The tempting cheaper alternative - move the CONTAINER to Ubuntu so it matches
+the runner - is blocked: the image builds on `ruby:$RUBY_VERSION-slim`, and the
+official Ruby images are Debian-only. Matching that way means hand-rolling Ruby
+on an Ubuntu base, which is more moving parts than publishing one image.
+
+The alternative is to accept the split: CI owns pixel truth, `bin/dtest` is a
+behavioural gate, and the divergent keys are screened. Free today, but an
+expected-red list is exactly what rotted into "everything is expected red"
+before #566. Pinning font and library versions across two distros is a third
+option and not a serious one - they drift independently, forever.


### PR DESCRIPTION
Verified against the Chrome for Testing manifest rather than assumed: 152.0.7977.54
publishes linux64, mac-arm64, mac-x64, win32, win64. No linux-arm64. So an
arm64 Linux container can only EMULATE the pinned Chrome - slower and
pixel-divergent, which is the drift the compose comment warned about.

GitHub's ubuntu-24.04-arm runners are free for this public repo, so runner
availability was never the constraint; the browser is. That makes
platform: linux/amd64 on the `t` service a forced choice rather than a
preference, and bin/dc's DOCKER_DEFAULT_PLATFORM=linux/arm64/v8 wrong for
anything that renders.

Also recorded the feasibility of the other direction, since it is the live
decision: the repo is public so GHCR is free, the image is 2.54 GB, and a job
can run inside it via the job-level `container:` key, published only when
.dev/Dockerfile or .dev/cft-version changes. The honest comparison is not
"pull vs nothing" - CI already spends the same class of time installing ruby,
Chrome and fonts, all of which the container replaces. The cheaper-looking
alternative of moving the container to Ubuntu is blocked: it builds on
ruby:$RUBY_VERSION-slim and official Ruby images are Debian-only.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011SP5gaqXEgUie8pdFrmbeJ
