### PR TITLE
Byline: Paul Keen, and the voice that a byline requires

### DIFF
--- a/content/blog/how-to-audit-content-you-didnt-write/index.md
+++ b/content/blog/how-to-audit-content-you-didnt-write/index.md
@@ -3,7 +3,7 @@ title: "How to Audit Content You Didn't Write"
 description: "Someone spent $900,000 publishing fake research so chatbots would repeat it. The same economics apply to the blog your agency built. Four checks you can run."
 date: 2026-08-22
 draft: false
-author: 'JetThoughts Team'
+author: "Paul Keen"
 slug: how-to-audit-content-you-didnt-write
 keywords: 'content audit, ai generated content, fabricated case studies, blog credibility, agency content review, non-technical founder'
 tags: ['content', 'ai', 'startup', 'marketing', 'trust']
@@ -54,7 +54,7 @@ So the honest position is that the web's average is unknown and the detectors th
 
 ## Four checks, and the commands that run them
 
-Run them in this order. It is ranked by what each one costs you to skip, not by how quick it is.
+Run them in this order. I have ranked them by what each one costs you to skip, not by how quick it is.
 
 The commands assume a Hugo or Jekyll-shaped repo where posts are markdown files. Adapt the paths; the shapes they look for are the same everywhere. If you do not have repo access, these are exactly the four things to ask whoever does.
 
@@ -95,7 +95,7 @@ Run the first one and read every hit. Real client work names the client or does 
 
 Count how many of your long posts link to nothing outside your own domain.
 
-A post with no external citation is not necessarily wrong. It is unverifiable, which means nobody could have checked it - including whoever wrote it, at the moment they wrote it.
+A post with no external citation is not necessarily wrong. It is unverifiable, which means nobody could have checked it - including whoever wrote it, at the moment they wrote it. That is the distinction I care about, and it is the one this count actually measures.
 
 Uncheckable is where wrong survives, and the number usually comes back higher than anyone guesses.
 

--- a/content/blog/what-senior-developers-catch-that-ai-misses/index.md
+++ b/content/blog/what-senior-developers-catch-that-ai-misses/index.md
@@ -3,7 +3,7 @@ title: "What Senior Devs Catch That AI Misses"
 description: "A change swapped a made-up number for a confident, wrong explanation of how Propshaft works. Spotting the difference is the thing you are actually hiring for."
 date: 2026-08-22
 draft: false
-author: 'JetThoughts Team'
+author: "Paul Keen"
 slug: what-senior-developers-catch-that-ai-misses
 keywords: 'ai code review, senior developer value, llm expertise, ai generated code errors, hiring developers ai, technical due diligence'
 tags: ['ai', 'hiring', 'startup', 'engineering', 'code-review']
@@ -16,7 +16,9 @@ canonical_url: 'https://jetthoughts.com/blog/what-senior-developers-catch-that-a
 related_posts: false
 ---
 
-Here is a diff we stopped in review. It is small, it is plausible, and it is wrong in a way you cannot see without knowing Rails.
+Cards on the table before I start: I run a development shop, and this post argues you need experienced people reviewing AI output. That is convenient for me. So I am going to make the case with a diff you can check yourself, and if the Rails reasoning does not hold up, none of the rest should persuade you either.
+
+Here is a change we stopped in review. It is small, it is plausible, and it is wrong in a way you cannot see without knowing Rails.
 
 ```diff
 - Propshaft is dramatically faster than Sprockets: precompilation drops from
@@ -75,7 +77,7 @@ It came back with four findings. This was one, stated flatly:
 
 > On applications with many assets, Propshaft still enumerates, fingerprints, and copies every asset during `assets:precompile`, so its work still scales with asset count. Removing transpilation and concatenation reduces the per-asset cost but does not make the build independent of asset count; the new wording gives readers an incorrect performance expectation.
 
-Then a person had to decide whether the reviewer was right. That took knowing the answer independently, or being willing to go read the Propshaft source until you did.
+Then a person had to decide whether the reviewer was right, and I want to be precise about what that took: either knowing the answer already, or being willing to go and read the Propshaft source until you did.
 
 Three links in that chain, and only one of them is automatable. A model wrote, another model challenged, and someone with domain knowledge adjudicated.
 
@@ -109,7 +111,7 @@ Nobody skipped the check there. The check ran, felt complete, and stopped one ro
 
 You are not buying keystrokes any more. That part got cheap, and pretending otherwise is how founders end up overpaying for output they could have generated themselves.
 
-What stayed expensive is the ability to look at a fluent, well-structured, technically-worded paragraph and say *that specific clause is false*. There is no shortcut to it. It comes from having been wrong about the same thing before.
+What stayed expensive is the ability to look at a fluent, well-structured, technically-worded paragraph and say *that specific clause is false*. I have not found a shortcut to it. It comes from having been wrong about the same thing before, which is a slow way to acquire anything.
 
 So when you are deciding who to hire, or whether the shop you are already paying is worth it, the question changed. It is no longer "can they build this." It is: **when the AI hands them something plausible, do they check it, and can they?**
 
@@ -128,6 +130,8 @@ Every defect in this post was caught the same way: a second pass whose brief was
 Neither half works alone. The reviewer that only agrees is decoration, and the reviewer that objects to something nobody can adjudicate is noise.
 
 Expertise earns its money in a handful of moments per week, and none of them look like productivity. Someone reads a paragraph that scans perfectly and says no, and cannot always explain why until they go and check.
+
+That is an awkward thing to sell and an awkward thing to measure. I would still rather tell you that than quote you a velocity number.
 
 ## Sources
 

--- a/content/blog/when-did-a-test-last-fail-on-purpose/index.md
+++ b/content/blog/when-did-a-test-last-fail-on-purpose/index.md
@@ -3,7 +3,7 @@ title: "Your Link Checker Is Probably Checking Nothing"
 description: "We planted eight defects in our own CI. Three were caught. One gate was skipping 133,874 of 149,516 links and reporting green. Here is the command that proves it."
 date: 2026-08-22
 draft: false
-author: 'JetThoughts Team'
+author: "Paul Keen"
 slug: when-did-a-test-last-fail-on-purpose
 keywords: 'lychee link checker, flaky ci gates, fault injection testing, green tests false confidence, rails ci gates'
 tags: ['testing', 'quality', 'ci', 'engineering', 'ruby']
@@ -60,7 +60,9 @@ From 15,642 links checked to 114,239.
 
 ## Run this on your own repo before you keep reading
 
-Whatever checker you run, the diagnostic is the same.
+The diagnostic is cheap.
+
+Whatever checker you run, it works the same way.
 
 **Compare what your checker says it inspected against how many links your built site actually contains.**
 
@@ -108,7 +110,7 @@ def test_rendered_pages_do_not_regress_on_banned_phrases
 end
 ```
 
-Setting it to 10 and watching it fail takes fifteen seconds. It is the only thing that distinguishes a ratchet from a decoration.
+Setting it to 10 and watching it fail takes fifteen seconds. As far as I can tell it is the only thing separating a ratchet from a decoration.
 
 ## The one that should genuinely worry you
 
@@ -141,11 +143,13 @@ If your CI output cannot distinguish "inspected everything and found nothing" fr
 
 ## What we do now, and what it costs
 
+One rule, and it is not negotiable here.
+
 A new test is not finished until someone has broken the thing it guards and watched it fail. Flaky failures do not count; this has to be deliberate, and someone has to be watching when it goes red.
 
 That adds maybe two minutes to writing a test.
 
-We think it is the highest-return two minutes in the whole suite, and we would rather tell you that than quote you a coverage percentage that cannot distinguish a working check from a decorative one.
+I think it is the highest-return two minutes in the whole suite, and I would rather tell you that than quote you a coverage percentage that cannot tell a working check apart from a decorative one.
 
 If you want the exercise: pick your three most important checks, plant one realistic defect against each, and write down beforehand which one should catch it. You will learn more in an afternoon than a coverage report has told you all year.
 


### PR DESCRIPTION
Byline: Paul Keen, and the voice that a byline requires

Paul: "you can use my name." All three posts now carry `author: "Paul Keen"`,
matching the `paul_keen` record already in data/authors.yaml and the seven
existing posts that use it. Verified rendering - the page shows "by Paul".

A name on the byline is not just a frontmatter change, so three things moved
with it.

**First person where the sentence is a judgement.** "We think it is the
highest-return two minutes" became "I think". "It is the only thing that
distinguishes a ratchet from a decoration" became "as far as I can tell it is
the only thing separating". Kept "we" wherever it describes what the firm
actually does - we stopped a change in review, we ran the exercise. The
distinction is: "we" for actions the team took, "I" for opinions someone is
staking their name on.

**Cards on the table, the Arkency move.** The AI-review post now opens by
disclosing the conflict before making the argument:

  Cards on the table before I start: I run a development shop, and this post
  argues you need experienced people reviewing AI output. That is convenient
  for me. So I am going to make the case with a diff you can check yourself,
  and if the Rails reasoning does not hold up, none of the rest should
  persuade you either.

That was Sample 4's strongest lesson and it was unusable while the byline said
"JetThoughts Team" - a company noun cannot disclose an interest or stake a
reputation. Now it can.

**An admission that costs something**, in the same post's close: expertise
"is an awkward thing to sell and an awkward thing to measure. I would still
rather tell you that than quote you a velocity number."

Gates: cadence quotas pass in every section of all three - two failed after the
first-person edits (a section lost its short sentence) and were fixed, not
waived. Slop measurement clean on all three: zero negative parallelism, zero
definitional cadence, zero generalized actors, openers within caps.
bin/hugo-build green. marketing_copy_test 5/13/0. bin/rake test:links clean at
31,948 unique links, zero errors.

FLAGGED, not fixed - out of scope for a byline change, and Paul's data to
decide on. `data/authors.yaml` line 5 says Paul has "22+ years" experience,
which matches claims-canon; line 7 says `experience_years: 15`, which
contradicts it. The field is referenced by no template in themes/ or layouts/,
so nothing publishes the wrong number today. It is a dormant defect: the moment
someone renders that field we publish 15 against a canon of 22+. Canon also
says derive tenure rather than hardcode it, so the fix is probably deletion
rather than correction.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg
