### PR TITLE
The post merged and did not publish: dated tomorrow

### DIFF
--- a/.claude/skills/blog-write/SKILL.md
+++ b/.claude/skills/blog-write/SKILL.md
@@ -129,6 +129,21 @@ criteria scored, and the scores written into the commit message.
 
 Feature branch, commit, `gh pr create` with the evidence. Never push to master.
 
+**Prove the post is in the PRODUCTION build before you call it delivered.**
+`bin/hugo-build` does not prove it - that writes to `_dest/public-dev`, which
+builds future-dated content, and production does not. Set `date:` to today or
+earlier, then:
+
+```
+bin/rake test:links
+find _dest/public-linkcheck -type d -name "<slug>"
+```
+
+Quote the page-count delta. A post dated one day ahead merges, passes every
+gate, and does not publish - and the link check reports a clean zero because it
+crawled everything except your post. "Merged" and "delivered" are different
+claims; only the second one needs this check (2026-08-22).
+
 **Do NOT wait for CI on a content-only PR** (Paul 2026-08-22). Prose and
 frontmatter cannot move the app build, so local gates decide and you merge as
 soon as they are green.

--- a/content/blog/how-to-audit-content-you-didnt-write/index.md
+++ b/content/blog/how-to-audit-content-you-didnt-write/index.md
@@ -1,7 +1,7 @@
 ---
 title: "How to Audit Content You Didn't Write"
 description: "Someone spent $900,000 publishing fake research so chatbots would repeat it. The same economics apply to the blog your agency built. Four checks you can run."
-date: 2026-08-23
+date: 2026-08-22
 draft: false
 author: 'JetThoughts Team'
 slug: how-to-audit-content-you-didnt-write

--- a/docs/workflows/blog-pipeline.md
+++ b/docs/workflows/blog-pipeline.md
@@ -468,6 +468,22 @@ Before flipping draft: false or before any LinkedIn/external promotion drives tr
 If any of the above checks fail, fix before proceeding to STEP 7.
 
 STEP 7 — VALIDATE
+- **CONFIRM THE POST IS IN THE PRODUCTION BUILD.** `bin/hugo-build` passing does
+  NOT prove this and never did: it writes to `_dest/public-dev`, which builds
+  future-dated content. Production does not. A post dated even one day ahead
+  merges cleanly, passes every gate, and silently does not publish — that
+  happened on 2026-08-22 with `how-to-audit-content-you-didnt-write`, dated
+  tomorrow, merged, absent from the live set.
+
+  ```
+  bin/rake test:links   # builds production into _dest/public-linkcheck
+  find _dest/public-linkcheck -type d -name "<slug>"
+  ```
+
+  Quote the page-count delta as the evidence: the run above went 1,768 → 1,775
+  pages when the post entered the set. A link check that reports zero errors
+  while your post is missing from the crawl is a vacuous green — it scanned
+  everything except the thing you wrote.
 - bin/hugo-build must pass (zero errors)
 - Chrome DevTools: open the post page, verify:
   - Zero console errors


### PR DESCRIPTION
The post merged and did not publish: dated tomorrow

Paul asked whether the post was delivered. It was not, and I would not have
noticed - I had reported it shipped.

`how-to-audit-content-you-didnt-write` carried `date: 2026-08-23`. Today is the
22nd. Production does not build future-dated content, so the post merged to
master, passed every gate, and was absent from the live site. Date corrected to
2026-08-22.

**Both pieces of evidence I cited were vacuous, and that is the part worth
keeping.**

`bin/hugo-build` passed - it writes to `_dest/public-dev`, which DOES build the
future, so my post was there and I read that as proof. Production writes
elsewhere. The build never claimed what I took it to claim.

`bin/rake test:links` reported zero errors across 1,768 pages - because the post
was not among them. A crawl that skips the thing you wrote reports a clean green
for exactly that reason. It scanned everything except the artifact under test.

This is the same shape as the dtest incident (#578, green because it compared
nothing) and the reason the fault-injection work exists: a gate that cannot see
the artifact reports success indistinguishable from real success.

The falsifiable check, now in blog-pipeline.md STEP 7 and the blog-write skill:
build production, find the slug in it, and QUOTE THE PAGE-COUNT DELTA. This run
went 1,768 -> 1,775 pages when the post entered the set. That delta is the
evidence; "the build passed" is not.

  bin/rake test:links
  find _dest/public-linkcheck -type d -name "<slug>"

"Merged" and "delivered" are different claims. Only the second needs this check,
and I made the first while reporting the second.

Verified after the fix: post present in _dest/public-linkcheck, 1,775 pages,
31,908 unique links, zero errors.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg
