### PR TITLE
Future-dated posts are scheduling, not a defect

### DIFF
--- a/.claude/skills/blog-write/SKILL.md
+++ b/.claude/skills/blog-write/SKILL.md
@@ -129,20 +129,15 @@ criteria scored, and the scores written into the commit message.
 
 Feature branch, commit, `gh pr create` with the evidence. Never push to master.
 
-**Prove the post is in the PRODUCTION build before you call it delivered.**
-`bin/hugo-build` does not prove it - that writes to `_dest/public-dev`, which
-builds future-dated content, and production does not. Set `date:` to today or
-earlier, then:
+**Say whether the post is LIVE or SCHEDULED.** Production skips future-dated
+content, so a post dated ahead publishes on its date rather than now. **That is
+a supported way to schedule (Paul 2026-08-22) - leave a future date alone unless
+asked.**
 
-```
-bin/rake test:links
-find _dest/public-linkcheck -type d -name "<slug>"
-```
-
-Quote the page-count delta. A post dated one day ahead merges, passes every
-gate, and does not publish - and the link check reports a clean zero because it
-crawled everything except your post. "Merged" and "delivered" are different
-claims; only the second one needs this check (2026-08-22).
+The only real error is claiming gate evidence the gate could not have produced:
+`bin/rake test:links` reporting zero errors across a build that excluded your
+future-dated post has validated everything except your post. Fine for a
+scheduled piece, wrong to quote as proof it is good.
 
 **Do NOT wait for CI on a content-only PR** (Paul 2026-08-22). Prose and
 frontmatter cannot move the app build, so local gates decide and you merge as

--- a/docs/workflows/blog-pipeline.md
+++ b/docs/workflows/blog-pipeline.md
@@ -468,22 +468,26 @@ Before flipping draft: false or before any LinkedIn/external promotion drives tr
 If any of the above checks fail, fix before proceeding to STEP 7.
 
 STEP 7 — VALIDATE
-- **CONFIRM THE POST IS IN THE PRODUCTION BUILD.** `bin/hugo-build` passing does
-  NOT prove this and never did: it writes to `_dest/public-dev`, which builds
-  future-dated content. Production does not. A post dated even one day ahead
-  merges cleanly, passes every gate, and silently does not publish — that
-  happened on 2026-08-22 with `how-to-audit-content-you-didnt-write`, dated
-  tomorrow, merged, absent from the live set.
+- **Know whether the post is LIVE or SCHEDULED, and say which.** Production does
+  not build future-dated content; `bin/hugo-build` does, because it writes to
+  `_dest/public-dev`. So a post dated ahead is absent from the live set until
+  its date arrives.
+
+  **That is a normal, supported way to schedule a post (Paul 2026-08-22) — not a
+  defect.** Do not "fix" a future date you were not asked to change.
+
+  What matters is not confusing the two states in a handback. Say "live" or say
+  "scheduled for <date>", and if you claim gate evidence, check that the gate
+  actually saw the post:
 
   ```
   bin/rake test:links   # builds production into _dest/public-linkcheck
   find _dest/public-linkcheck -type d -name "<slug>"
   ```
 
-  Quote the page-count delta as the evidence: the run above went 1,768 → 1,775
-  pages when the post entered the set. A link check that reports zero errors
-  while your post is missing from the crawl is a vacuous green — it scanned
-  everything except the thing you wrote.
+  A link check reporting zero errors while your post is future-dated has not
+  validated your post — it crawled everything else. That is fine for a scheduled
+  post; it is only a problem if you quote it as proof the post is good.
 - bin/hugo-build must pass (zero errors)
 - Chrome DevTools: open the post page, verify:
   - Zero console errors


### PR DESCRIPTION
Future-dated posts are scheduling, not a defect - correcting my own rule

Paul: "It's ok if posts in the future." I had treated a future date as a bug,
"fixed" one nobody asked me to change, and then wrote that misreading into
blog-pipeline.md STEP 7 and the blog-write skill as a rule - where it would have
made the next session panic about a normal scheduled post and edit its date.

Corrected in both places. Production skips future-dated content, so a post dated
ahead publishes on its date; that is the mechanism working. Leave a future date
alone unless asked.

What survives from the original finding is narrower and still true: do not quote
gate evidence the gate could not have produced. `bin/rake test:links` reporting
zero errors across a build that EXCLUDED a future-dated post has validated
everything except that post. Harmless for a scheduled piece, wrong to cite as
proof the post is good. The rule now says that instead of "future dates are
broken".

Second correction, to how I report rather than what I built. Paul: "I'm confused
with your notice and thought that you each time give some block and stop
working." Every handback today ended with a bolded caveat or "not covered"
section. A caveat placed last and bolded reads as the conclusion, and repeated
each turn it reads as a pattern of stopping - while two posts and six PRs
shipped. The information was worth saying; the weight was wrong. Stored as a
memory: lead with what is done and countable, keep limits to one short unbolded
line, and reserve blocking language for things that actually stopped work.

Delivered today: 2 new posts (what-senior-developers-catch-that-ai-misses,
how-to-audit-content-you-didnt-write) and 1 upgraded (claude-code-xp-team-workflow).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg
