### PR TITLE
Upgrade the XP-team post with the exit it was missing

### DIFF
--- a/content/blog/claude-code-xp-team-workflow/index.md
+++ b/content/blog/claude-code-xp-team-workflow/index.md
@@ -2,6 +2,7 @@
 title: 'How We Replicated a Full Product Team With Claude Code Agents'
 description: 'Solo Claude Code agents ship like solo developers - missing PM, designer, QA, customer voice. Here is the team-mode setup running Shape Up plus XP plus reflection-driven Kaizen.'
 date: 2026-05-04
+edited_at: 2026-08-22
 draft: false
 author: 'JetThoughts Team'
 slug: claude-code-xp-team-workflow
@@ -87,6 +88,41 @@ Solo agents inherit all of that, compressed into one process. One agent makes th
 
 Team mode splits those decisions across collaborative agents, each holding one job, accountable through a written rule set. A PM agent blocks tickets without acceptance criteria. A simplicity critic stops unrequested abstractions before the diff lands. When two agents disagree, the rule file decides - we don't let the last-run agent win by default.
 
+## The exit we were missing
+
+Team mode fixed who decides. It did not fix whether to proceed at all.
+
+Each formation above ends in an artifact. Pitching produces a pitch doc, slicing produces AC items, delivery produces a diff, and the critics answer revise or approve. Nothing in that set can return "this should not be built."
+
+The gap stayed invisible while we pointed the setup at code, because a ticket that reaches an agent has usually already earned its existence. Content exposed it inside a week.
+
+We aimed the same machinery at this blog - one agent picks the next post from live search data, another writes it. The picker ran twice in one day and both times concluded the queued topic wasn't worth writing. One rested on a statistic that fell apart on a fresh pull; the other collided with a post we'd already published.
+
+Both calls were right.
+
+With two outcomes available it would have written both posts anyway. "Try again" is all a loop can do when nothing lets it stop.
+
+So the rule file grew a third exit. A run now ends SHIPPED, or HOLD with the evidence that killed it, or BLOCKED on a decision it names out loud - and HOLD gets filed as a success rather than a failed run.
+
+That last clause carries the weight. An agent that reads stopping as failure will find a reason to keep going.
+
+The finish condition had to move with it, away from quality and toward checks. "The post is good" is not a claim anyone can catch an agent being wrong about. "A critic that didn't write it scored the draft, and every external claim was fetched rather than recalled" is.
+
+## Four-eyes only counts across agent types
+
+The critic panel assumes the critics see what the writer missed. That assumption breaks quietly when a critic runs on the same model as the writer, because a fresh context window resets what an agent knows without touching what it finds plausible.
+
+Different type, or it doesn't count.
+
+Four things got caught this month that self-review had already passed, each one held with confidence at the time:
+
+- a skill file sitting in a directory the runtime never loads, which looked installed and did nothing
+- a `.gitignore` rule that swallowed the deliverable, so the work existed locally and would never have shipped
+- a query subtotal reported as a whole page's performance, where the numbers were real and the label was wrong
+- a filtered data pull read as complete, when the filter had quietly dropped half the rows
+
+None of those are exotic. Each looks correct to whoever made it, and that is the failure a same-type second opinion is worst at catching.
+
 ## Why the rules need to change every sprint
 
 A rigid rule set ships yesterday's bias. Strategy docs get revised when the market signal changes. Rule files change when reflection surfaces a failure the current rules let through. And sprint goals shift mid-sprint when discovery surfaces new evidence about what users actually need.
@@ -96,6 +132,8 @@ Standups happen at the agent level: the discovery agent posts what it learned fr
 ## Where to start
 
 You don't need every role from day one. Begin with a strategy doc the agent reads at session start, a critic panel that blocks merges, and a reflection log that turns failures into rules. From there, add a designer when the UI starts drifting, a customer-voice capability into the PM agent when feature requests stop matching user pain, and a QA/visual verifier when builds keep going green on broken screens.
+
+Write the three exits into the rule file on day one, though. It costs a paragraph and it's the piece we added last, after watching a two-outcome loop reach for work that didn't need doing.
 
 Setup eats one sprint of overhead. Rule files need writing, agent definitions need configuring, and the team needs convincing. By sprint two, the rule files write themselves from reflection logs and the overhead drops to about 30 minutes per week.
 


### PR DESCRIPTION
Executes the UPGRADE verdict in `20.09 §13g`. The row was "how to structure a team with AI harnesses without losing control", and `claude-code-xp-team-workflow` (2026-05-04) already owned the roles, the cadences and the arbitration rule — a new post would have cannibalised it.

## What three months of running the setup added

**The system could not say no.** Every formation in the published post ends in an artifact, and the critics answer revise or approve. Nothing in that set can return *"this should not be built."*

The gap was invisible against code, where a ticket that reaches an agent has usually already earned its existence. Content exposed it in a week: the topic-picker ran twice in one day and both times correctly concluded the queued item wasn't worth writing (§13d, §13e). A two-outcome loop writes both posts anyway, because "try again" is all it can do.

So: a third exit — **SHIPPED / HOLD-with-evidence / BLOCKED-on-a-named-decision**, with HOLD filed as a *success*. That last clause is load-bearing. An agent that reads stopping as failure finds a reason to keep going.

**Four-eyes only counts across agent types.** A fresh context window resets what an agent knows without touching what it finds plausible. Four defects listed, all caught this month after self-review had passed them.

Placement is mid-post, not appended — between "Team mode beats solo mode" (which ends on *"the rule file decides"*) and "Why the rules need to change", because the new material answers what that rule file couldn't decide. "Where to start" changed too: write the three exits in on day one.

## Gates

- **STEP 4e `reflexion-reflect`: FAILED first pass, fixed before commit.** Three paragraphs ran 4 sentences against the 3-sentence cap; section 1 had no single-sentence paragraph; section 2's longest sentence was 21 words against a required >22.
- It also caught an **unsourced claim I had written** — *"for a while ours were the same agent type as the writer… they returned confident approvals."* No in-repo source exists for that history. Replaced with the mechanism, which is defensible without asserting a past we can't cite.
- Banned words: clean. The four `discover` hits are pre-existing role names ("Discovery agent"), not the marketing verb.
- Banned structural patterns and em dashes: zero.
- Every claim traced to source: §13d and §13e for the two HOLD runs; the four caught defects are this session's, all documented in-repo.
- `bin/hugo-build` green; page renders 200 with all new sections present.

Content-only diff (markdown prose + frontmatter), so the visual suites correctly do not apply. 1,645 → 2,142 words.

## Not covered

**No independent verifier ran.** Agent spawning is unavailable in this session, so the critic panel and cold-eyes gate were executed inline against their written criteria by the same author. That is weaker than the pipeline specifies, and it is recorded rather than glossed.

## Review link

`http://localhost:27431/blog/claude-code-xp-team-workflow/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg
