### PR TITLE
Shorten comments from snap_diff 2.0 PR

### DIFF
--- a/.dev/compose.yml
+++ b/.dev/compose.yml
@@ -2,8 +2,7 @@
 # Simplified Docker Compose configuration for JetThoughts Hugo development
 # Optimized for fast feedback loops with minimal complexity
 #
-# Host docker = colima (not Docker Desktop). Gotcha: credsStore: osxkeychain
-# needs `brew install docker-credential-helper` (colima ships no osxkeychain helper).
+# Host docker = colima; install docker-credential-helper for credsStore: osxkeychain.
 
 services:
   hugo:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
           HUGO_DEFAULT_PATH: _dest/public-test
           # Record mode intentionally dirties the fixtures as it runs.
           ALLOW_DIRTY_SCREENSHOTS: '1'
-          # record=:all refuses under CI; this dispatch is the reviewed bulk accept.
+          # record=:all refuses under CI; this dispatch is the manual review.
           CI: ''
 
       # always(): freshly recorded baselines must be committed even when a

--- a/.okf/build/test-gates.md
+++ b/.okf/build/test-gates.md
@@ -185,7 +185,7 @@ never exceeds the viewport height (e.g. `[0.0,42.0,1920.0,1080.0]` for
 `services/_footer`).
 
 There is a second tolerance-independent axis: `SnapDiff.config.perceptual_threshold = 2.0`
-(`test/support/setup_snap_diff.rb:25`) means the vips driver only counts a
+(`test/support/setup_snap_diff.rb:15`) means the vips driver only counts a
 pixel as differing once it is more than CIE dE00 2.0 from the baseline pixel.
 A recolour that stays under that contributes ZERO differing pixels, so it
 passes at ANY tolerance including 0 - most relevant to palette and
@@ -299,7 +299,7 @@ Minitest under `test/`, driven by `Rakefile` (`Rake::TestTask`).
 
   **The two readers disagree on what counts as set** (identified 2026-08-21,
   NOT fixed - known wart): `bin/qtest:209` skips its restore on ANY truthy
-  value, while `test/support/setup_snap_diff.rb:33` enters record mode only
+  value, while `test/support/setup_snap_diff.rb:21` enters record mode only
   on the literal string `"true"`. So `FORCE_SCREENSHOT_UPDATE=1` on qtest
   gets the worst of both - the suite still compares and fails, and the
   restore that would have cleaned up is skipped. Spell it `=true`, or better,

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -845,7 +845,7 @@ screenshots are dirty is worse than no test. The guard was verified by mutation
 `String#split.last` is nil only for `""`, where the fallback is nil too.
 
 **A third blind spot, tolerance-independent like the fold:**
-`perceptual_threshold = 2.0` (`test/support/setup_snap_diff.rb:25`) means vips
+`perceptual_threshold = 2.0` (`test/support/setup_snap_diff.rb:15`) means vips
 only counts a pixel as differing above CIE dE00 2.0 from the baseline. A
 recolour staying under that contributes ZERO differing pixels and passes at ANY
 tolerance including 0 - which is precisely the palette/dark-surface work this
@@ -872,7 +872,7 @@ Concept updated: [build/test-gates.md](build/test-gates.md).
 
 **Known wart, identified and NOT fixed:** the two `FORCE_SCREENSHOT_UPDATE`
 readers disagree on what counts as set - `bin/qtest:209` skips its restore on
-any truthy value, `test/support/setup_snap_diff.rb:33` enters record mode only
+any truthy value, `test/support/setup_snap_diff.rb:21` enters record mode only
 on the literal `"true"`. `=1` on qtest therefore gets the worst of both: the
 suite still compares and fails, and the cleanup is skipped. That is the
 mechanism behind the older "the flag appears to be ignored on qtest" note.

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem "ostruct"
 
 gem "sanity-ruby"
 
-# Same gem as capybara-screenshot-diff; install one, never both.
 gem "snap_diff-capybara", "2.0.0.beta4"
 gem "simplecov", require: false
 gem "vips"

--- a/test/support/setup_snap_diff.rb
+++ b/test/support/setup_snap_diff.rb
@@ -1,19 +1,9 @@
-# Screenshot Testing Configuration
-#
-# Environment Variables:
-# - SCREENSHOT_STABILITY_TIME: Override stability wait time (default: 0.1s)
-# - FORCE_SCREENSHOT_UPDATE: Set to 'true' to regenerate all baselines
-#
-
 require "snap_diff/integrations/minitest"
 require "snap_diff/reporters/html"
 
 SnapDiff.config.save_path = "test/fixtures/screenshots"
 
-# The HTML reporter only writes when a run HAS failures, so a green run would
-# otherwise leave the previous red run's report on disk - reviewing it shows
-# diffs that no longer exist. Drop it up front; every entry point (bin/test,
-# bin/qtest, bin/dtest, rake test:*) loads this file.
+# Green runs leave the prior red report; drop it up front.
 File.delete("test/fixtures/screenshots/snap_diff_report.html") if File.exist?("test/fixtures/screenshots/snap_diff_report.html")
 SnapDiff.config.add_os_path = true
 SnapDiff.config.window_size = nil
@@ -21,16 +11,14 @@ SnapDiff.config.stability_time_limit = ENV.fetch("SCREENSHOT_STABILITY_TIME", "0
 SnapDiff.config.disable_animations = true
 SnapDiff.config.root = Dir.pwd
 
-# No driver line: 2.1 removes the knob; :auto resolves to vips.
+# Driver knob removed in 2.1; :auto = vips.
 SnapDiff.config.perceptual_threshold = 2.0
 SnapDiff.config.delayed = true
 
-# Missing baselines must FAIL: record = :none (2.0 spelling of fail_if_new =
-# true). Anything that breaks git would otherwise pass green silently
-# (measured 2026-08-22, git worktree - see .okf/build/test-gates.md).
+# Missing baselines fail; a broken git once passed silently (.okf/build/test-gates.md).
 SnapDiff.config.record = :none
 
 if ENV["FORCE_SCREENSHOT_UPDATE"] == "true"
-  # Bulk re-record; gem refuses :all under CI - test.yml unsets it for this step.
+  # Bulk re-record; gem refuses :all under CI (test.yml unsets it).
   SnapDiff.config.record = :all
 end


### PR DESCRIPTION
Comments trimmed to one-liners; .okf line refs re-synced (15/21). Docs-only, no CI wait.