### PR TITLE
Voice guide: today's corrections, and the contradiction it was carrying

### DIFF
--- a/docs/90-99-content-strategy/strategy-analysis/90.11-voice-guide.md
+++ b/docs/90-99-content-strategy/strategy-analysis/90.11-voice-guide.md
@@ -489,7 +489,85 @@ Every number in a post must link to its source. No exceptions. If you can't find
 2. **Emotional honesty** — admit doubts, fears, conflicted feelings alongside expertise
 3. **Visceral language** — "Boom. Everything broke." not "Issues were encountered."
 4. **Self-aware contradiction** — "I used to think X. I was wrong. Here's what changed my mind."
-5. **Interrupt the flow** — parenthetical asides, em dashes, sentence fragments that break the rhythm
+5. **Interrupt the flow** - parenthetical asides, a dash on its own, sentence fragments that break the rhythm. Use `-`, never `—`: §3 bans the em dash and this line used to recommend it, which is how one crept into three drafts before anyone noticed the guide disagreed with itself (fixed 2026-08-22).
+
+---
+
+## 6b. The competitor standard, and what every post owes (2026-08-22)
+
+Measured against thoughtbot, Evil Martians and Arkency after Paul called three
+of our own posts off-level. The full comparison and the samples live in
+`docs/workflows/blog-writer-reference-samples.md` (Samples 4 and 5). Two rules
+came out of it that are **not cadence choices** - they apply to every post:
+
+**1. An artifact the reader can use.** A command they run, a diff they apply, a
+config they copy, or a diagram carrying a number the prose states. Evil Martians
+ship ~28 code blocks in one post; Arkency ship 8 plus 4 images. Three of our
+posts shipped with zero of either. A post with no artifact asks to be believed
+on tone, which is the one thing a sceptical founder will not extend.
+
+**2. Receipts.** A named source, a study fetched at the primary (press coverage
+of a study is not the study), or our own measured number with its denominator.
+"Studies show" and aggregate comment counts cost nothing to write and persuade
+nobody.
+
+### Length and visual rhythm, measured in a browser
+
+Not by word count - by what the reader scrolls. Open the built page in
+chrome-devtools and measure:
+
+- **screens to scroll** = `document.body.scrollHeight / window.innerHeight`
+- **longest unbroken text run**, in screens, between any two of `h2 img pre table ul ol`
+
+On 2026-08-22 all three posts measured ~12 screens for a 6-minute read with ONE
+in-body diagram across seven or eight H2s. That is the shape Paul flagged as
+"too long and not enough visuals". Aim for a visual break per H2 and treat an
+unbroken text run over ~1.5 screens as a defect.
+
+Force lazy images to load before judging (`img.loading = 'eager'`) and check
+`naturalWidth > 0`. A full-page screenshot races the lazy loader and will show
+you missing images that are fine.
+
+### Slop is found by cold eyes, not by a script
+
+A `bin/check-post-voice` was written and deleted the same day (Paul, 2026-08-22).
+A regex catches "Not X. Not Y." and misses prose that is fluent, on-pattern and
+lifeless, which is the actual defect - and a passing run reads as "the voice is
+fine", the same false confidence as a link checker reporting green over a tenth
+of a site. Correctness is not greppable and neither is voice.
+
+Route it to reviewers of a **different agent type than the writer**, each with a
+distinct lens, briefed with goal and artifact and never with your conclusions,
+and require each to name something it would cut. Three approvals is not a pass;
+it is a panel that was not asked a real question.
+
+---
+
+## 6c. What we never disclose (Paul, 2026-08-22)
+
+**Never write that AI drafts our content, or that our own archive is unverified.**
+
+This is positioning, not style, and it survived a research pass that got it
+wrong. Admitting a *caught* error builds trust - that much is supported. Telling
+a founder who was burned by a devshop that our blog is machine-written and
+unpoliced is a different claim entirely, and it undercuts the thing we sell.
+Three posts shipped with five instances of it before Paul caught it.
+
+Write from the reviewer's chair. The technical substance survives intact: keep
+the diff, keep the source quote that settles it, keep the reviewer's verdict
+verbatim. Drop the claim that the wrong sentence was ours.
+
+**Do not open with a personal disclosure.** Arkency's "cards on the table" works
+because Fiedler maintains the library he is arguing about - a material,
+specific conflict. "I run a dev shop and think review matters" is not a
+disclosure, it is throat-clearing, and it delays the artifact the reader came
+for. Paul's words: "readers are not interested."
+
+**One more, about how these rules get applied.** The failure mode when a
+correction lands is over-applying it: told to use a name, I put the person in
+the intro; told about caveats, I bolded a caveat block into every handback.
+Notice a correction, apply it where it belongs, and stop. A rule from a
+reference sample is a tool for a situation, not a mandate.
 
 ---
 


### PR DESCRIPTION
Voice guide: today's corrections, and the contradiction it was carrying

The competitor standard and Paul's corrections were sitting in
blog-writer-reference-samples.md and in commit messages. CLAUDE.md points
writers at 90.11 as THE voice source, so that is where they belong.

**Fixed a contradiction the guide had with itself.** §6 listed "em dashes" as a
technique to copy while §3 bans them outright. That is how one crept into three
drafts before anyone noticed the guide disagreed with itself. §6 now says use
`-`, and says why the line changed.

**§6b - the competitor standard, and what every post owes.** Two rules promoted
out of cadence-choice into apply-to-every-post, measured against thoughtbot,
Evil Martians and Arkency:

  1. An artifact the reader can use - a command, a diff, a config, or a diagram
     carrying a number the prose states. Evil Martians ship ~28 code blocks in
     one post; Arkency ship 8 plus 4 images. Three of ours shipped with zero.
  2. Receipts - a named source, a study fetched at the PRIMARY, or our own
     measured number with its denominator.

Plus length and visual rhythm measured in a browser rather than by word count:
screens-to-scroll, and the longest unbroken text run between any two of
`h2 img pre table ul ol`. On 2026-08-22 all three posts measured ~12 screens for
a 6-minute read with ONE in-body diagram across seven or eight H2s. Includes the
lazy-image trap: force `loading = 'eager'` and check `naturalWidth > 0` before
judging, because a full-page screenshot races the loader and shows you missing
images that are fine.

And why slop detection is not a script: a `bin/check-post-voice` was built and
deleted the same day. A regex catches "Not X. Not Y." and misses prose that is
fluent, on-pattern and lifeless, and a passing run reads as "the voice is fine".

**§6c - what we never disclose.** Never write that AI drafts our content or that
our archive is unverified. This is positioning, not style, and it survived a
research pass that got it wrong: admitting a CAUGHT error is supported, telling
a founder burned by a devshop that our blog is machine-written and unpoliced is
a different claim that undercuts what we sell. Write from the reviewer's chair -
keep the diff, the source quote, the reviewer's verdict; drop the claim that the
wrong sentence was ours.

Also: do not open with a personal disclosure. Arkency's cards-on-the-table works
because Fiedler maintains the library he is arguing about. "I run a dev shop and
think review matters" is throat-clearing that delays the artifact.

And the meta-rule, because it caused two of today's corrections: the failure mode
when a correction lands is OVER-APPLYING it. Told to use a name, I put the person
in the intro. Told about caveats, I bolded a caveat block into every handback.
Notice a correction, apply it where it belongs, stop.

Cold-eyes re-review of the three posts is running in parallel - four reviewers,
distinct lenses (ICP cold read, voice and AI tells, competitor standard, claim
verification), briefed with goal and artifact rather than my conclusions, each
required to name something it would cut. Findings will land separately.

Gate: bin/hugo-build green. Docs-only diff.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg
