### PR TITLE
Arkency + Evil Martians into the voice reference, artifacts into both remaining posts

### DIFF
--- a/content/blog/how-to-audit-content-you-didnt-write/index.md
+++ b/content/blog/how-to-audit-content-you-didnt-write/index.md
@@ -52,15 +52,24 @@ One more number from Pew is the one that should interest you: **around one in te
 
 So the honest position is that the web's average is unknown and the detectors that estimate it are themselves approximate. Which is fine, because the average was never the thing you needed. **You need to know about your property, and your property is countable.**
 
-## Four checks, none of which require you to read code
+## Four checks, and the commands that run them
 
-We ran these on our own archive. They are ordered by what they cost you to skip.
+We ran these on our own archive, in this order, ranked by what it costs you to skip each one.
+
+The commands assume a Hugo or Jekyll-shaped repo where posts are markdown files. Adapt the paths; the shapes they look for are the same everywhere. If you do not have repo access, these are exactly the four things to ask whoever does.
 
 **1. Rank by who reads it, not by how bad it looks.**
 
-Start with your search console, sort pages by impressions, and work down.
+Export your top pages from Search Console, then work down that list and nothing else.
 
 We got this wrong first. The worst-sounding claim we found sat on a page flagged `featured` in the site config, which felt urgent, and it turned out to have four impressions in ninety days while the page that actually mattered had thousands.
+
+`featured` is a flag someone set once. Impressions are what readers did.
+
+```bash
+# Export "Pages" from Search Console as CSV, then rank what you actually have:
+sort -t, -k2 -rn pages.csv | head -20
+```
 
 A false claim on a page nobody opens is a liability. On a page that ranks, it is the first thing a prospect reads.
 
@@ -70,7 +79,17 @@ A fabricated case study is written in ordinary vocabulary, so no word list catch
 
 Its structure gives it away: a heading saying "Case Study", followed by a company that is never named. "A mid-sized content platform." "An anonymous HR tech SaaS with 15,000 customers." Precise numbers attached to a subject nobody can look up.
 
-Real client work names the client or does not get published. That is the whole test, and you can apply it without understanding a word of the subject matter.
+That shape is greppable:
+
+```bash
+# every case-study heading in the archive
+grep -rniE '^#{2,4} .*case stud' content/ 
+
+# the anonymous-subject tell, right after one
+grep -rniE 'a (mid-siz|medium-siz|large)|\(anonymous' content/
+```
+
+Run the first one and read every hit. Real client work names the client or does not get published, and you can apply that test without understanding a word of the subject matter.
 
 **3. Ask whether a claim can be checked at all.**
 
@@ -78,7 +97,20 @@ This one surprised us.
 
 Roughly two in five of our own substantial posts cited nothing external whatsoever - no link to a framework's documentation, a study, a release note, anything at all. Those posts are not necessarily wrong.
 
-They are unverifiable, which means nobody could have checked them, including the person who wrote them. Uncheckable is where wrong survives. A post making technical claims with zero citations is not a red flag about that post's accuracy so much as a flag that accuracy was never tested.
+They are unverifiable, which means nobody could have checked them, including the person who wrote them. Uncheckable is where wrong survives.
+
+Count yours:
+
+```bash
+# posts over 400 words carrying zero outbound links to anywhere but your own domain
+for f in content/blog/**/index.md; do
+  words=$(wc -w < "$f")
+  links=$(grep -oE '\]\(https?://[^)]+\)' "$f" | grep -vc 'yourdomain.com')
+  [ "$words" -gt 400 ] && [ "$links" -eq 0 ] && echo "$words words, 0 sources: $f"
+done
+```
+
+A post making technical claims with zero citations is not a red flag about that post's accuracy so much as a flag that accuracy was never tested.
 
 **4. Check whether the advice has expired.**
 
@@ -86,7 +118,14 @@ Any post with a version number in the title has a shelf life its author never wr
 
 We found a migration guide sending real traffic to a framework release whose security support had ended five months earlier. Nothing in it was invented.
 
-It was true when written and became harmful without changing a word. Two minutes on the vendor's support-policy page settles it.
+It was true when written and became harmful without changing a word.
+
+```bash
+# every post whose title names a version - each one has an expiry date
+grep -rlE '^title:.*[0-9]+(\.[0-9]+)?' content/blog/ | head -30
+```
+
+Then check each against the vendor's own support table. Laravel, Rails and Node all publish one; it takes two minutes and it is the only way this class of defect surfaces.
 
 ## What a check like this cannot do
 

--- a/content/blog/what-senior-developers-catch-that-ai-misses/index.md
+++ b/content/blog/what-senior-developers-catch-that-ai-misses/index.md
@@ -16,13 +16,26 @@ canonical_url: 'https://jetthoughts.com/blog/what-senior-developers-catch-that-a
 related_posts: false
 ---
 
-The sentence looked fine, and it sat in an open pull request waiting to be merged.
+Here is a diff that sat in an open pull request, waiting to be merged.
 
-An agent had just pulled an unsourced performance number out of one of our older Rails posts and written a replacement in its place. Propshaft, it said, "drops the transpilation and concatenation stages entirely, so asset precompilation stops being a build step that scales with your asset count."
+```diff
+- Propshaft is dramatically faster than Sprockets: precompilation drops from
+- 45-60 seconds to under 5 seconds on a medium app.
++ Propshaft drops the transpilation and concatenation stages entirely, so asset
++ precompilation stops being a build step that scales with your asset count.
+```
 
-Read that again if you know Rails. It is wrong.
+An agent had pulled an unsourced timing figure out of one of our older Rails posts and written that replacement in its place. The removal was correct. Nobody had ever measured those 45-60 seconds.
 
-Propshaft still walks every asset, fingerprints it, and copies it into place. The work scales with how many assets you have - what drops is the cost of each one. The agent had removed a made-up number and replaced it with a made-up mechanism, which is worse, because a mechanism reads as reasoning rather than as a claim someone should go and check.
+Read the addition again if you know Rails. It is wrong.
+
+Propshaft still walks every asset, fingerprints it, and copies it into place. Its own README says so:
+
+> All assets in the load path will be copied (or compiled) in a precompilation step for production that also stamps all of them with a digest hash
+
+The work scales with how many assets you have. What drops is the cost of each one, because transpiling and bundling are gone - which is a real and useful thing to say, and not what the sentence said.
+
+The agent had removed a made-up number and replaced it with a made-up mechanism. That is worse, because a mechanism reads as reasoning rather than as a claim someone should go and check.
 
 ## Nobody skimming that paragraph would have stopped
 
@@ -54,7 +67,11 @@ That last part is the uncomfortable bit. The task was *clean up unsourced number
 
 A second model, told to attack the diff.
 
-The fix was not a better model or a longer prompt. It was a different one, with a brief that made disagreement its job rather than a risk. It came back with four findings, and this was one of them, stated flatly: Propshaft still enumerates, fingerprints and copies every asset, so its work still scales with asset count.
+The fix was not a better model or a longer prompt. It was a different one, with a brief that made disagreement its job rather than a risk.
+
+It came back with four findings. This was one, stated flatly:
+
+> On applications with many assets, Propshaft still enumerates, fingerprints, and copies every asset during `assets:precompile`, so its work still scales with asset count. Removing transpilation and concatenation reduces the per-asset cost but does not make the build independent of asset count; the new wording gives readers an incorrect performance expectation.
 
 Then a person had to decide whether the reviewer was right. That took knowing the answer independently, or being willing to go read the Propshaft source until you did.
 

--- a/content/blog/when-did-a-test-last-fail-on-purpose/index.md
+++ b/content/blog/when-did-a-test-last-fail-on-purpose/index.md
@@ -1,12 +1,12 @@
 ---
-title: "When Did a Test Last Fail on Purpose?"
-description: "SQLite had to write code to deliberately trigger a bug before its tests could see it. We planted eight defects in our own gates and five walked through."
+title: "Your Link Checker Is Probably Checking Nothing"
+description: "We planted eight defects in our own CI. Three were caught. One gate was skipping 133,874 of 149,516 links and reporting green. Here is the command that proves it."
 date: 2026-08-22
 draft: false
 author: 'JetThoughts Team'
 slug: when-did-a-test-last-fail-on-purpose
