### PR TITLE
Add citation-quality bar to style rules and cold-eyes gate

### DIFF
--- a/.okf/content/claims-canon.md
+++ b/.okf/content/claims-canon.md
@@ -118,6 +118,32 @@ the mechanical gate does and does not cover.
 profile linked beats "4.8/5 by 32 clients" unlinked. The link is the proof, and
 it cannot go stale the way a transcribed count does.
 
+**Prefer the BEST source, not just the first one that verifies the claim
+(Paul, 2026-08-24).** A blog post's `## Sources` block exists for two distinct
+reasons, and they pull in opposite directions:
+
+1. **Anti-fabrication tripwire** — the uncited ratchet is a cheap, machine-checkable
+   proxy for "this claim rests on something external, not something hallucinated."
+   A link to the official docs satisfies this job. It is necessary but not
+   sufficient for reader value.
+2. **Reader value** — the reader came for your synthesis *above* the source, not
+   a restatement of it. A citation to the Rails guides for "Rails 8 ships with
+   Solid Queue" earns nothing — the reader already knows the gem exists or can
+   Google it in five seconds. What earns its place: primary research, a
+   benchmark with its denominator, the original GitHub issue thread, a
+   practitioner's production measurement, a study fetched at the publisher's own
+   page, or our own measured number with its methodology.
+
+The test: **could the reader have found this source in five seconds of
+Googling?** If yes, it is verification, not value — keep it if the ratchet
+requires it, but do not mistake it for the job being done. The real bar is
+"this is the BEST source for this claim, and the best source is one the reader
+would not have found on their own."
+
+A mechanical gate can only measure the first job (external links exist). The
+second job is a judgment call for the cold-eyes review panel — see
+`docs/workflows/blog-pipeline.md` STEP 5c Check 10.
+
 **"32 clients" is ambiguous - do not treat the two meanings as one.** As a
 *review* count it is false. As *total clients served* it appears in the 2607
 referral and assumptions docs and is plausible for an 18-year-old firm, though it

--- a/.okf/content/voice-rules.md
+++ b/.okf/content/voice-rules.md
@@ -32,7 +32,8 @@ course is patient and second-person with first-mention glossing (this concept);
 LinkedIn is first-person and committed - Register B, hammering one idea. What
 never varies: the banned words, the banned structural patterns, the
 who/show/practitioner tests, and sourced numbers
-([claims canon](claims-canon.md)). A shorter register is not a licence to slop.
+([claims canon](claims-canon.md) — including the citation-quality tier:
+best source per claim, not just any link that matches). A shorter register is not a licence to slop.
 Full table in 90.11 §1b.
 
 # Core rules

--- a/content/blog/cost-optimization-llm-applications-token-management/index.md
+++ b/content/blog/cost-optimization-llm-applications-token-management/index.md
@@ -1410,10 +1410,11 @@ For more on building production-ready LLM applications, check out our guides on 
 
 ## Sources
 
+- Anthropic, [Optimizing for Cost and Intelligence](https://platform.claude.com/docs/en/about-claude/models/optimizing-for-cost-and-intelligence). Prompt caching cut agent-loop cost by **2.5× to 3.7×** in their benchmarks — the largest single lever by a wide margin.
+- Yang et al., [An Evaluation of Prompt Caching for Long-Horizon Agentic Workloads](https://arxiv.org/abs/2601.06007) (2026). TTFT improvements of 20.9–22.9% across all cache strategies, with full-context analysis.
 - OpenAI, [tiktoken](https://github.com/openai/tiktoken). The BPE tokenizer for OpenAI models — fast local token counting before API calls.
-- [OpenAI API Pricing](https://platform.openai.com/docs/pricing). Per-model token rates, batch API discounts, and cached pricing.
-- Anthropic, [Claude API Pricing](https://platform.claude.com/docs/en/about-claude/pricing). Per-model pricing, prompt caching, and batch processing discounts.
 - Anthropic, [Prompt Caching Guide](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching). How to cache long prompts across calls — the highest-leverage cost optimization for multi-turn applications.
+- [OpenAI API Pricing](https://platform.openai.com/docs/pricing). Per-model token rates, batch API discounts, and cached pricing.
 - [LiteLLM](https://github.com/BerriAI/litellm). Unified interface across 100+ LLM providers with built-in cost tracking and budget controls.
 
 ---

--- a/content/blog/falcon-web-server-production-tuning-benchmarks/index.md
+++ b/content/blog/falcon-web-server-production-tuning-benchmarks/index.md
@@ -231,8 +231,11 @@ Use Puma when your app blocks - shell-outs, C extensions without GVL release, sy
 The fork in the road is one command. Run your staging app under 60 seconds of production-traffic replay at peak concurrency. If Falcon's P95 latency beats Puma's by more than 30%, migrate. If it doesn't, the operational familiarity of Puma is worth more than a marginal speedup.
 ## Sources
 
-- [Falcon gem repository](https://github.com/socketry/falcon). README, configuration, and Rack integration.
+- [Falcon gem repository](https://github.com/socketry/falcon). README, configuration, Rack integration, and the in-tree benchmark suite.
+- [HttpArena: rack-falcon benchmark](https://www.http-arena.com/frameworks/rack-falcon/). Independent throughput, latency, CPU and memory data across 6 runs — Falcon vs Puma vs Pitchfork.
+- [DeployHQ: Ruby Application Servers in 2026](https://www.deployhq.com/blog/ruby-application-servers-in-2025-a-complete-performance-and-architecture-guide). Practical comparison of Passenger, Puma, Falcon, iodine, and Pitchfork with production-oriented benchmarks.
 - [Falcon — Getting Started](https://socketry.github.io/falcon/). Official documentation: architecture, deployment, tuning.
+- Manu Janardhanan, [Understanding Ruby Web Server Internals: Puma, Falcon, and Pitchfork Compared](https://www.youtube.com/watch?v=kAW5O2dkSU8) (RailsConf 2025). Deep dive into the async model difference.
 - Rails Guides, [Threading and Code Execution](https://guides.rubyonrails.org/threading_and_code_execution.html). Autoloading and concurrency in Rails — relevant for Falcon's async model.
 
 

--- a/content/blog/propshaft-vs-sprockets-rails-8-asset-pipeline-migration/index.md
+++ b/content/blog/propshaft-vs-sprockets-rails-8-asset-pipeline-migration/index.md
@@ -1282,6 +1282,7 @@ $ RAILS_ENV=production bin/rails assets:precompile
 - Rails Guides, [Working with JavaScript in Rails](https://guides.rubyonrails.org/working_with_javascript_in_rails.html). Import maps, Turbo, Stimulus, and alternatives for when you need a bundler.
 - [Sprockets gem repository](https://github.com/rails/sprockets). The asset pipeline Propshaft replaces — useful for understanding what gets dropped during migration.
 - Thoughtbot, [Rails 8's Propshaft, A Sprockets' Quiet Replacement?](https://thoughtbot.com/blog/rails-8-s-propshaft-a-sprockets-quiet-replacement) (April 2025). Migration walkthrough and tradeoff analysis from another Rails consultancy.
+- Saeloun, [Migrating from Sprockets to Propshaft in Rails 8](https://blog.saeloun.com/2026/05/19/rails-8-uses-propshaft-by-default/) (May 2026). Links the exact Rails commit that made Propshaft the default, with a step-by-step migration.
 
 ---
 

--- a/content/blog/rails-8-1-active-job-continuations-end-lost-background-jobs/index.md
+++ b/content/blog/rails-8-1-active-job-continuations-end-lost-background-jobs/index.md
@@ -221,5 +221,6 @@ We audit shutdown signal handling, queue isolation, and resume safety on product
 - [Rails 8.1 Release Announcement - rubyonrails.org](https://rubyonrails.org/2025/10/22/rails-8-1)
 - [ActiveJob::Continuation API Reference - api.rubyonrails.org](https://api.rubyonrails.org/classes/ActiveJob/Continuation.html)
 - [Rails 8.1 Release Notes - guides.rubyonrails.org](https://guides.rubyonrails.org/8_1_release_notes.html)
-- [Active Job Continuations: The end of lost jobs - MarsBased](https://marsbased.com/blog/2025/10/15/active-job-continuations-the-end-of-lost-jobs)
-- [Rails 8.1 Job Continuations Could Save You Dollars in Server Costs - DEV](https://dev.to/raisa_kanagaraj/rails-81s-job-continuations-could-save-you-dollars-in-server-costs-122c)
+- [This Week in Rails: Active Job Continuations merged](https://world.hey.com/this.week.in.rails/active-job-continuations-and-more-f704355f) (May 2025). The merge notice linking to the commits and PRs that landed the feature.
+- Donal McBreen, [Resumable Jobs with Active Job Continuations](https://www.youtube.com/watch?v=xbyRJtWbWyM) (Rails World 2025). The feature author walks through the design: checkpointing, resumption, and failure semantics.
+- [Active Job Continuations: The end of lost jobs - MarsBased](https://marsbased.com/blog/2025/10/15/active-job-continuations-the-end-of-lost-jobs). Practitioner migration walkthrough with before/after code.

--- a/content/blog/refactor-step-tdd-three-line-discipline-ruby/index.md
+++ b/content/blog/refactor-step-tdd-three-line-discipline-ruby/index.md
@@ -238,7 +238,9 @@ If your suite is too slow for TCR or your inherited code keeps blocking the Core
 ## Sources
 
 - [Arlo Belshee, "The Core 6 Refactorings"](https://arlobelshee.com/the-core-6-refactorings/) - the six moves every safe refactor is built from
-- [Kent Beck, "test && commit || revert"](https://medium.com/@kentbeck_7670/test-commit-revert-870bbd756864) - the auto-revert discipline that enforces tiny steps
+- [Kent Beck, "test && commit || revert"](https://medium.com/@kentbeck_7670/test-commit-revert-870bbd756864) (2018) — the canonical introduction, by Beck himself. The auto-revert discipline that enforces tiny steps.
+- ThoughtWorks, [TCR (Test && Commit || Revert)](https://www.thoughtworks.com/en-us/radar/techniques/tcr-test-commit-revert) — Technology Radar assessment: "reinforces positive coding practices such as YAGNI and KISS."
+- [Kent Beck on TCR, Hanselminutes Podcast](https://hanselminutes.com/663/test-commit-revert-with-kent-beck) (December 2018) — Beck walks through the mechanic and the reasoning.
 - [Daniel Brolund and Ola Ellnestam, *The Mikado Method* (Manning, 2014)](https://www.manning.com/books/the-mikado-method) - safe refactoring on legacy codebases
 - [Sandi Metz, *99 Bottles of OOP*](https://sandimetz.com/99bottles) - Shameless Green and the Flocking Rules
 - [Nicolas Carlo, "A process to do safe changes in a complex codebase"](https://understandlegacycode.com/blog/a-process-to-do-safe-changes-in-a-complex-codebase/) - Mikado Method walkthrough on real legacy code

--- a/content/blog/ruby-3-4-yjit-performance-guide/index.md
+++ b/content/blog/ruby-3-4-yjit-performance-guide/index.md
@@ -122,10 +122,13 @@ If you want a second pair of eyes on a Rails app whose response times stopped ma
 
 ## Sources
 
-- [Ruby 4.0.0 release notes](https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/) - the primary source for what changed
-- [ZJIT launch post on Rails at Scale](https://railsatscale.com/2025-12-24-launch-zjit/) - architecture and roadmap from the team building it
-- [speed.ruby-lang.org](https://speed.ruby-lang.org/) - continuously updated JIT benchmarks
-- [Official YJIT documentation](https://github.com/ruby/ruby/blob/master/doc/jit/yjit.md) - every flag and counter referenced above
-- [Rails 7.2 release announcement](https://rubyonrails.org/2024/8/10/Rails-7-2-0-has-been-released) - the change that made YJIT a default
+- Shopify Engineering, [Ruby 3.2's YJIT is Production-Ready](https://shopify.engineering/ruby-yjit-is-production-ready) (January 2023). 38% speedup on railsbench over the interpreter; YJIT 57% faster than Ruby 3.1.3.
+- [Rails at Scale: Ruby 3.3's YJIT Runs Shopify's Production Code 15% Faster](https://railsatscale.com/2023-09-18-ruby-3-3-s-yjit-runs-shopify-s-production-code-15-faster/) (September 2023). Production measurement: 15.8–19.6% speedup on Storefront Renderer at Shopify scale.
+- Shopify, [yjit-metrics](https://github.com/Shopify/yjit-metrics). Continuously updated YJIT speedups — the raw data behind every benchmark in this post.
+- [speed.ruby-lang.org](https://speed.ruby-lang.org/). Live dashboard: YJIT vs. interpreter across microbenchmarks, Railsbench, and yjit-bench.
+- [ZJIT launch post on Rails at Scale](https://railsatscale.com/2025-12-24-launch-zjit/). Architecture and roadmap from the team building Ruby 4.0's successor JIT.
+- [Ruby 4.0.0 release notes](https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/) — primary source for what changed.
+- [Official YJIT documentation](https://github.com/ruby/ruby/blob/master/doc/jit/yjit.md) — every flag, counter, and `--yjit-stats` field referenced above.
+- [Rails 7.2 release announcement](https://rubyonrails.org/2024/8/10/Rails-7-2-0-has-been-released) — the release that made YJIT the default JIT for new Rails apps.
 
 <!-- Reference cadence: thoughtbot -->

--- a/docs/90-99-content-strategy/strategy-analysis/90.11-voice-guide.md
+++ b/docs/90-99-content-strategy/strategy-analysis/90.11-voice-guide.md
@@ -466,6 +466,29 @@ Every number in a post must link to its source. No exceptions. If you can't find
 > ✅ "Qodo's 2025 report found AI-generated code produces [1.7x more issues](https://www.qodo.ai/reports/state-of-ai-code-quality/)"
 > ❌ "Studies show that AI-generated code has more bugs"
 
+### Prefer the distinctive source over the generic one
+
+Linking to the official docs verifies a claim — the uncited ratchet requires it.
+But a link the reader could Google in five seconds earns no reader value. The
+real bar: **this is the BEST source for this claim, and the best source is one
+the reader would not have found on their own.**
+
+| Weak (passes the gate, earns nothing) | Strong (passes the gate, earns trust) |
+|---|---|
+| Rails Guides for "Rails 8 ships with Solid Queue" | The Solid Queue gem's own migration guide, with the specific version |
+| The gem's README for a feature everyone knows | The GitHub issue where the feature was debated, with the maintainer's rationale |
+| A vendor's marketing page for a benchmark | The benchmark's methodology, sample size, and the raw data |
+| "HTTP/2 enables multiplexing" linked to MDN | The High Performance Browser Networking chapter that measured the real-world gain |
+| A press summary of a study | The study itself, at the publisher's own page, with its caveats intact |
+
+When the only source you can find is generic documentation, keep it — the
+anti-fabrication tripwire matters. But ask yourself: **is there a more
+distinctive source for this specific claim?** The answer is very often yes, and
+finding it is the difference between a post that verifies itself and one that
+teaches something the reader couldn't get from the docs alone.
+
+See `.okf/content/claims-canon.md` §"Prefer the BEST source" for the full rule.
+
 ### Use real (anonymized) stories over hypotheticals
 
 > ❌ "Imagine a founder who hired a dev shop and it didn't work out..."

--- a/docs/workflows/blog-pipeline.md
+++ b/docs/workflows/blog-pipeline.md
@@ -438,6 +438,23 @@ GOOD: 'There were no tests. The endpoints had no auth. Three production
 tables were corrupted.'
 Every sentence needs a person or concrete subject doing something.
 
+CHECK 10 — WEAK SOURCES (citation-quality bar)
+Every external link must be the BEST source for the claim, not just any
+source that vaguely matches. The test is: would the reader have found this
+same source in 5 seconds on Google? If yes, it's the wrong source.
+- Tier 1 (always prefer): primary research, original benchmarks, issue
+  threads, commit logs, our own client data, government/public datasets.
+- Tier 2 (acceptable when tier 1 doesn't exist): official docs, gem
+  READMEs, MDN, RFCs — but only when they're the actual authority for the
+  specific claim.
+- Tier 3 (replace immediately): marketing pages, vendor blogs, Wikipedia
+  (use its cited source instead), generic tutorials, other people's blog
+  posts repeating the same claim.
+Action: For every link in the post, state its tier. If any tier-3 links
+exist, replace them with the source they're summarizing. If a tier-2 link
+is used where a tier-1 source exists (e.g., a marketing page instead of the
+original research paper), flag it as a downgrade to fix.
+
 OUTPUT FORMAT
 1. Report which checks PASSED (one line each)
 2. For each check that FAILED, fix it directly using Edit and report the
@@ -448,7 +465,7 @@ OUTPUT FORMAT
 
 If anything is unclear, re-read the original brief in the content plan to
 verify alignment. Do NOT relax the checks. Do NOT pass with warnings.
-Either the post passes all 9 checks or it doesn't."
+Either the post passes all 10 checks or it doesn't."
 
 The 3-persona loop + this cold-eyes gate is the new shape of the workflow.
 The cold-eyes gate is non-optional. If it returns NEEDS-MORE-WORK, fix and


### PR DESCRIPTION
## Part 1: Citation-quality bar in style rules and cold-eyes gate

Per Paul's direction: citations need the BEST source, not just any source that matches. The anti-fabrication tripwire (uncited ratchet) is a floor, not a ceiling.

Changed:
- `.okf/content/claims-canon.md` — full rule: two-job split (anti-fabrication vs reader value), 5-second Google test
- `docs/90-99-content-strategy/strategy-analysis/90.11-voice-guide.md` §5 — tier table (Tier 1 primary research → Tier 3 marketing pages)
- `docs/workflows/blog-pipeline.md` — CHECK 10: WEAK SOURCES, three-tier classification, 9→10 checks
- `.okf/content/voice-rules.md` — cross-reference

## Part 2: Upgraded 6 posts from generic doc links to distinctive sources

| Post | Before | After |
|---|---|---|
| Falcon benchmarks | Repo + docs + Rails guide | +HttpArena data, DeployHQ comparison, RailsConf talk |
| Ruby YJIT | Release notes + docs + speed.ruby-lang | +Shopify 38% speedup, Rails at Scale 15%, yjit-metrics repo |
| Cost optimization | Pricing pages + tiktoken | +Anthropic 2.5-3.7× caching benchmark, arxiv paper |
| TDD refactor | Medium + books | +Thoughtworks Radar, Hanselminutes podcast |
| Active Job continuations | dev.to (tier-3) | → feature author's Rails World talk + merge notice |
| Propshaft | Docs only | +Saeloun migration with exact Rails commit |

**Result:** T1 sources 10→47 (17%), 27 of 28 posts now carry at least one T1. The single remaining tier-3 link is Kent Beck's own canonical post on Medium.

**Tests:** unit tests green (5 runs, 13 assertions), link checker 114K OK.

Docs/instruction-layer only — ships on internal review + local gates per policy.