### PR TITLE
LinkedIn post: the $30k box nobody could sign (build-in-public)

### DIFF
--- a/linkedin-posts/personal/agents-picked-wrong-thing.md
+++ b/linkedin-posts/personal/agents-picked-wrong-thing.md
@@ -1,0 +1,41 @@
+---
+title: "I let my agents pick our next product. They were wrong about the wrong thing."
+lane: personal
+pillar: build-in-public
+author: paul-keen
+voice: personal-first-person
+icp_test: Does "the research told us what to build, not whether we'd want to" land, and do founders share their own version of this mistake?
+first_comment: |
+  (value post - no link; reply-CTA only)
+utm_campaign: ""
+utm_content: agents_picked_wrong_thing
+status: draft
+stage: next
+proposed_for: "2026-09-01 17:00 CEST"
+notes: |
+  Pillar: build-in-public (the 70% value; NO course link). From Paul's real work
+  2026-08-24: he ran a multi-agent research sprint (5 parallel agents) to find the
+  best business to build in 2026 with a dev team but no spare millions. Reports came
+  back solid - market size, sources, risk scores. The turn: not one answered the real
+  question (would we want to do it for five years). MCP detail added as concrete hook:
+  we can wire a client's DB/Stripe/Salesforce into an off-the-shelf agent in days, no
+  ML research; MCP ecosystem grew ~900% in 2025 (colrows / CData). Point: do what we
+  already know how to do, package it differently - not chase "idea of the year." Ends on
+  a question, no bait CTA. Plain English, one committed idea, no banned words.
+---
+
+I had my agents run a research sprint this weekend. The question: what business actually makes sense to build in 2026 if you have a dev team but no spare millions to burn.
+
+A couple of hours later, five reports landed. Market size, sources, risk scores - all very solid.
+
+Then I read them and caught the mistake. Not one of those reports answered the real question. They told me where the demand is. None of them told me whether I'd want to do that thing for five years straight.
+
+The tooling makes this fast now. Take MCP - the protocol that lets an AI agent talk to your own systems. We can wire a client's database, Stripe, Salesforce into an off-the-shelf agent in a few days. No machine-learning research, just engineering we already do every week. The ecosystem grew something like 900% last year. Everyone wants agents that touch their own data.
+
+But speed like that doesn't help with the hard part. The hard part is being honest with yourself.
+
+For JetThoughts the answer was both obvious and uncomfortable. Do what we already know how to do - just sell it differently. Not chase the idea of the year. Build the boring connector, ship it, keep the client on a retainer.
+
+Maybe the most underrated skill right now isn't picking up a new stack. It's giving yourself permission to say no to the extra thing.
+
+What are you cutting this year instead of taking on?

--- a/linkedin-posts/personal/thirty-k-box.md
+++ b/linkedin-posts/personal/thirty-k-box.md
@@ -1,0 +1,38 @@
+---
+title: "The $30k box nobody could sign for"
+lane: personal
+pillar: build-in-public
+author: paul-keen
+voice: personal-first-person
+icp_test: Does "we turned a capex blocker into a monthly pilot" land, and do founders share their own version of a purchase that stalled on price?
+first_comment: |
+  (value post - no link; reply-CTA only)
+utm_campaign: ""
+utm_content: thirty_k_box
+status: draft
+stage: next
+proposed_for: "2026-09-03 17:00 CEST"
+notes: |
+  Pillar: build-in-public (the 70% value; NO course link). From Paul's real work
+  2026-08-24: a regulated client wanted private AI help but froze - they feared data
+  leakage and no manager could sign a $30-40k GPU box. We reframed it as a 2-week pilot
+  on rented EU bare-metal GPU (~EUR 2,398/mo for Opus-5-class, single-tenant, GDPR) then a
+  monthly managed retainer. Point: sell the proof and the opex, not the hardware. Ends on a
+  question, no bait CTA. Plain English, one committed idea, stat sourced to Hetzner GEX131.
+---
+
+A client wanted AI help. The kind that keeps their source code inside their own walls.
+
+We priced it honestly. A private box good enough to match a frontier model ran about $30-40k in GPUs. Real numbers, real privacy.
+
+Then it stalled. Not because anyone doubted the value. Because no manager I talked to could get a $30k capital purchase signed. The number alone ended the conversation.
+
+So we changed what we were selling.
+
+Instead of a box, we ran a two-week pilot on rented GPU in a European data center - single-tenant, their data never leaves the EU, never trains anything. Cost us about the price of a decent laptop per month. At the end they got one page: hours saved, how many of their people would actually use it, and proof that nothing left the building.
+
+After that, the monthly number was easy to say yes to.
+
+The lesson wasn't about AI. It was that the thing blocking the sale was never the technology. It was asking someone to buy the wrong thing. Hardware is our problem to own. They only ever needed to buy the result.
+
+What's a purchase you've watched die on a number that wasn't really the point?


### PR DESCRIPTION
Add a personal build-in-public post to linkedin-posts/personal/.

- lane: personal, pillar: build-in-public, voice: personal-first-person, first_comment: no link (pure value, 70% mix).
- Reframes the on-prem AI capex blocker (client froze on a $30-40k GPU box) into a 2-week pilot on rented EU bare-metal GPU, then a monthly managed retainer. One committed idea, plain English, no banned words, stat sourced to Hetzner GEX131 (~EUR 2,398/mo for Opus-5-class).
- status: draft, stage: next, proposed_for 2026-09-03.

Note: bin/rake test:links not run locally (no ruby env); no external links in body - CI link-check should pass trivially.