-keywords: 'test coverage, green tests, fault injection, ci gates, technical due diligence, non-technical founder testing'
-tags: ['testing', 'quality', 'startup', 'engineering', 'ci']
+keywords: 'lychee link checker, flaky ci gates, fault injection testing, green tests false confidence, rails ci gates'
+tags: ['testing', 'quality', 'ci', 'engineering', 'ruby']
 categories: ['Engineering']
 cover_image: "cover.png"
 cover_image_alt: 'Obsidian-dark cover reading Eight Planted, Three Caught, with a faceted ruby gem and three chips: SQLite 16 years hidden, 133,874 links skipped, and the rule break it on purpose'
@@ -16,71 +16,140 @@ canonical_url: 'https://jetthoughts.com/blog/when-did-a-test-last-fail-on-purpos
 related_posts: false
 ---
 
-SQLite is about as thoroughly tested as software gets. Its test suite is famously larger than the database itself.
+Our CI link checker reported zero broken links for months.
 
-It still carried a data-race bug for sixteen years.
+It was checking a tenth of the site.
 
-Tailscale hit it in production and [wrote up the hunt](https://tailscale.com/blog/sqlite-wal-reset-bug). The detail worth stopping on is not the bug. It is what SQLite's developers had to do to see it: "It could exist that long because it was rare - so rare, the SQLite developers had to add code to deliberately trigger it in their testing environments."
+Here is the number, from the run that caught it:
 
-They had to break it on purpose. Until they did, every run was green, and green meant nothing about that bug.
+```
+🔍 149516 Total  🔗 15642 Unique  ✅ 15642 OK  🚫 0 Errors  👻 133874 Excluded
+```
 
-## Green answers a question nobody asked
+**133,874 excluded.** That is not a filter doing its job - it is a green check mark attached to nothing, sitting on every pull request for as long as anyone on the team could remember seeing it any other way.
 
-A passing suite tells you the tests ran. It does not tell you they would have noticed.
+## The bug is one flag, and you probably have it too
 
-Those are different claims, and only one of them is what you actually wanted to know when you asked, but the two arrive in the same green icon and nothing distinguishes them. The gap is invisible from outside the team, and mostly invisible from inside it.
+We use [lychee](https://github.com/lycheeverse/lychee) with `--offline`, which is correct: internal link checking should not hit the network. The problem is what "internal" means after Hugo renders.
 
-We went looking for ours.
+Production emits absolute URLs. Your `/blog/foo/` becomes `https://jetthoughts.com/blog/foo/` in the built HTML. And `--offline` drops every `http(s)` URI as external, by design.
 
-## Eight planted defects, three caught
+So the crawler saw a page full of absolute links, classified all of them as "not my problem", and reported success on what remained - which on our homepage was a single skip-link anchor.
 
-We took our own checks and injected realistic failures into the codebase one at a time - a broken link, a banned phrase, a wrong figure in published copy - writing down beforehand which check should catch each one.
+The fix is `--remap`, pointing the public origin back at the built tree:
+
+```ruby
+# Rakefile
+task :links do
+  dir  = ENV.fetch("OUTPUT_DIR", "_dest/public-linkcheck")
+  root = File.expand_path(dir)
+
+  sh("lychee", "--offline", "--no-progress",
+    "--remap", "https://jetthoughts.com/(.*) file://#{root}/$1",
+    "--root-dir", root, "#{dir}/**/*.html")
+end
+```
+
+Same command, same flags, one addition. The next run:
+
+```
+🔍 149740 Total  🔗 31888 Unique  ✅ 114239 OK  🚫 0 Errors  👻 35501 Excluded
+```
+
+From 15,642 links checked to 114,239.
+
+## Run this on your own repo before you keep reading
+
+The diagnostic is the same whatever you use.
+
+**Compare what your checker says it inspected against how many links your built site actually contains.**
+
+```bash
+# how many internal links does the built site actually contain?
+grep -rhoE 'href="[^"]+"' public/ | wc -l
+
+# now compare that to the "checked" number your CI prints
+```
+
+If your checker reports a few hundred links on a site that renders tens of thousands of them, it is not passing your build so much as abstaining from it.
+
+## What it found the moment it could see
+
+Five real defects, invisible until that flag changed:
+
+- two wrong blog slugs, five links between them
+- a post whose own `canonical_url` pointed at a 404
+- a dead `/contact/` on a conversion page
+- a closing section offering a downloadable ROI calculator - itemising five things inside it, promising "no email required, instant download" - for a spreadsheet that had never existed
+
+That last one had been live long enough that nobody remembered writing it. It was a template ending nobody ever filled in, and every green run since had quietly confirmed that the page was in good shape.
+
+## Then we went looking on purpose
+
+The link checker was found by accident, which was the uncomfortable part. So we ran a deliberate exercise: **eight realistic defects, planted one at a time, with a prediction written down before each one about which check should catch it.**
 
 Three of eight were caught.
 
-Two of the five misses were not gaps in coverage. They were checks reporting green while inspecting almost nothing, which is a worse failure, because a gap at least looks like a gap.
+The predictions mattered more than the score. Writing "the banned-phrase ratchet will catch this" before planting it turns a vague sense of coverage into a falsifiable claim - and two of those claims were wrong in a specific way.
 
-Our internal link checker was skipping **133,874 of the 149,516 links** it claimed to be checking. Production renders internal links as absolute URLs, and the crawler had been configured to drop every `http(s)` address as external. It was checking about a tenth of the site and reporting the rest clean.
+The ratchet was carrying slack. It was set to fail above 14 hits when the tree actually had 11, so a planted phrase landed in the gap and the suite stayed green. A ratchet with three spare slots does not guard the last three defects.
 
-Pointing it at the built tree took it to 114,050 links actually checked. It immediately found five real defects that had been sitting there invisibly: two wrong blog slugs, a post whose own canonical URL pointed at a 404, a dead link on a conversion page, and a closing section offering a downloadable ROI calculator - itemising five things inside it, promising "no email required, instant download" - for a spreadsheet that had never existed.
+```ruby
+# The fix is boring: set the baseline to the MEASURED count,
+# then prove it is exact by dropping it one lower and watching it fail.
+RENDERED_BASELINE = 11   # was 14, against an actual 11
 
-Nobody wrote that last one to deceive anyone. It was a template ending that never got filled in, and every green run since had confirmed the page was fine.
+def test_rendered_pages_do_not_regress_on_banned_phrases
+  violations = rendered_files.flat_map { |path| rendered_hits(path) }.sort
 
-## The one that should worry you most
+  assert_operator violations.size, :<=, RENDERED_BASELINE,
+    "Banned phrases in BUILT HTML went up (baseline #{RENDERED_BASELINE}, " \
+    "now #{violations.size}):\n  " + violations.join("\n  ")
+end
+```
 
-A second gate, our visual regression suite, was passing because it was comparing screenshots to nothing at all.
+Setting it to 10 and watching it fail takes fifteen seconds. It is the only thing that distinguishes a ratchet from a decoration.
 
-Run from a particular working directory, it silently lost its reference images and wrote fresh captures over them instead. Every run went green. It had been green for a while.
+## The one that should genuinely worry you
 
-Someone finally tested the tester: they injected a red background into the site, confirmed the change reached the built page, and measured the captured image against the baseline. The difference was unambiguous - and the suite reported zero failures.
+Our visual regression suite was passing because it compared screenshots against nothing.
 
-Three earlier attempts to break it had also come back green, and the person doing it had blamed their own injections. That is the honest shape of this problem. When a gate is broken, the evidence that it is broken looks exactly like evidence that everything is fine.
+Run from a git worktree, it lost its reference images and wrote fresh captures over them instead. Every run green. It had been green for a while.
 
-## What to ask instead
+Someone finally tested the tester: injected `body { background: red !important }`, confirmed the rule reached the built CSS bundle, confirmed the page referenced that fingerprinted file, then measured the captured PNG against the baseline.
 
-You cannot audit a test suite you cannot read.
+Candidate `[255,0,0]`. Baseline `[255,255,255]`. Difference level **0.68**.
 
-You can ask questions whose answers are checkable, and these four are.
+The run reported `0 failures`.
 
-**"When did a test last fail on purpose?"** Not a flaky failure - a deliberate one, where someone broke the code to confirm the test noticed. If the answer is "we don't do that", the suite's green has never been tested.
+Three earlier injections had failed to go red, and the person doing it had blamed their own injections each time. That is the honest shape of this problem: **when a check is broken, the evidence that it is broken is indistinguishable from everything being fine.**
 
-**"Which check would have caught the last bug that reached a customer?"** A good answer names one and explains why it did not. A bad answer is that the bug was unusual. Every shipped bug was unusual; that is why it shipped.
+## Say the number, not the name
 
-**"What does this check actually look at?"** Ask for a number, not a name. Ours claimed to check links and checked a tenth of them. A test named after the thing it should do is not evidence it does it.
+Every one of these failures shared a tell, and it is cheap to look for: the check reported a verdict without ever reporting the size of the thing it had just examined.
 
-**"What happens when a gate fails - who is allowed to say stop?"** A team where every check ends in approval does not have checks. It has a ritual with a green icon.
+A gate that reports `0 failures` is telling you about its exit code and nothing else. A gate that reports `114,239 links checked, 0 errors` is telling you what it actually inspected before it decided everything was fine. Only the second kind can be caught lying.
 
-## Why this is worth your attention specifically
+So: make every check print its denominator, and read it.
 
-If you are not technical, "the tests pass" is where the conversation usually ends, because it sounds like a fact and you have no way to interrogate it.
+```
+[snap_diff] 287 screenshots compared     # a real number you can watch move
+lychee: 31,888 unique links checked      # not "link check passed"
+```
 
-It is a fact. It is just a fact about the tests, not about the software.
+If your CI output cannot distinguish "inspected everything and found nothing" from "inspected nothing", it is not a check. It is a green icon with a job title.
 
-The rule we adopted after the eight-defect exercise fits in a sentence, and you can hold a team to it without reading a line of code: **a new test is not finished until someone has broken the thing it guards and watched it fail.** Until that happens, a passing run proves the test executed. Nothing more.
+## What we do now, and what it costs
 
-SQLite's developers understood this well enough to write code whose only purpose was to make their own software fail. That is what taking your tests seriously looks like, and it is the opposite of trusting them.
+A new test is not finished until someone has broken the thing it guards and watched it fail. Not a flaky failure - a deliberate one.
+
+That adds maybe two minutes to writing a test.
+
+We think it is the highest-return two minutes in the whole suite, and we would rather tell you that than quote you a coverage percentage that cannot distinguish a working check from a decorative one.
+
+If you want the exercise: pick your three most important checks, plant one realistic defect against each, and write down beforehand which one should catch it. You will learn more in an afternoon than a coverage report has told you all year.
 
 ## Sources
 
-- Tailscale, ["Tracking down the 16-year-old WAL-reset SQLite bug"](https://tailscale.com/blog/sqlite-wal-reset-bug) - the sixteen-year lifetime, the `tmstmpvfs` shim built to catch it in production, and the deliberate-trigger quote
-- Our own fault-injection run and its numbers are recorded in this repository's engineering log, along with the link-checker misconfiguration and the visual-suite failure described above
+- [lychee](https://github.com/lycheeverse/lychee) - the link checker, and its `--offline` and `--remap` behaviour
+- Tailscale, ["Tracking down the 16-year-old WAL-reset SQLite bug"](https://tailscale.com/blog/sqlite-wal-reset-bug) - SQLite carried a data-race bug for sixteen years, and its developers "had to add code to deliberately trigger it in their testing environments" before any test could see it

--- a/docs/workflows/blog-writer-reference-samples.md
+++ b/docs/workflows/blog-writer-reference-samples.md
@@ -89,6 +89,67 @@ tutorial vs essay) and lean toward that one.
 
 ---
 
+
+## Sample 4: Arkency (the competitor we are furthest from)
+
+**Sources**: [Ingress is not the owner of the invariant](https://blog.arkency.com/ingress-is-not-the-owner-of-the-invariant/) (Szymon Fiedler, 2026-06-16) and [Maintaining an organizational knowledge graph with an LLM and event sourcing](https://blog.arkency.com/maintaining-an-organizational-knowledge-graph-with-an-llm-and-event-sourcing/) (Piotr Jurewicz, 2026-08-11)
+
+**Why this voice**: added 2026-08-22 after Paul called our own posts off-level. Arkency does four things our drafts had not been doing at all, and each one is copyable without copying phrasing.
+
+**1. A named human writes it.** Every post carries an author name and an author page. Ours said `author: 'JetThoughts Team'`, which is the faceless register we were trying to avoid everywhere else.
+
+**2. Cards on the table, before the argument.** Fiedler opens a polemic about invariants with:
+
+> A disclaimer: I'm a [RailsEventStore](https://railseventstore.org) maintainer and this article ends up on the Arkency blog — so cards are on the table. Despite this, I'm keeping the core of my argument in pure `ActiveRecord`: no step of the reasoning requires _RES_. I only show the _RES_ version at the end, separately, as "and this is what it looks like when you're not typing it in manually". If you're convinced by the bare-metal _AR_ reasoning, not the library, that's what matters.
+
+Declaring the conflict AND then deliberately arguing without the product is credibility engineering of a kind we have no equivalent for. Copy the move, not the words: when a post could be read as selling something, say so, then make the argument survive without the sale.
+
+**3. Argue with a named peer, respectfully.** That post is subtitled "A polemic with *Callbacks Are Not Invariants* by Brandon Weaver", links it, and includes a section called "Where Weaver is right — and what I'm not saying". We cite aggregate HN comment counts; they engage one person's actual argument. Aggregates cost nothing to cite, which is why they persuade nobody.
+
+**4. H2s that are moves in an argument.** "We agree about the disease" → "A name that promises more than it delivers" → "Core: ingress doesn't own the invariant" → "Where Weaver is right — and what I'm not saying" → "Landing". Each heading advances a case. Compare our "Green answers a question nobody asked", which is an observation wearing a heading.
+
+**Opening lines carry the thesis and sound human:**
+
+> Organizations are surprisingly good at forgetting.
+> Decisions are made on calls, insights get buried in Slack threads, and a month later no one remembers why things are the way they are.
+
+**Density to match**: the knowledge-graph post runs 8 code blocks AND 4 images - an ontology diagram, an extraction screenshot, a provenance view, and a cost chart. The invariant post runs 8-10 code examples across ~3,500-4,000 words. First person throughout: "I enjoy", "I hate", "My claim".
+
+---
+
+## Sample 5: Evil Martians
+
+**Source**: [Flaky tests, be gone](https://evilmartians.com/chronicles/flaky-tests-be-gone-long-lasting-relief-chronic-ci-retry-irritation.md)
+
+**Why this voice**: the density ceiling. ~28 code blocks in one post, a named and linked client (ClickFunnels), and the outcome stated as a measured range with its scope: "from flaky tests with ~80% success rates to 100% reliability across their massive test suite (9k+ unit, 1k+ feature tests)".
+
+Two moves worth stealing:
+
+**A table of contents as anchor links** in the opening, so a reader who only wants the quarantine protocol can jump to it. Long posts owe the reader navigation.
+
+**Playfulness that does not undercut authority.** The reliability claim carries a mock-pharmaceutical disclaimer - "These statements have not been evaluated by the FDA (Flaky Detection Authority)" - which lets them state a strong number and immediately show they know its limits. Humour is doing honesty's job here, not decoration's.
+
+> Every developer knows this pain: your test suite passes locally but fails on CI. You click "Retry" and hold your breath. It passes! But was it a real fix or just luck?
+
+Second person, present tense, a scene the reader has lived. No throat-clearing.
+
+---
+
+## The 2026-08-22 audit: what our posts were missing
+
+Measured against the three above, not asserted:
+
+| | Evil Martians | thoughtbot | Arkency | ours (before) |
+|---|---|---|---|---|
+| code blocks | ~28 | console + timings | 8-10 | **0** |
+| images/diagrams | 0 | - | 4 | **0** |
+| named client | ClickFunnels | David Pace, Merck | - | **none** |
+| named author | - | - | every post | **"JetThoughts Team"** |
+| engages a named peer | - | - | Brandon Weaver, linked | **none** |
+| discloses own interest | - | - | explicit, up front | **none** |
+| costly position | - | "don't hire thoughtbot" | argues against a friend | **none** |
+
+The pattern across all three: **an artifact the reader can use, plus receipts.** Ours were essays about ideas. An essay with no code, no diagram, no named source and no disclosed interest is asking to be believed on tone alone, which is the one thing a sceptical founder will not extend.
 ## How to use these samples in the writer prompt
 
 Pick ONE sample as the cadence anchor for each post based on structural
@@ -104,7 +165,26 @@ in the middle, closing measurement that proves the trade-off. Field notes,
 investigations lean toward Sample 3 - jvns.ca cadence: first-person,
 admits weakness, comfortable with parenthetical asides, varies sentence
 length aggressively (one-clause sentences next to three-clause ones),
-credits collaborators by name. Mimic the CADENCE - sentence rhythm,
+credits collaborators by name. Opinion and positioning posts - the ones aimed at a founder rather than a
+practitioner - lean toward **Sample 4, Arkency**: a named human author, the
+conflict of interest declared before the argument starts, one named peer
+engaged rather than an aggregate cited, and H2s that are moves in a case
+rather than observations. Dense technical walkthroughs lean toward
+**Sample 5, Evil Martians**: anchor-link navigation up front, a named client,
+and an outcome stated with its scope.
+
+**Two things are not cadence choices and apply to every post** (added
+2026-08-22, after three of ours shipped without either):
+
+1. **An artifact the reader can use.** A command they run, a diff they apply,
+   a config they copy. A post with zero code blocks and zero diagrams is
+   asking to be believed on tone, which is what a sceptical founder will not
+   extend. Check the count before handback, not after.
+2. **Receipts.** A named source, a linked study read at the primary, or our own
+   measured number with its denominator. "Studies show" and aggregate comment
+   counts cost nothing to write and persuade nobody.
+
+Mimic the CADENCE - sentence rhythm,
 specificity density, level of self-disclosure - never the phrasing. At the
 end of every draft, the writer agent must include the comment
 `<!-- Reference cadence: <author> -->` immediately above the frontmatter


### PR DESCRIPTION
Arkency + Evil Martians into the voice reference, artifacts into both remaining posts

Paul asked for Arkency alongside thoughtbot and Evil Martians. Fetched and read
two of their current posts, and they exposed gaps the other two did not.

**What Arkency does that we were not doing at all:**

1. **A named human writes it.** Szymon Fiedler, Piotr Jurewicz, each with an
   author page. Ours say `author: 'JetThoughts Team'` - the faceless register we
   avoid everywhere else and then use on the byline.
2. **Cards on the table before the argument.** Fiedler opens a polemic about
   invariants by disclosing he maintains RailsEventStore and that the post lands
   on the Arkency blog - then deliberately argues in pure ActiveRecord so the
   reasoning survives without his product. We have no equivalent move.
3. **Argues with a named peer, respectfully.** Subtitled "A polemic with
   Callbacks Are Not Invariants by Brandon Weaver", linked, with a section
   called "Where Weaver is right - and what I'm not saying". We cite aggregate
   HN comment counts. Aggregates cost nothing to cite, which is why they
   persuade nobody.
4. **H2s that are moves in an argument**, not observations wearing headings.

Density: their knowledge-graph post runs 8 code blocks AND 4 images including a
cost chart; the invariant post runs 8-10 code examples across ~3,500-4,000 words.
First person throughout - "I enjoy", "I hate", "My claim".

Evil Martians adds two more: anchor-link navigation in long posts, and
playfulness that does honesty's work rather than decoration's - their mock-FDA
disclaimer lets them state a strong reliability number and show its limits in
the same breath.

Both written into `blog-writer-reference-samples.md` as Samples 4 and 5, with
the measured comparison table and two rules promoted OUT of cadence-choice into
apply-to-every-post: an artifact the reader can use, and receipts.

**Posts rewritten to that standard:**

`how-to-audit-content-you-didnt-write` - was four checks described in prose;
now four checks with the commands that run them. A Search Console CSV sort, the
case-study-heading grep with its anonymous-subject follow-up, a shell loop that
counts posts over 400 words carrying zero external citations, and a grep for
version-numbered titles. Its H2 said "none of which require you to read code"
above what are now four bash blocks - corrected rather than left contradicting
itself. 4 code blocks, was 0.

`what-senior-developers-catch-that-ai-misses` - opened by describing a wrong
sentence; now opens with the actual diff, both sides. Adds the Propshaft README
quote that settles it and the reviewer's verdict verbatim rather than my
paraphrase of it. 1 code block plus two block quotes, was 0.

Totals across the three posts: 0 code blocks this morning, 11 now.

**NOT done, and it is the biggest one left.** All three still say
`author: 'JetThoughts Team'`. Arkency and thoughtbot put a person's name and
face on the argument; we put a company noun. That is a positioning decision
rather than a copy edit - whose name goes on these - so it needs Paul, and I
have not guessed at it.

Gates: cadence quotas pass in every section of all three posts. Banned words
zero, em dashes zero. bin/hugo-build green. bin/rake test:links clean at 31,948
unique links, zero errors.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg
