### PR TITLE
ARM is waiting on a channel promotion, not missing: CfT ships linux-arm64 from 153

### DIFF
--- a/.okf/build/rendering-stack.md
+++ b/.okf/build/rendering-stack.md
@@ -63,19 +63,41 @@ been first: read the container's OS and library versions.
 - A green visual run that prints no `[snap_diff] N screenshots compared` line
   compared nothing - see [test-gates](/build/test-gates.md).
 
-## ARM on Linux is a dead end, and that is why compose pins amd64
+## ARM on Linux: not a dead end, a WAITING one (re-checked 2026-08-22)
 
-Verified 2026-08-22 against the Chrome for Testing manifest: version
-152.0.7977.54 publishes `linux64, mac-arm64, mac-x64, win32, win64` - **there is
-no `linux-arm64` build**. So an arm64 Linux container cannot run the pinned
-Chrome natively; it can only emulate the amd64 one, which is both slower and
-pixel-divergent. GitHub's `ubuntu-24.04-arm` runners are free for this public
-repo, so runner availability is NOT the constraint - the browser is.
+Chrome for Testing **does** publish `linux-arm64` - chrome and chromedriver
+both - from **153.0.8001.0** onward. An earlier check here concluded "no
+linux-arm64 build" because it queried the PINNED version, 152.0.7977.54, which
+is one major release too early. Query the manifest, not the pin.
 
-That makes `platform: linux/amd64` on the `t` service a forced choice rather
-than a preference, and `bin/dc`'s `DOCKER_DEFAULT_PLATFORM=linux/arm64/v8`
-straightforwardly wrong for anything that renders. Do not "try ARM" again
-without first re-checking that manifest.
+| channel | version | `linux-arm64` |
+|---|---|---|
+| **Stable** | 152.0.7977.54 | **no** |
+| Beta | 153.0.8010.5 | yes |
+| Dev / Canary | 154.x | yes |
+
+`.dev/cft-version` pins current Stable, which is the right policy - so ARM is
+blocked only until **153 promotes to Stable**. Google shipped official Chrome
+for ARM64 Linux on 2026-07-30, so this is a channel-timing question now, not an
+availability one.
+
+**TRIGGER: when CfT Stable >= 153, migrate the whole stack to arm64.** It is
+strictly better than today on every axis:
+
+- the container currently runs **amd64 under emulation on an ARM Mac** - that
+  is why `.dev/compose.yml` carries `mem_limit: 4g` with the note "Chrome 152
+  needs >2g under amd64 emulation (OOM 'tab crashed' at 2g)". Native arm64
+  removes that tax entirely.
+- GitHub's `ubuntu-24.04-arm` runners are free for this public repo, so CI can
+  match.
+- same arch on both sides, and if CI also runs this image, the same distro -
+  which closes the Debian-vs-Ubuntu gap below at the same time.
+
+Cost: bump `.dev/cft-version`, drop the `platform: linux/amd64` pins, switch
+`runs-on`, and re-record every `linux/` baseline once on the new stack.
+
+**Do not chase the Debian-vs-Ubuntu difference before that trigger** - the ARM
+migration forces a full re-record anyway, so paying for parity twice is waste.
 
 ## The open decision: one rendering stack, or two?
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -32,7 +32,7 @@
 | What | Where the full ask lives |
 |---|---|
 | Five 2608 decisions (register pick, 3 claims, first page, legacy CTO sweep, Sept measurement gate) | [`2608 README`](docs/projects/2608-site-design-system/README.md) |
-| **One rendering stack, or two?** dtest fails 8 codeblocks screenshots because local renders on **Debian 13** and CI on **ubuntu-latest** — same arch, same pinned Chrome, same fonts.conf, different distro libraries. Run CI in the same container (one stack, dtest becomes authoritative) or accept the split and let CI own pixels | [`2608 README §Known red`](docs/projects/2608-site-design-system/README.md) |
+| **Rendering stack: wait for Chrome 153 Stable, then go all-ARM.** dtest fails 8 codeblocks screenshots (local Debian 13 vs CI ubuntu-latest). Don't chase that parity now — Chrome for Testing ships `linux-arm64` from 153 (Beta today, Stable pins at 152), and migrating to arm64 both sides removes the emulation tax AND forces one re-record anyway. **Trigger: CfT Stable ≥ 153** | [`rendering-stack`](.okf/build/rendering-stack.md) |
 | **Joy Adamson override** (1 min; Paul's one override candidate from outreach batch 1, still publicly unanswered) | [`20.09 §1`](docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md) desk table + 2607 backlog card #12 |
 | Three 2605 fabricated-fact findings (five-tech-words client claim, $78K/$400 story, SVG chart stats) | [`2605 TASK-TRACKER`](docs/projects/2605-tech-for-non-technical-founders/TASK-TRACKER.md) §Aug-20 sweep |
 | 2607 T3 (Gmail warm-source consent) + T10 (split strategy docs, [#449](https://github.com/jetthoughts/jetthoughts.github.io/issues/449)) | [`2607 backlog`](docs/projects/2607-vibe-code-rescue/backlog.md) |


### PR DESCRIPTION
Paul was right and my check was wrong. Chrome for Testing publishes
linux-arm64 - chrome AND chromedriver - from 153.0.8001.0. The earlier
"no linux-arm64 build" conclusion queried the PINNED version, 152.0.7977.54,
which is one major release too early. Query the manifest, not the pin.

Channels today: Stable 152 (no arm64), Beta 153.0.8010.5 (yes), Dev/Canary 154
(yes). .dev/cft-version pins current Stable, which is correct policy, so ARM is
blocked only until 153 promotes. Google shipped official Chrome for ARM64 Linux
on 2026-07-30; this is channel timing now, not availability.

Recorded as a TRIGGER rather than a task, because the end state is strictly
better than today: the container currently runs amd64 UNDER EMULATION on an ARM
Mac - that is what mem_limit: 4g and the "Chrome 152 needs >2g under amd64
emulation" note are paying for - and ubuntu-24.04-arm runners are free for this
public repo, so CI can match. Same arch both sides, and the same image in CI
closes the Debian-vs-Ubuntu gap at the same time.

Explicitly deferring the distro-parity work until then: the ARM migration
forces a full linux/ re-record anyway, so paying for parity twice is waste.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011SP5gaqXEgUie8pdFrmbeJ
