### PR TITLE
Track the two untracked working-paper trees

### DIFF
--- a/data/skills/lighthouse-verification
+++ b/data/skills/lighthouse-verification
@@ -1,0 +1,1 @@
+../../.agents/skills/lighthouse-verification

--- a/docs/projects/2609-sales-collateral/README.md
+++ b/docs/projects/2609-sales-collateral/README.md
@@ -1,0 +1,48 @@
+# Sales & website collateral — working papers
+
+JetThoughts marketing collateral imported from Google Drive (2026-07-30) and relocated
+here from the PKM vault on 2026-08-26. These are channel working papers — the vault owns
+the decisions (`jt-business-os`, `jt-website-redesign`); this folder owns the documents.
+
+The decisions and bet status live in the vault (`~/Documents/pkm`). This repo is growth /
+marketing campaigns only; do not create a parallel portfolio here.
+
+## Before you reuse any of this: it predates the current claims canon
+
+**24 of the 43 files here sell a fractional CTO, fractional CPO, tech-lead or
+engineering-manager engagement.** `.okf/content/claims-canon.md` has banned those
+title claims on any new or v2 surface since 2026-08-21, and the basis is factual
+rather than stylistic: Paul was the lead tech at Crosslake, a PM opened the
+engagement, and leadership was promoted from inside the team, so a title claim
+misstates what happened. Treat it as the same class as a fabricated testimonial.
+
+These files are kept as an **imported historical record**, not as approved copy.
+They were written before that decision. Nothing here is a source of truth for
+what JetThoughts sells today - the canon is, and it says: an embedded team of
+senior self-managed full-stack developers.
+
+**If you lift anything from this folder into a live surface, strip the title
+claims first.** This is the documented way the bad canon comes back: outreach
+kits, `PRODUCT.md` and `docs/business/` have each re-introduced it before, and
+four of eight published figures were wrong on 2026-08-14 for the same reason.
+
+Two further cautions. This repository is **public**, and these documents name
+eight clients (Agent Inbox, CampSyte, Corsi, Credit Glory, LimeLeads, Mobile
+Coach, OpenApply, OrchestrateCS) - confirm each is cleared to be named before
+reusing a case study outward. And the case studies have not been through the
+fabrication sweep that purged invented client stories from 14 blog posts; verify
+every number against an artifact before it goes anywhere near a live page.
+
+| File group | What it is |
+|---|---|
+| `drafts-draft-*-service-overview.md` | Full service overviews (testing, staffing, recruiting, MVP, fractional CTO/CPO, custom dev) |
+| `editable-versions-*-service-2-pager.md` | One-page condensed versions of the same services |
+| `drafts-draft-*-getting-started*.md` / `editable-versions-*-getting-started.md` | Getting-started / onboarding / scoping / free-trial guides |
+| `*-case-study.md` | Client case studies (Agent Inbox, CampSyte, Corsi, Credit Glory, LimeLeads, Mobile Coach, OpenApply, OrchestrateCS) in two formats |
+| `templates-template-*.md` / `templates-jetthoughts-*.md` | Reusable proposal / pricing / services / case-study templates |
+
+The three stale strategy plans (Q1-23, Q4, game plan) were archived in the vault, not moved.
+
+Originals (with images) live in Google Drive `Documents/2. Resource/Marketing & Brand/`.
+The `media/` image references in the imported Markdown were dead (no `media/` dir was
+imported) and were stripped on relocation.

--- a/docs/projects/2609-sales-collateral/drafts-draft-agent-inbox-case-study.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-agent-inbox-case-study.md
@@ -1,0 +1,87 @@
+# Draft - Agent Inbox Case Study
+
+This outline was created based on my review of [this case study page](https://www.jetthoughts.com/agentinbox.html) on the website.
+
+1.  **Tease Header Statement**
+
+2.  **Technologies** (What tech stack / codebase?)
+
+3.  **Client Overview** (What they are / what they do / what industry)
+
+4.  **Vision** (What were their goals / needs / ideal outcomes?)
+
+5.  **Problem** (What blocked / disrupted / cost them?)
+
+6.  **Solution** (What's the summary of how JetThoughts helped?)
+
+7.  **Approach / Milestones** (Specific Pieces / Achievements of the Project)
+
+8.  **Outcome** (How did the story end? Stats on Team, Timeline, Outcomes, etc.)
+
+9.  **Quotes / Testimonials** (What did the client have to say about their experience?)
+
+**(1) See How JetThoughts Helped Agent Inbox Go From Idea to Software in 60 Days**
+
+**(2)** Ruby on Rails, JQuery, AngularJS, React Native, CSS3, Mongo DB
+
+**(3) Client Overview**
+
+Agent Inbox is an industry-leading real estate messaging platform that leverages Multiple Listing Services (MLS) data to help centralize & streamline deal-making for realtors.
+
+They initially reached out to JetThoughts to make their product idea a reality and help build the right internal development team for long-term success.
+
+**(4) Vision**
+
+Agent Inbox envisioned an idea to create a competitive software product to disrupt real estate communication.
+
+To attract investors and customers as quickly as possible, Agent Inbox desired to develop a Minimal Viable Product (MVP) that could be used as a foundation for additional development.
+
+**(5) Problem**
+
+Agent Inbox initially tried to develop their product internally, but ran into obstacles with the project's complexity.
+
+After a full year attempting to develop the product internally, Agent Inbox struggled to deliver a market-ready solution and realized the platform would need to be rebuilt from scratch.
+
+With limited resources & technical expertise available, it became apparent that their current internal development team wouldn't be able to realistically deliver the right outcome on time.
+
+**(6) Solution**
+
+JetThoughts provided a fractional CTO resource to help guide the project and 5 full-time engineers to act as a virtual development team for Agent Inbox.
+
+In addition, we provided a dedicated project advisor to bring real-time visibility into progress and ensure alignment with the leadership team at Agent Inbox.
+
+**(7) Approach**
+
+From the very beginning of the engagement, JetThoughts provided Agent Inbox's team with deep technical guidance based on decades of experience to help ensure a successful outcome.
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software idea, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Agent Inbox to monitor budget & maximize the value delivered by our team.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that Agent Inbox faced.
+
+**(8) Outcome**
+
+- From Zero to MVP in 60 Days
+
+- Grew to Support 100,000+ Users in Year 1
+
+- Scaled Internal Team from 1 to 6 Developers
+
+**(9) Quotes / Testimonials**
+
+"They are very accurate with their projections and estimates, even though we've always iterated on the idea due to feedback and the constantly changing nature of a startup."
+
+"As Agent Inbox grew, JetThoughts was able to scale up really quickly, has been super flexible with changing products, changing demands with us internally, and has been able to integrate very successfully with our engineering teams."
+
+"We believe we\'re leading the messaging revolution as it relates to our industry and JetThoughts helped us build it.\"
+
+"The team cleaned up our code, organized our workflows, enhanced our app, etc. They also handled product development, QA testing, staging, and live production. It was easy and satisfying to work with them."
+
+"Over the years as we worked with them, the team directly contacted and collaborated with the Agent Inbox team to build a solution that suits the business needs."
+
+"With their help, we were able to quickly scale up into our market and land new clients... They also helped us raise millions of dollars in funding over multiple rounds for the project."
+
+"JetThoughts is definitely a good partner. We do not see them as a contractor or outsourcing. We wouldn\'t be where we were without the effort they put into our business."
+
+"They put a lot of importance on understanding our business on a granular level and they were deeply embedded in our culture and our successes."

--- a/docs/projects/2609-sales-collateral/drafts-draft-campsyte-case-study.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-campsyte-case-study.md
@@ -1,0 +1,85 @@
+# Draft - Campsyte Case Study
+
+This outline was created based on my review of [this case study page](https://www.jetthoughts.com/agentinbox.html) on the website.
+
+1.  **Tease Header Statement**
+
+2.  **Technologies** (What tech stack / codebase?)
+
+3.  **Client Overview** (What they are / what they do / what industry)
+
+4.  **Vision** (What were their goals / needs / ideal outcomes?)
+
+5.  **Problem** (What blocked / disrupted / cost them?)
+
+6.  **Solution** (What's the summary of how JetThoughts helped?)
+
+7.  **Approach / Milestones** (Specific Pieces / Achievements of the Project)
+
+8.  **Outcome** (How did the story end? Stats on Team, Timeline, Outcomes, etc.)
+
+9.  **meQuotes / Testimonials** (What did the client have to say about their experience?)
+
+**(1) See How JetThoughts Helped Campsyte Salvage a Stalled Software Project & Go From Zero to Revenue with a Competitive Product**
+
+**(2)** Ruby on Rails, Stripe
+
+**(3) Client Overview**
+
+Campsyte is a startup building a mobile application to help users find, book and access unique outdoor space for social experiences.
+
+They initially reached out to JetThoughts to help salvage their software project and make their product idea a reality.
+
+**(4) Vision**
+
+Campsyte envisioned replacing their current development resource with a top-caliber engineering partner to recover their software project & launch a compelling product.
+
+In addition, Campsyte desired a partner that could understand the product's architecture and optimize the quality of their final software.
+
+**(5) Problem**
+
+Campsyte had initially tried to develop the product with a different engineering team, but it was ultimately unsuccessful and the team was unable to complete the project.
+
+Due to a lack of technical expertise & product leadership, Campsyte's project stalled out and became stuck with no usable product and no clear idea about how to build it.
+
+Meanwhile, Campsyte had no choice but to lose time, burn valuable runway, and delay both their product launch and their path to revenue.
+
+**(6) Solution**
+
+JetThoughts provided a full-time senior-level CTO & architect to help guide the project and act as a virtual extension of Campsyte's development team.
+
+In addition, we provided a dedicated project advisor to bring real-time visibility into progress and ensure alignment with the leadership team at Campsyte..
+
+**(7) Approach**
+
+From the very beginning of the engagement, JetThoughts provided Campsyte's team with deep technical guidance based on decades of experience to help ensure a successful outcome.
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Campsyte to monitor budget & maximize the value delivered by JetThoughts.
+
+Throughout the entirety of the engagement, we kept the team composition & functions flexible to the specific needs and circumstances that Campsyte faced.
+
+**(8) Outcome**
+
+- Salvaged a stalled & incomplete project
+
+- Exceeded timeline expectations for the product launch
+
+- Optimized development & product management processes
+
+**(9) Quotes / Testimonials**
+
+"I wouldn\'t have chosen a different vendor, nor will I do so in the future."
+
+"Before working with them, we had a team that wasn't successful at getting the product out. Paul and his team took over that stalled-out project and made it a reality when we thought we were stuck on a dead page."
+
+"We got a product that real-time users began to use, however, we didn't expect a launch so soon. It allowed us to attract more real-time users and evaluate the success of our startup."
+
+"The team is highly professional and wonderful to work with. Their attention to detail gave me confidence in their experience. They produced a flawlessly functional deliverable and excel at communication, rapidly resolving internal challenges."
+
+"Our cooperation was fully transparent and visible. We not only set expectations for what should be done but also saw the result from the first week. Every week we had a better version that made us understand where to go next."
+
+"They also have a high level of communication and keep the project plan on schedule. I always feel comfortable texting the owner - Paul, who personally responds within 5-10 minutes."
+
+"A good developer who didn't have to be checked and tested. Communication was simple and enjoyable. We have learned a lot about working with companies remotely. There were no problems with the timezone at all."

--- a/docs/projects/2609-sales-collateral/drafts-draft-corsis-case-study.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-corsis-case-study.md
@@ -1,0 +1,79 @@
+# Draft - Corsis Case Study
+
+This outline was created based on my review of [this case study page](https://www.jetthoughts.com/agentinbox.html) on the website.
+
+1.  **Tease Header Statement**
+
+2.  **Technologies** (What tech stack / codebase?)
+
+3.  **Client Overview** (What they are / what they do / what industry)
+
+4.  **Vision** (What were their goals / needs / ideal outcomes?)
+
+5.  **Problem** (What blocked / disrupted / cost them?)
+
+6.  **Solution** (What's the summary of how JetThoughts helped?)
+
+7.  **Approach / Milestones** (Specific Pieces / Achievements of the Project)
+
+8.  **Outcome** (How did the story end? Stats on Team, Timeline, Outcomes, etc.)
+
+9.  **Quotes / Testimonials** (What did the client have to say about their experience?)
+
+**(1) See How JetThoughts Helped Corsis Transform a Legacy Software Project & Gain Control Over a Complex Codebase**
+
+**(2)** Ruby on Rails, GraphQL, React, R, Hotwire, Bootstrap, AngularJS
+
+**(3) Client Overview**
+
+Corsis is a technology advisory services firm that include consultant-led, self-administered evaluations of a company's adherence to industry best practices.
+
+They initially reached out to JetThoughts to take over responsibility for ongoing architecture and development for a proprietary software in need of a technical owner.
+
+**(4) Vision**
+
+Corsis envisioned a transformation of their software project from a complex legacy codebase in need of improvements to a high-quality product that's easier to support.
+
+In addition, Corsis knew they were in need of more experienced technical resources and desired to evolve their internal development processes to meet industry best practices.
+
+**(5) Problem**
+
+After the original developer of this software moved on, Corsis had to assign new development resources to replace the creator and continue the project without any considerable disruptions.
+
+With little documentation for a legacy codebase with many redundancies, Corsis quickly realized that the junior developers they assigned to the project weren't equipped to handle the situation.
+
+In addition, the codebase's complexity combined with the "bus factor" of lost knowledge made the maintenance and development processes very time-consuming.
+
+**(6) Solution**
+
+JetThoughts provided a full-time senior-level CTO & architect to help guide the project and act as a virtual extension of Corsis' development team.
+
+In addition, we provided a dedicated project advisor to bring real-time visibility into progress and ensure alignment with the leadership team at Corsis.
+
+**(7) Approach**
+
+From the very beginning of the engagement, JetThoughts provided Corsis' team with deep technical guidance based on decades of experience to help ensure a successful outcome.
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Corsis to monitor budget & maximize the value delivered by JetThoughts.
+
+Throughout the entirety of the engagement, we kept the team composition & functions flexible to the specific needs and circumstances that Corsis faced.
+
+**(8) Outcome**
+
+- Refactored a legacy codebase based on best practices
+
+- Maximized code visibility & test coverage
+
+- Optimized application speed, performance, & efficiency
+
+**(9) Quotes / Testimonials**
+
+"Paul is passionate about what he does, and truly has his client\'s best interests in mind."
+
+"Paul brings a wealth of architecture and development experience to our project. He is a strong believer in doing things the right way - which may not always be the fastest way in the short run, but which ultimately saves time and money through less technical debt and improved code scalability."
+
+"Paul does not simply complete tasks. He seeks to understand the purpose behind the activity that we may task him with and actively engages in appropriate discussion to ensure that our approach is sound and that all considerations are adequately vetted."
+
+"Paul is working +7 hours from our local time, but has done a good job of making himself available when needed during our normal business hours"

--- a/docs/projects/2609-sales-collateral/drafts-draft-credit-glory-case-study.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-credit-glory-case-study.md
@@ -1,0 +1,83 @@
+# Draft - Credit Glory Case Study
+
+This outline was created based on my review of [this case study page](https://www.jetthoughts.com/agentinbox.html) on the website.
+
+1.  **Tease Header Statement**
+
+2.  **Technologies** (What tech stack / codebase?)
+
+3.  **Client Overview** (What they are / what they do / what industry)
+
+4.  **Vision** (What were their goals / needs / ideal outcomes?)
+
+5.  **Problem** (What blocked / disrupted / cost them?)
+
+6.  **Solution** (What's the summary of how JetThoughts helped?)
+
+7.  **Approach / Milestones** (Specific Pieces / Achievements of the Project)
+
+8.  **Outcome** (How did the story end? Stats on Team, Timeline, Outcomes, etc.)
+
+9.  **Quotes / Testimonials** (What did the client have to say about their experience?)
+
+**(1) See How JetThoughts Helped Credit Glory Accelerate Feature Development & Scale Their Development Operations**
+
+**(2)** Ruby on Rails, React, GraphQL
+
+**(3) Client Overview**
+
+Credit Glory is a consumer financial services company that provides credit repair services to help customers fix their credit and improve their financial situation.
+
+They initially reached out to JetThoughts to help scale up their development team's capacity so they could develop features faster while maintaining best practices and code quality.
+
+**(4) Vision**
+
+Credit Glory envisioned scaling their development efforts while maintaining quality so they could outcompete in the marketplace and keep pace with the growth of their customer base.
+
+Their goals for the collaboration with JetThoughts was to improve the technical capabilities of their engineering team while achieving better quality, more stability, and faster development.
+
+**(5) Problem**
+
+While Credit Glory's software provided a good user experience, they decided it was time to upgrade their existing front-end and migrate over to a better tech stack.
+
+Unfortunately, much of their codebase was incredibly complex and driven by the intimate business knowledge that the leadership possessed about their industry. In addition, their user experience & functionality relied heavily on specific integrations with key technology partners.
+
+In order to make the changes they wanted, Credit Glory knew they would need a partner with both deep technical expertise and experience collaborating with business leadership.
+
+**(6) Solution**
+
+JetThoughts provided a fractional CTO resource to help guide the project and 2 full-time senior-level engineers to act as a virtual extension of Credit Glory's development team.
+
+In addition, we provided a dedicated project advisor to bring real-time visibility into progress and ensure alignment with the leadership team at Credit Glory.
+
+**(7) Approach**
+
+From the very beginning of the engagement, JetThoughts provided Credit Glory's team with deep technical guidance based on decades of experience to help ensure a successful outcome.
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Credit Glory to monitor budget & maximize the value delivered by JetThoughts.
+
+Throughout the entirety of the engagement, we kept the team composition & functions flexible to the specific needs and circumstances that Credit Glory faced.
+
+**(8) Outcome**
+
+- Upgraded codebase quality & performance
+
+- Increased test coverage & eliminated bugs
+
+- Optimized third-party integrations
+
+**(9) Quotes / Testimonials**
+
+"We talked to a couple of different companies at the time. However, we felt that JetThoughts really understood what we were looking for and had a solid approach to do it."
+
+"A lot of what I'm getting is more than I expected. They've put a lot more effort and thought into it than I anticipated."
+
+"We've basically been with the same resources since the start of the engagement, so even though they are outsourced, we really feel that they are a part of the team."
+
+"They want to deliver a good product with us. Rather than just sending them specifications, they actually come with suggestions, so it's very dynamic and fruitful cooperation. It's very valuable and cost-effective for us to have part of our development with JetThoughts."
+
+"They have a rare eagerness to solve problems, which helps them understand each functionality and ensure its future proof."
+
+"The team has great technological expertise, they know how to do user testing and everything else, and have no fear using a variety of technologies for the proof of concept. That approach and reliability make them unique."

--- a/docs/projects/2609-sales-collateral/drafts-draft-custom-development-service-overview.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-custom-development-service-overview.md
@@ -1,0 +1,83 @@
+# Draft - Custom Development - Service Overview
+
++-----------------------------------------------------------------------+
+| **CUSTOM SOFTWARE DEVELOPMENT**                                       |
+|                                                                       |
+| **How it Works**                                                      |
++=======================================================================+
+
+**OVERVIEW**
+
+JetThoughts provides on-demand access to a team of pre-trained developers to help companies build high-quality technology at a fraction of the costs. As a fully-managed service, we can handle everything from research, scoping, & roadmap planning to product development, testing, & post-launch maintenance.
+
+  --------------------------------------------------
+  **Phase**
+  --------------------------------------------------
+  Discovery & Consultation
+
+  Research & Scoping
+
+  Strategy & Design
+
+  Onboarding & Kick-Off
+  --------------------------------------------------
+
+**PHASE 1 - DISCOVERY & CONSULTATION**
+
+Before getting started, the first step is an initial discovery phase.
+
+For any technology project to be successful, we believe in the need for alignment. To do this, we need a clear understanding of the specific situation, problems, & goals driving your technology initiatives.
+
+The goal of discovery is to gain visibility into your situation, understand your key business objectives and KPIs, and use that information to fine-tune our recommendations for the engagement.
+
+Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your project, identify your priorities, and understand any unique requirements.
+
+**PHASE 2 - RESEARCH & SCOPING**
+
+After our team gets better context on your situation, we can do the necessary research, due diligence, and technical brainstorming to help design a clear scope for the engagement.
+
+Transparency is essential when developing technology, so we use the scoping phase to discuss the technical implications of your project and align around a winning strategy.
+
+During the scoping phase, we'll share an overview of our research and provide recommendations for scope based on our technical expertise.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+**PHASE 3 - STRATEGY & DESIGN**
+
+We believe thorough planning and methodical design is critical to the performance, costs, and long-term stability of any technology engagement.
+
+During this phase, JetThoughts combines fractional CTO, UX/UI, product, and project management resources to prepare the engagement for success.
+
+Our team helps conceptualize, design, plan, and outline a roadmap that can create a successful outcome for your project based on the scope and budget established.
+
+At the end of this phase, we provide a detailed product strategy, Scope of Work (SOW), and set of milestones to keep track of our progress towards achieving your objectives.
+
+**PHASE 4 - ONBOARDING & KICK-OFF**
+
+Once we're aligned about how to execute on the project, we begin the onboarding phase.
+
+During this phase, JetThoughts onboards the best engineering & technical resources available for the given scope and budget of the project.
+
+From there, our team begins integrating in your operations and assists your team in any needed preparations to ensure a smooth project launch.
+
+**TECHNOLOGIES WE SERVE**
+
+A.  **Ruby on Rails Development -** Ruby on Rails is a full-stack development framework that is short & expressive, allowing for faster & cheaper software development that's easier to maintain.
+
+B.  **React, Vue.js, Node.js, & React Native Development -** JavaScript provides several powerful open-source code libraries to streamline front-end development & make it easier to create compelling user experiences.
+
+C.  **Python Development -** Python is a robust general-purpose programming language that provides the flexibility, extensibility, and portability to simplify development.
+
+**DEDICATED ACCOUNT & PROJECT MANAGEMENT**
+
+JetThoughts will act as a virtual extension of your team, helping to increase visibility, empower collaboration, and accelerate progress.
+
+A dedicated account manager and project manager will be provided to support project communication, alignment, and efficiency throughout the engagement.
+
+**DOCUMENTATION & REPORTING**
+
+As part of the engagement, JetThoughts helps support some of the background functions necessary for any successful technology project.
+
+This includes activities like code optimization & refactoring, bug-testing, and thorough documentation on both the codebase and the development roadmap.
+
+In addition, a report will be given each month to provide visibility into progress, outcomes, and next steps.

--- a/docs/projects/2609-sales-collateral/drafts-draft-fractional-cpo-service-overview.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-fractional-cpo-service-overview.md
@@ -1,0 +1,73 @@
+# Draft - Fractional CPO - Service Overview
+
++-----------------------------------------------------------------------+
+| **FRACTIONAL CHIEF PRODUCT OFFICER**                                  |
+|                                                                       |
+| **How it Works**                                                      |
++=======================================================================+
+
+**OVERVIEW**
+
+JetThoughts provides on-demand access to product management leadership on a fractional, part-time, or full-time basis to help companies of any size accelerate development & improve user experiences. From roadmap planning & UX research to project & cycle management, we can provide the support needed to deliver better, faster technology outcomes.
+
+  --------------------------------------------------
+  **Phase**
+  --------------------------------------------------
+  Discovery
+
+  Scoping
+
+  Onboarding
+  --------------------------------------------------
+
+**PHASE 1 - DISCOVERY**
+
+Before getting started, the first step is an initial discovery phase.
+
+For any product manager to be successful, we believe in the need for organizational alignment. To do this, we need a clear understanding of the specific situation, problems, & goals driving your technology initiatives.
+
+The goal of discovery is to gain visibility into your situation, understand your key business objectives and KPIs, and use that information to fine-tune our recommendations for the engagement.
+
+Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your project, identify your priorities, and understand any unique requirements.
+
+**PHASE 2 - SCOPING**
+
+After our team gets better context on your situation, we can do the necessary research, due diligence, and technical brainstorming to help create a clear scope for the engagement.
+
+Transparency is essential when developing software products, so we use the scoping phase to discuss the technical implications of your project and align around a winning strategy.
+
+During the scoping phase, we'll share an overview of our research and provide recommendations for scope based on our technical expertise.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+**PHASE 3 - ONBOARDING**
+
+Once we're aligned around a clear scope, we begin the onboarding phase.
+
+To ensure a successful outcome, we conduct a thorough search within our organization, talent pipeline, and general network to identify the best CPO placement for your specific situation.
+
+During this phase, JetThoughts identifies, vets, and onboards the best fractional CPO available for the given scope and budget of the engagement.
+
+In addition, our team integrates in your operations and assists your team in any needed preparations to ensure a smooth launch of the engagement.
+
+**FRACTIONAL CPO SERVICES**
+
+A.  **Strategy & Roadmap -** There are millions of solutions to a problem, thousands of ways to make it a software product, and hundreds of ways to build it. To prevent scope creep or unpredictable costs, it's critical to design the right product & plan the right roadmap. A fractional CPO can help conceptualize, design, and outline a roadmap to create a successful software product optimized for the scope and budget established.
+
+B.  **Research & Planning -** Thorough research and planning is critical to the performance, costs, and long-term stability of any software project. A fractional CPO can conduct the research necessary to avoid obstacles and better resonate with customers.
+
+C.  **Project & Process Management -** Software development is a significant initiative that involves a lot of moving pieces and requires rigorous discipline between employees. A fractional CPO can provide the project management structure to accelerate development while providing the supervision to ensure consistency and operational excellence.
+
+D.  **Prioritization & Sprint Management -** Developing & managing technology is unpredictable. Game plans often have to change as we face technical challenges, product bugs, and customer complaints. A fractional CPO can help keep your team focused on what matters and adapt the game plan as the situation changes.
+
+E.  **Process Optimization -** Software development requires effective, well-documented processes that can be used to both eliminate error and enable organizational scale. Whether it's software development, release management, or squashing bugs, a fractional CPO can help drive productivity and optimize the path to better outcomes.
+
+F.  **Business-Customer Alignment -** The greatest challenge of finding product-market fit is the task of creating alignment between the business, sales/marketing, engineering, and customers. A fractional CPO can translate between these worlds and bring these parties together around a product vision that is compelling for everyone.
+
+**DOCUMENTATION & REPORTING**
+
+JetThoughts will act as a virtual extension of your team and your fractional CPO.
+
+Throughout the engagement, a dedicated account manager and project manager will be provided to support project communication, alignment, and efficiency
+
+In addition, a report will be given each month to provide visibility into progress, outcomes, and next steps.

--- a/docs/projects/2609-sales-collateral/drafts-draft-fractional-cto-service-overview.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-fractional-cto-service-overview.md
@@ -1,0 +1,71 @@
+# Draft - Fractional CTO - Service Overview
+
++-----------------------------------------------------------------------+
+| **FRACTIONAL CHIEF TECHNOLOGY OFFICER**                               |
+|                                                                       |
+| **How it Works**                                                      |
++=======================================================================+
+
+**OVERVIEW**
+
+JetThoughts provides on-demand access to CTO leadership on a fractional, part-time, or full-time basis to help companies of any size level up their technology operations. From technical vision, strategy, and organizational structure to hiring, training, and managing a development team, we can provide the technical support needed to drive sustainable growth.
+
+  --------------------------------------------------
+  **Phase**
+  --------------------------------------------------
+  Discovery
+
+  Scoping
+
+  Onboarding
+  --------------------------------------------------
+
+**PHASE 1 - DISCOVERY**
+
+Before getting started, the first step is an initial discovery phase.
+
+For any CTO to be successful, we believe in the need for organizational alignment. To do this, we need a clear understanding of the specific situation, problems, & goals driving your technology initiatives.
+
+The goal of discovery is to gain visibility into your situation, understand your key business objectives and KPIs, and use that information to fine-tune our recommendations for the engagement.
+
+Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your technology operations, identify your priorities, and understand any unique requirements.
+
+**PHASE 2 - SCOPING**
+
+After our team gets better context on your situation, we can do the necessary research, due diligence, and technical brainstorming to help create a clear scope for the engagement.
+
+Transparency is essential when managing technology, so we use the scoping phase to discuss the technical implications of your operations and align around a winning strategy.
+
+During the scoping phase, we'll share an overview of our research and provide recommendations for scope based on our technical expertise.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+**PHASE 3 - ONBOARDING**
+
+Once we're aligned around a clear scope, we begin the onboarding phase.
+
+To ensure a successful outcome, we conduct a thorough search within our organization, talent pipeline, and general network to identify the best CTO placement for your specific situation.
+
+During this phase, JetThoughts identifies, vets, and onboards the best fractional CTO available for the given scope and budget of the engagement.
+
+In addition, our team integrates in your operations and assists your team in any needed preparations to ensure a smooth launch of the engagement.
+
+**FRACTIONAL CTO SERVICES**
+
+A.  **Technical Leadership -** Effective technology operations requires the right people, processes, and structure to ensure alignment with the organization and its goals. A fractional CTO can provide the executive guidance to improve technology operations, manage organizational change, and support operational excellence.
+
+B.  **Process Optimization -** Technology operations require effective, well-documented processes that can be used to both eliminate error and enable organizational scale. Whether it's software development, website development, or simply managing IT infrastructure, a fractional CTO can help optimize the path to better outcomes.
+
+C.  **People Optimization** - People are at the heart of every organization, especially when it comes to developing and managing technology. A fractional CTO can help accelerate the team-building process and minimize bad hires for a growing organization. Meanwhile, they can also help educate, empower, and motivate existing employees.
+
+D.  **Strategy & Planning** - Technical vision and architecture makes the fundamental difference between successful and struggling technology operations. A fractional CTO can help build long-term technical strategies for your organization and provide the groundwork for successful development initiatives.
+
+E.  **Security, Stability, & Scale -** Technology must be secure, stay stable, and contain the capacity for scale as usage increases. Without these components, the technology is at risk of facing catastrophe over time. A fractional CTO can provide the technical expertise and team guidance to help minimize obstacles and maximize technology uptime.
+
+**MANAGEMENT & REPORTING**
+
+JetThoughts will act as a virtual extension of your team and your fractional CTO.
+
+Throughout the engagement, a dedicated account manager and project manager will be provided to support project communication, alignment, and efficiency
+
+In addition, a report will be given each month to provide visibility into progress, outcomes, and next steps.

--- a/docs/projects/2609-sales-collateral/drafts-draft-getting-started-guide-scoping.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-getting-started-guide-scoping.md
@@ -1,0 +1,57 @@
+# Draft - Getting Started Guide (Scoping)
+
++-----------------------------------------------------------------------+
+| **GETTING STARTED GUIDE**                                             |
+|                                                                       |
+| **Scoping & Planning**                                                |
++=======================================================================+
+
+**OVERVIEW**
+
+Getting started with JetThoughts is easy. From the beginning, our team provides guidance and support to ensure alignment and a clear path to the positive outcome you want. Here is an overview of the steps we typically take to go from zero to launching an engagement.
+
+  -----------------------------------------------------------------------
+  **Phase**                                          **Timeline**
+  -------------------------------------------------- --------------------
+  **Research & Analysis**                            
+
+  **Recommendations & Scoping**                      
+
+  **Project Design & Planning**                      
+
+  **Strategy & Proposal**                            
+  -----------------------------------------------------------------------
+
+**PHASE 1: RESEARCH & ANALYSIS**
+
+As soon as the scoping engagement begins, our first step is to conduct the research, due diligence, and technical brainstorming necessary to prepare your project for success.
+
+Planning is essential when managing technology, so our team uses this phase to dissect all technical implications and identify the best path forward for your project.
+
+Once we complete our research, we design a winning strategy for your situation and build a concrete list of recommendations that we'll use to help create understanding & build alignment.
+
+**PHASE 2: RECOMMENDATIONS & SCOPING**
+
+After the research phase, we setup a call to discuss the technical implications of your project, offer our recommendations, and align around a winning strategy.
+
+During scoping, we'll share an overview of our research and provide recommendations for the project based on our technical expertise.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, align around budget, and define a game plan for the engagement.
+
+**PHASE 3: PROJECT DESIGN & PLANNING**
+
+We believe thorough planning and methodical design is critical to the performance, costs, and long-term stability of any technology.
+
+During this phase, JetThoughts combines fractional CTO, UX/UI, product, and project management resources to prepare the engagement for success.
+
+Our team helps conceptualize, design, plan, and outline a roadmap that can create a successful outcome for your project based on the scope and budget established.
+
+At the end of this phase, we provide a detailed product strategy, Scope of Work (SOW), and set of milestones to keep track of our progress towards achieving your objectives.
+
+**PHASE 4: STRATEGY & PROPOSAL**
+
+To ensure early alignment in an engagement, we provide a proposal that clearly outlines the scope, strategy, deliverables, and milestones involved in your project.
+
+In addition, we offer a summary of the resource requirements, timelines, and key outcomes to expect throughout the collaboration.
+
+Once the proposal has been shared, we ask for a follow-up call to review the proposal together, get feedback on our strategy, and align around the best next steps.

--- a/docs/projects/2609-sales-collateral/drafts-draft-kick-off-onboarding.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-kick-off-onboarding.md
@@ -1,0 +1,61 @@
+# Draft - Kick-Off & Onboarding
+
+-----------------------------------------------------------------------
+  **KICK-OFF & ONBOARDING GUIDE**
+  -----------------------------------------------------------------------
+
+  -----------------------------------------------------------------------
+
+**OVERVIEW**
+
+Onboarding with JetThoughts is easy and our team will provide guidance and support throughout the process to ensure alignment. Here is an overview of the onboarding steps we typically take to go from zero to launching an engagement.
+
+  -----------------------------------------------------------------------
+  **Phase**                                          **Timeline**
+  -------------------------------------------------- --------------------
+  **Kick-Off Call**                                  
+
+  **Recruiting & Placement**                         
+
+  **Training & Onboarding**                          
+
+  **Project Kick-Off & Launch**                      
+  -----------------------------------------------------------------------
+
+**PHASE 1: KICK-OFF CALL**
+
+Before we officially get started, we setup a kick-off call to review the project strategy and ensure all stakeholders are aligned around scope, objectives, deliverables, and expected timelines.
+
+Transparency is essential when managing technology, so we use the kick-off call to answer questions, address any concerns, and make sure everyone involved is on the same page.
+
+Before we finish the kick-off call, we'll provide an overview of the onboarding process and outline the immediate next steps required to get our engagement to full speed.
+
+**PHASE 2: RECRUITING & PLACEMENT**
+
+After the kick-off call, we begin the onboarding process. The first step of onboarding is the recruiting & placement phase.
+
+To ensure a successful outcome, we conduct a thorough search within our organization, talent pipeline, and general network to identify the best resources for your specific situation.
+
+JetThoughts uses a proprietary recruiting, interviewing, and vetting process to acquire top-tier engineering talent and A-player personalities that's based on decades of experience.
+
+During the phase, JetThoughts secures the best team members available for the given scope and budget of our engagement.
+
+**PHASE 3: TRAINING & ONBOARDING**
+
+Once we've found the right team members for your project, we begin the process of ramping these engineering resources to deploy as soon as possible.
+
+JetThoughts uses a robust proprietary training process to get your developers up-to-speed and ready to perform at the level of excellence we expect.
+
+From there, JetThoughts onboards your developers to the project and begins to integrate them into your operations.
+
+In addition, our team is available to assist in any needed preparations to ensure a smooth launch of the engagement.
+
+**PHASE 4: PROJECT KICK-OFF & LAUNCH**
+
+As soon as the resources are fully ramped up, JetThoughts will officially kick-off the engagement and begin executing on the project strategy at full speed.
+
+Throughout the engagement, JetThoughts will act as a virtual extension of your team and help support your organization's technology operations.
+
+To ensure transparency, a dedicated account manager and project manager will be provided to support project communication, alignment, and efficiency.
+
+In addition, a report will be given each month to provide visibility into progress, outcomes, and next steps as we move forward.

--- a/docs/projects/2609-sales-collateral/drafts-draft-limeleads-case-study.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-limeleads-case-study.md
@@ -1,0 +1,81 @@
+# Draft - LimeLeads Case Study
+
+This outline was created based on my review of [this case study page](https://www.jetthoughts.com/agentinbox.html) on the website.
+
+1.  **Tease Header Statement**
+
+2.  **Technologies** (What tech stack / codebase?)
+
+3.  **Client Overview** (What they are / what they do / what industry)
+
+4.  **Vision** (What were their goals / needs / ideal outcomes?)
+
+5.  **Problem** (What blocked / disrupted / cost them?)
+
+6.  **Solution** (What's the summary of how JetThoughts helped?)
+
+7.  **Approach / Milestones** (Specific Pieces / Achievements of the Project)
+
+8.  **Outcome** (How did the story end? Stats on Team, Timeline, Outcomes, etc.)
+
+9.  **Quotes / Testimonials** (What did the client have to say about their experience?)
+
+**(1) See How JetThoughts Helped LimeLeads Transform a Legacy Codebase and Stabilize the Product for Long-Term Performance**
+
+**(2)** Ruby on Rails, React, PostgreSQL, ElasticSearch, Heroku, Amazon Web Services
+
+**(3) Client Overview**
+
+LimeLeads is a searchable B2B database software that provides access to high-quality sales & marketing data with a do-it-yourself user experience and real-time validation.
+
+They initially reached out to JetThoughts to augment their on-site product development team to help increase the velocity of feature development and bug-fixing at minimal financial cost.
+
+**(4) Vision**
+
+LimeLeads envisioned a complete transformation of their software product, which was built on an out-of-date codebase years ago by the original founder.
+
+In addition to the development initiative, LimeLeads also desired to optimize their technology operations and development processes to be more effective.
+
+**(5) Problem**
+
+The codebase at LimeLeads had been touched by several people and service vendors, which made it difficult to understand, navigate, and maintain without a dedicated specialist.
+
+After losing their main technology specialist, LimeLeads knew they would need the assistant of a full-stack technical consultant who could untangle the problems with their legacy codebase.
+
+**(6) Solution**
+
+JetThoughts provided a fractional CTO resource to help guide the project and a full-time engineer to act as a virtual extension of LimeLeads' development team.
+
+In addition, we provided a dedicated project advisor to bring real-time visibility into progress and ensure alignment with the leadership team at LimeLeads.
+
+**(7) Approach**
+
+From the very beginning of the engagement, JetThoughts provided LimeLeads' team with deep technical guidance based on decades of experience to help ensure a successful outcome.
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled LimeLeads to monitor budget & maximize the value delivered by our engineers.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that LimeLeads faced.
+
+**(8) Outcome**
+
+- Unblocked release changes & development
+
+- Transformed product performance & speed
+
+- Solved all technical scale & reliability issues
+
+**(9) Quotes / Testimonials**
+
+"Thanks to him I saved a large sum of money as he is doing the work of four!"
+
+"JetThoughts is able to find highly skilled engineers much faster than we are able to in the US at an equivalent or even higher quality"
+
+"The project was hugely successful in that it was released in a short amount of time, one of the consultants from JetThoughts helped us to remove all issues and accomplished all of our core goals of infinite scale, high performance, and reliability."
+
+"A lead developer from JetThoughts quickly finds a solution. In general, I would just say that his timeliness and level of professionalism was always very helpful."
+
+"There was very close coordination between all teams involved, which meant to me that he guiding that quite closely in order to provide timely and relevant updates."
+
+"I was impressed by the talented developer and his great technical and communication skills. He is a proactive full-stack, so he knows as well frontend as backend and how to manage. Very much appreciate the quick response from him."

--- a/docs/projects/2609-sales-collateral/drafts-draft-mobile-coach-case-study.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-mobile-coach-case-study.md
@@ -1,0 +1,81 @@
+# Draft - Mobile Coach Case Study
+
+This outline was created based on my review of [this case study page](https://www.jetthoughts.com/agentinbox.html) on the website.
+
+1.  **Tease Header Statement**
+
+2.  **Technologies** (What tech stack / codebase?)
+
+3.  **Client Overview** (What they are / what they do / what industry)
+
+4.  **Vision** (What were their goals / needs / ideal outcomes?)
+
+5.  **Problem** (What blocked / disrupted / cost them?)
+
+6.  **Solution** (What's the summary of how JetThoughts helped?)
+
+7.  **Approach / Milestones** (Specific Pieces / Achievements of the Project)
+
+8.  **Outcome** (How did the story end? Stats on Team, Timeline, Outcomes, etc.)
+
+9.  **Quotes / Testimonials** (What did the client have to say about their experience?)
+
+**(1) See How JetThoughts Helped Mobile Coach Launch a Game-Changing Product Feature & Scale Their Development Team**
+
+**(2)** Ruby on Rails, Angular.js / AngularJS, PostgreSQL, Twillio, Amazon Web Services
+
+**(3) Client Overview**
+
+Mobile Coach is a chatbot platform that's trying to change how enterprises influence employee engagement, learning, customer service, sales performance, and overall behavior change.
+
+They initially reached out to JetThoughts to help support and build new features for a group of internal products related to the chatbot platform while eventually helping to scale their R&D team.
+
+**(4) Vision**
+
+Mobile Coach envisioned an enterprise-level authoring platform which would allow larger customers to setup complicated chatbot workflows with multiple channels, multi-language compatibility, and seamless back-office integrations.
+
+In addition to the development initiative, Mobile Coach also desired to scale their team in terms of both development manpower and R&D expertise.
+
+**(5) Problem**
+
+While Mobile Coach had reliable and skilled people internally to help develop this feature, they understood that this enterprise-level feature was a big project.
+
+To build such a large-scale platform, Mobile Coach knew they would need to scale their team and increase the depth of their technical expertise.
+
+**(6) Solution**
+
+JetThoughts provided 4 full-time engineers to act as Mobile Coach's development team and support their development initiatives.
+
+In addition, we provided a dedicated project advisor to bring real-time visibility into progress and ensure alignment with the leadership team at Mobile Coach.
+
+**(7) Approach**
+
+From the very beginning of the engagement, JetThoughts provided Mobile Coach's team with deep technical guidance based on decades of experience to help ensure a successful outcome.
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Mobile Coach to monitor budget & maximize the value delivered by our engineers.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that Mobile Coach faced.
+
+**(8) Outcome**
+
+- Grew to Support Hundreds of Thousands of Users
+
+- Scaled Team from 2 to 10 Developers
+
+- Onboarded Stable Delivery Pipeline for Predictable Releases
+
+**(9) Quotes / Testimonials**
+
+"JetThoughts\' work is flawless. They've never failed to deliver. As on early-stages, we moved fast and made decisions just as fast. Despite that, they've always delivered value."
+
+"JetThoughts is more than a contractor---they're a trustworthy partner with impressive knowledge and skills. Currently, I\'m still working with them and giving my ideas to translate into concrete actions."
+
+"They've been founders themselves so they really understand the process of scaling and growing as a business. I feel like I have a really great partner. The technical skill level has been key for us, and communication has been a tremendous asset."
+
+"We're on schedule, which is rare. They've really been able to take everything I've thrown at them, which has been a lot."
+
+"Everyone on the team is very knowledgeable and provides excellent support. They are professionals at all levels, from the presale stage to the delivery stage. I appreciated their understanding of the not-so-simple project and interesting suggestions and recommendations."
+
+"Overall, we've enjoyed the communication with JetThoughts. They provide us with a high level of transparency. We have direct contact with every team member either through Slack, email, and meetings."

--- a/docs/projects/2609-sales-collateral/drafts-draft-mvp-development-service-overview.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-mvp-development-service-overview.md
@@ -1,0 +1,93 @@
+# Draft - MVP Development - Service Overview
+
++-----------------------------------------------------------------------+
+| **STARTUP MVP DEVELOPMENT**                                           |
+|                                                                       |
+| **How it Works**                                                      |
++=======================================================================+
+
+**OVERVIEW**
+
+With more than a decade of experience in the software startup world, JetThoughts understands the critical steps that early-stage startups need to take to validate their business idea and go-to-market in a cost-efficient way. We can provide the technical expertise, product vision, and engineering manpower to make any software product a reality.
+
+  --------------------------------------------------
+  **Phase**
+  --------------------------------------------------
+  Discovery & Consultation
+
+  Research & Scoping
+
+  Strategy & Design
+
+  Proof-of-Concept & Prototyping
+
+  Onboarding & Kick-Off
+  --------------------------------------------------
+
+**PHASE 1 - DISCOVERY & CONSULTATION**
+
+Before getting started, the first step is an initial discovery phase.
+
+For any technology project to be successful, we believe in the need for alignment. To do this, we need a clear understanding of the specific situation, problems, & goals driving your technology initiatives.
+
+The goal of discovery is to gain visibility into your situation, understand your key business objectives and KPIs, and use that information to fine-tune our recommendations for the engagement.
+
+Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your project, identify your priorities, and understand any unique requirements.
+
+**PHASE 2 - RESEARCH & SCOPING**
+
+After our team gets better context on your situation, we can do the necessary research, due diligence, and technical brainstorming to help design a clear scope for the engagement.
+
+Transparency is essential when developing technology, so we use the scoping phase to discuss the technical implications of your software and align around a winning strategy.
+
+During the scoping phase, we'll share an overview of our research and provide recommendations for scope based on our technical expertise.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+**PHASE 3 - STRATEGY & DESIGN**
+
+We believe thorough planning and methodical design is critical to the performance, costs, and long-term stability of any startup software project.
+
+During this phase, JetThoughts combines fractional CTO, UX/UI, product, and project management resources to prepare the engagement for success.
+
+Our team helps conceptualize, design, plan, and outline a roadmap that can create a successful software product based on the scope and budget established.
+
+At the end of this phase, we provide a detailed product strategy, Scope of Work (SOW), and set of milestones to keep track of our progress towards achieving your objectives.
+
+**PHASE 4 - PROOF-OF-CONCEPT & PROTOTYPING**
+
+Once we're aligned about how to execute on the project, we use our product and design strategy to flesh out more concrete assets to review.
+
+During this phase, we come up with a Proof-of-Concept (POC) for the product strategy we outlined to ensure we're aligned around user experience and functionality.
+
+In addition, we can create interactive prototypes of your software product to illustrate the end-to-end user experience and overall design strategy.
+
+**PHASE 5 - ONBOARDING / SETTING UP**
+
+We should now be on the same page about the product strategy and fully aligned around how the MVP product will look, feel, and behave for users.
+
+During the onboarding phase, JetThoughts onboards the best engineering & technical resources available for the given scope and budget of the project.
+
+From there, our team begins integrating in your operations and assists your team in any needed preparations to ensure a smooth launch.
+
+**STARTUP MVP DEVELOPMENT SERVICES**
+
+A.  **Ruby on Rails Development -** Ruby on Rails is a full-stack development framework that is short & expressive, allowing for faster & cheaper software development that's easier to maintain.
+
+B.  **React, Vue.js, Node.js, & React Native Development -** JavaScript provides several powerful open-source code libraries to streamline front-end development & make it easier to create compelling user experiences.
+
+C.  **Python Development -** Python is a robust general-purpose programming language that provides the flexibility, extensibility, and portability to simplify development.
+
+**DEDICATED ACCOUNT & PROJECT MANAGEMENT**
+
+JetThoughts will act as a virtual extension of your team, helping to increase visibility, empower collaboration, and accelerate progress.
+
+A dedicated account manager and project manager will be provided to support project communication, alignment, and efficiency throughout the engagement.
+
+**DOCUMENTATION & REPORTING**
+
+As part of the engagement, JetThoughts helps support some of the background functions necessary for any successful technology project.
+
+This includes activities like code optimization & refactoring, bug-testing, and thorough documentation on both the codebase and the development roadmap.
+
+In addition, a report will be given each month to provide visibility into progress, outcomes, and next steps.

--- a/docs/projects/2609-sales-collateral/drafts-draft-open-apply-case-study.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-open-apply-case-study.md
@@ -1,0 +1,69 @@
+# Draft - Open Apply Case Study
+
+aThis outline was created based on my review of [this case study page](https://www.jetthoughts.com/agentinbox.html) on the website.
+
+1.  **Tease Header Statement**
+
+2.  **Technologies** (What tech stack / codebase?)
+
+3.  **Client Overview** (What they are / what they do / what industry)
+
+4.  **Vision** (What were their goals / needs / ideal outcomes?)
+
+5.  **Problem** (What blocked / disrupted / cost them?)
+
+6.  **Solution** (What's the summary of how JetThoughts helped?)
+
+7.  **Approach / Milestones** (Specific Pieces / Achievements of the Project)
+
+8.  **Outcome** (How did the story end? Stats on Team, Timeline, Outcomes, etc.)
+
+9.  **Quotes / Testimonials** (What did the client have to say about their experience?)
+
+**(1) See How JetThoughts Helped Stabilize Open Apply's Code & Transform Their Product's UX**
+
+**(2)** Ruby on Rails, jQuery, Bootstrap
+
+**(3) Client Overview**
+
+OpenApply is a fast-growing software platform to help simplify the admissions and enrollment processes for applicants around the world with a paperless, integrated online experience.
+
+They initially reached out to JetThoughts to help stop regressions, revamp the user experience, scale feature development, and streamline internal development processes.
+
+**(4) Vision**
+
+Open Apply envisioned an upgrade of their technology operations from end-to-end: fewer bugs, better UX/UI, faster development, and higher-quality releases..
+
+Because Open Apply was growing so quickly, they needed to level up both their software and their internal processes in order to maintain momentum.
+
+**(5) Problem**
+
+Open Apply's initial launch was a huge success and customers grew rapidly. However, their product wasn't designed to properly address the level of scale they had already reached.
+
+With an outdated user interface, bugs emerging faster, and an inability to expand the product, Open Apply knew it needed to make big changes to accommodate increasing demand.
+
+**(6) Solution**
+
+JetThoughts provided a fractional CTO resource to help guide the project and 2 full-time engineers to act as a virtual development team for Open Apply.
+
+In addition, we provided a dedicated project advisor to bring real-time visibility into progress and ensure alignment with the leadership team at Open Apply.
+
+**(7) Approach**
+
+From the very beginning of the engagement, JetThoughts provided Open Apply's team with deep technical guidance based on decades of experience to help ensure a successful outcome.
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To begin, we first prioritized tackling the unstable code with hundreds of bugs. This required both resolving these technical issues and setting up the analytics & testing processes to prevent future bugs.
+
+From there, we collaborated with Open Apply's team to redesign & rewrite the entire user interface while upgrading the Ruby on Rails code supporting the product.
+
+Once we tackled these priorities, we helped optimize the internal software development & project management processes at Open Apply while helping them grow a development team.
+
+**(8) Outcome**
+
+- Upgraded Code Quality from F to A & Improved Readability
+
+- Reduced Bug Risks via Best Practices & Testing Systems
+
+- Scaled Internal Team from 2 to 20 Developers

--- a/docs/projects/2609-sales-collateral/drafts-draft-orchestratecs-case-study.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-orchestratecs-case-study.md
@@ -1,0 +1,69 @@
+# Draft - OrchestrateCS Case Study
+
+This outline was created based on my review of [this case study page](https://www.jetthoughts.com/agentinbox.html) on the website.
+
+1.  **Tease Header Statement**
+
+2.  **Technologies** (What tech stack / codebase?)
+
+3.  **Client Overview** (What they are / what they do / what industry)
+
+4.  **Vision** (What were their goals / needs / ideal outcomes?)
+
+5.  **Problem** (What blocked / disrupted / cost them?)
+
+6.  **Solution** (What's the summary of how JetThoughts helped?)
+
+7.  **Approach / Milestones** (Specific Pieces / Achievements of the Project)
+
+8.  **Outcome** (How did the story end? Stats on Team, Timeline, Outcomes, etc.)
+
+9.  **Quotes / Testimonials** (What did the client have to say about their experience?)
+
+**(1) See How JetThoughts Helped Startup OrchestrateCS Go From Idea to Software in 60 Days**
+
+**(2)** Ruby on Rails, Hotwire, Tailwind UI / Tailwind CSS
+
+**(3) Client Overview**
+
+OrchestrateCS is a startup building software to help unify, simplify, and standardize both people and compliance operations.
+
+They initially reached out to JetThoughts to help them go from zero to revenue by making their first product idea a reality.
+
+**(4) Vision**
+
+OrchestrateCS envisioned a new software idea from scratch to pursue a new business opportunity that had emerged in their industry.
+
+Given the time-sensitive nature of this project, OrchestrateCS desired to develop a Minimal Viable Product (MVP) and go-to-market as quickly as possible.
+
+**(5) Problem**
+
+OrchestrateCS was driven by a group of business executives and growth experts. However, they lacked the technical knowledge & talent to make their software idea a reality.
+
+Because of the hasty timeline for delivering the MVP, OrchestrateCS knew it would be unrealistic to build any worthwhile development team internally.
+
+In addition, they realized that their unique situation would required a specific type of software development vendor that had the experience needed to deliver positive outcomes on-time.
+
+**(6) Solution**
+
+JetThoughts provided a fractional CTO resource to help guide the project and 2 full-time engineers to act as a virtual development team for OrchestrateCS.
+
+In addition, we provided a dedicated project advisor to bring real-time visibility into progress and ensure alignment with the leadership team at OrchestrateCS.
+
+**(7) Approach**
+
+From the very beginning of the engagement, JetThoughts provided OrchestrateCS' team with deep technical guidance based on decades of experience to help ensure a successful outcome.
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software idea, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled OrchestrateCS to monitor budget & maximize the value delivered by our team.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that OrchestrateCS faced.
+
+**(8) Outcome**
+
+- Conceptualized a successful mvp build
+
+- From zero to mvp in less than 60 days
+
+- Owned roadmap & product management

--- a/docs/projects/2609-sales-collateral/drafts-draft-pop-up-shops-case-study.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-pop-up-shops-case-study.md
@@ -1,0 +1,77 @@
+# Draft - Pop Up Shops Case Study
+
+This outline was created based on my review of [this case study page](https://www.jetthoughts.com/agentinbox.html) on the website.
+
+1.  **Tease Header Statement**
+
+2.  **Technologies** (What tech stack / codebase?)
+
+3.  **Client Overview** (What they are / what they do / what industry)
+
+4.  **Vision** (What were their goals / needs / ideal outcomes?)
+
+5.  **Problem** (What blocked / disrupted / cost them?)
+
+6.  **Solution** (What's the summary of how JetThoughts helped?)
+
+7.  **Approach / Milestones** (Specific Pieces / Achievements of the Project)
+
+8.  **Outcome** (How did the story end? Stats on Team, Timeline, Outcomes, etc.)
+
+9.  **Quotes / Testimonials** (What did the client have to say about their experience?)
+
+**(1) See How JetThoughts Helped Pop Up Shops Upgrade Their Legacy Codebase & Implement Software Testing Across the Organization.**
+
+**(2)** Ruby on Rails, jQuery
+
+**(3) Client Overview**
+
+Pop Up Shops is an online marketplace for brands, retailers, and space owners to help simplify the booking process for renting retail space.
+
+They initially reached out to JetThoughts to make significant upgrades to their legacy Ruby on Rails codebase, increase test coverage, and implement code-testing processes org-wide.
+
+**(4) Vision**
+
+Pop Up Shops envisioned a revamp of their legacy codebase to maximize performance, minimize bugs, and make test coverage easier to manage.
+
+In addition, Pop Up Shops desired to setup the infrastructure for better testing based on best practices and implement mandatory software testing processes for all developers.
+
+**(5) Problem**
+
+The Pop Up Shops app was originally developed 7+ years ago in 2014. While it was developed using best practices & well-organized, the age of their codebase began to create issues.
+
+Because of problems with a legacy codebase, Pop Up Shops recognized the need to focus on more rigorous Quality Assurance, testing, and review processes before making a pull request.
+
+However, their test coverage for the legacy codebase was 60% and the only testing or QA processes used by the development team were rudimentary and incomplete.
+
+**(6) Solution**
+
+JetThoughts provided a fractional CTO resource to help guide the project and 1 full-time senior-level engineer to act as a virtual extension of Pop Up Shops' development team.
+
+In addition, we provided a dedicated project advisor to bring real-time visibility into progress and ensure alignment with the leadership team at Pop Up Shops.
+
+**(7) Approach**
+
+From the very beginning of the engagement, JetThoughts provided Pop Up Shops' team with deep technical guidance based on decades of experience to help ensure a successful outcome.
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Pop Up Shops to monitor budget & maximize the value delivered by JetThoughts.
+
+Throughout the entirety of the engagement, we kept the team composition & functions flexible to the specific needs and circumstances that Pop Up Shops faced.
+
+**(8) Outcome**
+
+- Refactored a Legacy Codebase Based on Best Practices
+
+- Maximized Code Visibility & Test Coverage
+
+- Improved Internal QA & Testing Processes
+
+**(9) Quotes / Testimonials**
+
+"I found some good reviews about JetThoughts. I went on their site and was convinced they were the right company for us because they had very clear articles about how to work with no stress. It made things very easy for me to know what I had to do to help them understand my project."
+
+"From beginning to end, their processes are solid. Every single task and every single step is documented. Thanks to their work, we developed the application on schedule and on budget."
+
+"Their team has been most impressive. JetThoughts has been down to earth, approaching everything humbly. They've spoken their minds throughout the collaboration."

--- a/docs/projects/2609-sales-collateral/drafts-draft-recruiting-service-overview.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-recruiting-service-overview.md
@@ -1,0 +1,79 @@
+# Draft - Recruiting - Service Overview
+
++-----------------------------------------------------------------------+
+| **DEVELOPER TALENT RECRUITING**                                       |
+|                                                                       |
+| **How it Works**                                                      |
++=======================================================================+
+
+**OVERVIEW**
+
+JetThoughts provides on-demand access to a talent network of pre-vetted developers to help companies build a high-caliber software development team faster and at a fraction of the costs. As a fully-managed recruiting service, we can handle everything from researching and vetting candidates to interviewing, evaluating, and ranking developer talent.
+
+  --------------------------------------------------
+  **Phase**
+  --------------------------------------------------
+  Discovery
+
+  Scoping
+
+  Talent Search
+
+  Interviews
+
+  Onboarding
+  --------------------------------------------------
+
+**PHASE 1 - DISCOVERY**
+
+Before getting started, the first step is an initial discovery phase.
+
+For any developer to be successful, we believe in the need for alignment. To do this, we need a clear understanding of the specific situation, problems, & goals driving your technology initiatives.
+
+The goal of discovery is to gain visibility into your situation, understand your key business objectives and KPIs, and use that information to fine-tune our recommendations for the engagement.
+
+Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your technology operations, identify your priorities, and understand any unique requirements.
+
+**PHASE 2 - SCOPING**
+
+After our team gets better context on your situation, we can do the necessary research, due diligence, and technical brainstorming to help create a clear scope for the engagement.
+
+Transparency is essential when outsourcing developers, so we use the scoping phase to discuss the technical implications of your operations and align around a winning strategy.
+
+During the scoping phase, we'll share an overview of our research and provide recommendations for scope based on our technical expertise.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+**PHASE 3 - TALENT SEARCH**
+
+Once we're aligned around a clear scope, we begin the recruiting & placement phase.
+
+To improve hiring outcomes & simplify the team-building process, companies need the right systems in place to find and attract vetted developer talent.
+
+We conduct a thorough search within our global talent network that's been developed over 20+ years in the space to find the best developers for your specific situation.
+
+In addition, we deploy proprietary filtering & qualification processes that we use to optimize talent pools for the most skilled and driven developers.
+
+**PHASE 4 - INTERVIEWS**
+
+While we pride ourselves in the ability to find great A-players in the engineering world, we still conduct thorough interviews of each candidate to ensure competency and cultural fit.
+
+JetThoughts uses a proprietary two-stage interviewing process: A personal interview to identify A-player personalities and a technical interview to identify top-tier engineering talent.
+
+Upon narrowing the candidates down to the top choices, we provide our recommendations and help assist you in making the hiring decision for your organization.
+
+Before the end of this phase, we will help you find the best developer available for the given scope and budget of your project.
+
+**PHASE 5 - ONBOARDING**
+
+Once we've found the right developers for your project, we begin the process of acquiring these engineering resources for your team as soon as possible.
+
+JetThoughts has decades of experience with vetting developers, negotiating compensation, and securing technical talent.
+
+In addition, our team is available to help integrate developers into your operations or assist in any needed preparations to ensure a smooth hire.
+
+**DEDICATED ACCOUNT & PROJECT MANAGEMENT**
+
+JetThoughts will act as a virtual extension of your team, helping to increase visibility, empower collaboration, and accelerate progress.
+
+A dedicated account manager and project manager will be provided to support project communication, alignment, and efficiency throughout the engagement.

--- a/docs/projects/2609-sales-collateral/drafts-draft-staffing-free-trial.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-staffing-free-trial.md
@@ -1,0 +1,67 @@
+# Draft - Staffing Free Trial
+
+-----------------------------------------------------------------------
+  **GET A 2-WEEK FREE TRIAL OF STAFFING SERVICES**
+  -----------------------------------------------------------------------
+
+  -----------------------------------------------------------------------
+
+**OVERVIEW**
+
+Getting started with your 2-week free trial is easy. From the beginning, our team provides guidance and support to ensure alignment and a clear path to the positive outcome you want. Here is an overview of the steps we typically take to make your 2-week trial successful.
+
+  -----------------------------------------------------------------------
+  **Phase**                                          **Timeline**
+  -------------------------------------------------- --------------------
+  **Kick-Off Call**                                  
+
+  **Recruiting & Placement**                         
+
+  **Training & Onboarding**                          
+
+  **Trial Feedback Call**                            
+
+  **Keep or Discontinue**                            
+  -----------------------------------------------------------------------
+
+**PHASE 1: KICK-OFF CALL**
+
+Before we officially get started, we setup a kick-off call to review the project strategy and ensure all stakeholders are aligned around scope, objectives, deliverables, and expected timelines.
+
+Transparency is essential when managing technology, so we use the kick-off call to answer questions, address any concerns, and make sure everyone involved is on the same page.
+
+Before we finish the kick-off call, we'll provide an overview of the onboarding process and outline the immediate next steps required to get started.
+
+**PHASE 2: RECRUITING & PLACEMENT**
+
+Once we're aligned around a clear scope, we begin the recruiting & placement phase.
+
+To ensure a successful outcome, we conduct a thorough search within our organization, talent pipeline, and general network to identify the best developers for your specific situation.
+
+JetThoughts uses a proprietary recruiting, interviewing, and vetting process to acquire top-tier engineering talent and A-player personalities that's based on decades of experience.
+
+During the phase, JetThoughts secures the best developers available for the given scope and budget of the engagement.
+
+**PHASE 3: TRAINING & ONBOARDING**
+
+Once we've found the right developers for your project, we begin the process of ramping these engineering resources to deploy as soon as possible.
+
+JetThoughts uses a robust proprietary training process to get your developers up-to-speed and ready to perform at the level of excellence we seek.
+
+From there, JetThoughts onboards your developers to the project and begins to integrate them into your operations.
+
+In addition, our team is available to assist in any needed preparations to ensure a smooth launch of the engagement.
+
+**PHASE 4: TRIAL FEEDBACK CALL**
+
+Before the trial period ends, we ask for a call to review progress, get feedback on your experiences, and identify whether it makes sense to continue beyond the trial.
+
+In exchange for your feedback, we can provide recommendations to optimize your technology operations based on industry best practices and our expertise.
+
+Before the feedback call has been completed, we expect a decision to be made about whether we should continue the staffing engagement or wind down the collaboration.
+
+**PHASE 5: KEEP OR DISCONTINUE**
+
+Once a decision has been made about the engagement, we begin the next steps to either discontinue after the trial period or prepare the resources for further collaboration.
+
+Should you decide to discontinue, we will still provide the staffed engineering resources for the remainder of the trial period before transitioning that team member out of the project.

--- a/docs/projects/2609-sales-collateral/drafts-draft-staffing-service-overview.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-staffing-service-overview.md
@@ -1,0 +1,77 @@
+# Draft - Staffing - Service Overview
+
++-----------------------------------------------------------------------+
+| **OUTSOURCED DEVELOPER STAFFING**                                     |
+|                                                                       |
+| **How it Works**                                                      |
++=======================================================================+
+
+**OVERVIEW**
+
+JetThoughts provides on-demand access to pre-trained developers to help companies grow their software development team at a fraction of the costs. As a fully-managed staffing service, we can handle everything from vetting, training, and onboarding to managing payroll, benefits, and HR compliance.
+
+  --------------------------------------------------
+  **Phase**
+  --------------------------------------------------
+  Discovery
+
+  Scoping
+
+  Recruiting & Placement
+
+  Training & Onboarding
+  --------------------------------------------------
+
+**PHASE 1 - DISCOVERY**
+
+Before getting started, the first step is an initial discovery phase.
+
+For any developer to be successful, we believe in the need for alignment. To do this, we need a clear understanding of the specific situation, problems, & goals driving your technology initiatives.
+
+The goal of discovery is to gain visibility into your situation, understand your key business objectives and KPIs, and use that information to fine-tune our recommendations for the engagement.
+
+Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your technology operations, identify your priorities, and understand any unique requirements.
+
+**PHASE 2 - SCOPING**
+
+After our team gets better context on your situation, we can do the necessary research, due diligence, and technical brainstorming to help create a clear scope for the engagement.
+
+Transparency is essential when outsourcing developers, so we use the scoping phase to discuss the technical implications of your operations and align around a winning strategy.
+
+During the scoping phase, we'll share an overview of our research and provide recommendations for scope based on our technical expertise.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+**PHASE 3 - RECRUITING & PLACEMENT**
+
+Once we're aligned around a clear scope, we begin the recruiting & placement phase.
+
+To ensure a successful outcome, we conduct a thorough search within our organization, talent pipeline, and general network to identify the best developers for your specific situation.
+
+JetThoughts uses a proprietary recruiting, interviewing, and vetting process to acquire top-tier engineering talent and A-player personalities that's based on decades of experience.
+
+During the phase, JetThoughts secures the best developers available for the given scope and budget of the engagement.
+
+**PHASE 4 - TRAINING & ONBOARDING**
+
+Once we've found the right developers for your project, we begin the process of ramping these engineering resources to deploy as soon as possible.
+
+JetThoughts uses a robust proprietary training process to get your developers up-to-speed and ready to perform at the level of excellence we seek.
+
+From there, JetThoughts onboards your developers to the project and begins to integrate them into your operations.
+
+In addition, our team is available to assist in any needed preparations to ensure a smooth launch of the engagement.
+
+**DEDICATED ACCOUNT & PROJECT MANAGEMENT**
+
+JetThoughts will act as a virtual extension of your team, helping to increase visibility, empower collaboration, and accelerate progress.
+
+A dedicated account manager and project manager will be provided to support project communication, alignment, and efficiency throughout the engagement.
+
+**DOCUMENTATION & REPORTING**
+
+As part of the engagement, JetThoughts helps support some of the background functions necessary for any successful technology project.
+
+This includes activities like code optimization & refactoring, bug-testing, and thorough documentation on both the codebase and the development roadmap.
+
+In addition, a report will be given each month to provide visibility into progress, outcomes, and next steps.

--- a/docs/projects/2609-sales-collateral/drafts-draft-testing-service-overview.md
+++ b/docs/projects/2609-sales-collateral/drafts-draft-testing-service-overview.md
@@ -1,0 +1,77 @@
+# Draft - Testing - Service Overview
+
++-----------------------------------------------------------------------+
+| **FULLY-AUTOMATED QA & TESTING**                                      |
+|                                                                       |
+| **How it Works**                                                      |
++=======================================================================+
+
+**OVERVIEW**
+
+JetThoughts provides on-demand access to a team of pre-trained product testing experts to help companies build faster and worry less about costly mistakes. As a fully-managed service, we can handle everything from setting up testing automation and QA processes to troubleshooting potential issues.
+
+  --------------------------------------------------
+  **Phase**
+  --------------------------------------------------
+  Discovery
+
+  Scoping
+
+  Recruiting & Placement
+
+  Onboarding & Kick-Off
+  --------------------------------------------------
+
+**PHASE 1 - DISCOVERY**
+
+Before getting started, the first step is an initial discovery phase.
+
+For any technology project to be successful, we believe in the need for organizational alignment. To do this, we need a clear understanding of the specific situation, problems, & goals driving your technology initiatives.
+
+The goal of discovery is to gain visibility into your situation, understand your key business objectives and KPIs, and use that information to fine-tune our recommendations for the engagement.
+
+Discovery usually requires a 30-minute introductory meeting to get caught up on the state of your technology operations, identify your priorities, and understand any unique requirements.
+
+**PHASE 2 - SCOPING**
+
+After our team gets better context on your situation, we can do the necessary research, due diligence, and technical brainstorming to help create a clear scope for the engagement.
+
+Transparency is essential when managing technology, so we use the scoping phase to discuss the technical implications of your operations and align around a winning strategy.
+
+During the scoping phase, we'll share an overview of our research and provide recommendations for scope based on our technical expertise.
+
+Scoping usually requires a 30-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+**PHASE 3 - RECRUITING & PLACEMENT**
+
+Once we're aligned around a clear scope, we begin the recruiting & placement phase.
+
+To ensure a successful outcome, we conduct a thorough search within our organization, talent pipeline, and general network to identify the best developers for your specific situation.
+
+JetThoughts uses a proprietary recruiting, interviewing, and vetting process to acquire top-tier engineering talent and A-player personalities that's based on decades of experience.
+
+During the phase, JetThoughts secures the best developers available for the given scope and budget of the engagement.
+
+**PHASE 4 - ONBOARDING & KICK-OFF**
+
+Once we've found the right developers for your project, we begin the process of ramping these engineering resources to deploy as soon as possible.
+
+JetThoughts uses a robust proprietary training process to get your developers up-to-speed and ready to perform at the level of excellence we seek.
+
+From there, JetThoughts onboards your developers to the project and begins to integrate them into your operations.
+
+In addition, our team is available to assist in any needed preparations to ensure a smooth launch of the engagement.
+
+**DEDICATED ACCOUNT & PROJECT MANAGEMENT**
+
+JetThoughts will act as a virtual extension of your team, helping to increase visibility, empower collaboration, and accelerate progress.
+
+A dedicated account manager and project manager will be provided to support project communication, alignment, and efficiency throughout the engagement.
+
+**DOCUMENTATION & REPORTING**
+
+As part of the engagement, JetThoughts helps support some of the background functions necessary for any successful technology project.
+
+This includes activities like code optimization & refactoring, bug-testing, and thorough documentation on both the codebase and the development roadmap.
+
+In addition, a report will be given each month to provide visibility into progress, outcomes, and next steps.

--- a/docs/projects/2609-sales-collateral/editable-versions-agent-inbox-case-study.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-agent-inbox-case-study.md
@@ -1,0 +1,74 @@
+# Agent Inbox - Case Study
+
+CASE STUDY
+
+See How JetThoughts Helped Agent Inbox Go From Idea to Software in Just 60 Days
+
+# Technologies
+
+Tech stack or code bases that are implemented on the project comprise:
+
+# Client Overview
+
+Agent Inbox is an industry-leading real estate messaging platform that leverages Multiple Listing Services (MLS) data to help centralize & streamline deal-making for realtors.
+
+They initially reached out to JetThoughts to help:
+
+- Make their product idea a reality and help build the right internal development team for long-term success
+
+# Vision
+
+Agent Inbox envisioned an idea to create a competitive software product to disrupt real estate communication.
+
+To **attract investors and customers** as quickly as possible, Agent Inbox desired to develop a **Minimal Viable Product (MVP)** that could be used as a foundation for additional development.
+
+# Problem
+
+Agent Inbox initially tried to develop their product internally, but ran into obstacles with the project's complexity.
+
+After a year attempting to develop a MVP internally, Agent Inbox struggled to deliver a market-ready solution and realized the platform would need to be rebuilt from scratch.
+
+# Solution
+
+## Fractional CTO Support
+
+JetThoughts provided **an experienced CTO resource** to help Agent Inbox set strategy, organize plans, and guide the project to success.
+
+## Full-time Engineers for Development
+
+JetThoughts provided **5 full-time engineers** to act as Agent Inbox's development team and support their development initiatives.
+
+## Dedicated Project Advisor
+
+In addition, we provided **a dedicated project advisor** to bring **real-time visibility** into progress and ensure alignment with the leadership team at Agent Inbox.
+
+# Approach
+
+**From the very beginning of the engagement, JetThoughts provided Agent Inbox's team with deep technical guidance based on decades of experience to help ensure a successful outcome.**
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Agent Inbox to monitor budget & maximize the value delivered by our engineers.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that Agent Inbox faced.
+
+# Outcome
+
+# Testimonials
+
+> 
+
+> \
+> \
+> \
+> paul@jetthoughts.com\
+> +1 754 216 9568\
+> \
+> \
+> [][15]‬ [][17]
+>
+> **www.jetthoughts.com**
+
+  [15]: https://de.linkedin.com/in/paul-keen
+
+  [17]: https://twitter.com/pftg?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor

--- a/docs/projects/2609-sales-collateral/editable-versions-campsyte-case-study.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-campsyte-case-study.md
@@ -1,0 +1,74 @@
+# Campsyte - Case Study
+
+CASE STUDY
+
+See How JetThoughts Helped Campsyte Salvage a Stalled Software Project & Go From Zero to Revenue with a Competitive Product
+
+# Technologies
+
+Tech stack or code bases that are implemented on the project comprise:
+
+# Client Overview
+
+Campsyte is a startup building a mobile application to help users find, book and access unique outdoor space for social experiences.
+
+They initially reached out to JetThoughts to help:
+
+- Salvage their software project and make their product idea a reality.
+
+# Vision
+
+Campsyte envisioned replacing their current development resource with a top-caliber engineering partner to **recover their software project** & launch a compelling product.
+
+In addition, Campsyte desired a partner that could understand the product's architecture and **optimize the quality of their final software**.
+
+# Problem
+
+Campsyte had initially tried to develop the product with a different engineering team, but it was ultimately unsuccessful and the team was unable to complete the project.
+
+Due to a lack of technical expertise & product leadership, Campsyte's project stalled out and became stuck with no usable product and no clear idea about how to build it.
+
+# Solution
+
+## Fractional CTO Support
+
+JetThoughts provided **an experienced CTO resource** to help Campsyte set strategy, organize plans, and guide the project to success.
+
+## Senior Software Architect for Development
+
+JetThoughts provided **1 senior-level full-time engineer** to act as Campsyte's development team and support their development initiatives.
+
+## Dedicated Project Advisor
+
+In addition, we provided **a dedicated project advisor** to bring **real-time visibility** into progress and ensure alignment with the leadership team at Campsyte.
+
+# Approach
+
+**From the very beginning of the engagement, JetThoughts provided Campsyte's team with deep technical guidance based on decades of experience to help ensure a successful outcome.**
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Campsyte to monitor budget & maximize the value delivered by our engineers.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that Campsyte faced.
+
+# Outcome
+
+# Testimonials
+
+> 
+
+> \
+> \
+> \
+> paul@jetthoughts.com\
+> +1 754 216 9568\
+> \
+> \
+> [][16]‬ [][18]
+>
+> **www.jetthoughts.com**
+
+  [16]: https://de.linkedin.com/in/paul-keen
+
+  [18]: https://twitter.com/pftg?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor

--- a/docs/projects/2609-sales-collateral/editable-versions-consultation-getting-started.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-consultation-getting-started.md
@@ -1,0 +1,29 @@
+# Consultation - Getting Started
+
+## COLLABORATE WITH US
+
+# Free Consultation Guide
+
+  --------------------------------------------------------------------
+  Phase                                          Timeline
+  ---------------------------------------------- ---------------------
+  Initial Discovery                              Day 1
+
+  Requirements & Alignment                       Day 1
+
+  Recommendations & Advice                       Day 3 - 4
+
+  Scoping Project Proposal                       Day 5 - 8
+
+  Feedback & Next Steps                          Day 9 - 10
+  --------------------------------------------------------------------
+
+We first need to understand your situation. Discovery usually requires a 60-minute introductory meeting to get caught up on your situation, identify your priorities, & understand any unique technical challenges you're facing.
+
+Once we gain visibility into your situation and better understand your objectives, the next step is to align around the specific requirements, project scope, expectations, and budget you have in mind.
+
+We then reconnect on a follow-up call to share insights, offer advice, and discuss the needs of your project further. In addition, we can offer industry best practices on scoping, resource planning, cost optimization, & technical design for your project.
+
+If there is interest in exploring an engagement, then we recommend starting with a small scoping project to define a clear path to success. We will share a proposal that outlines the initial scoping engagement & summarizes the deliverables we'll provide.
+
+Once shared, we ask for a follow-up call to review the proposal together, get feedback, and align around next steps. In exchange for feedback, we can provide further details to help ensure alignment around the project scoping process.

--- a/docs/projects/2609-sales-collateral/editable-versions-corsis-case-study.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-corsis-case-study.md
@@ -1,0 +1,74 @@
+# Corsis - Case Study
+
+CASE STUDY
+
+See How JetThoughts Helped Corsis Transform a Legacy Software Project & Gain Control Over a Complex Codebase
+
+# Technologies
+
+Tech stack or code bases that are implemented on the project comprise:
+
+# Client Overview
+
+Corsis is a technology advisory services firm that include consultant-led, self-administered evaluations of a company's adherence to industry best practices.
+
+They initially reached out to JetThoughts to help:
+
+- Take over responsibility for ongoing architecture and development for a proprietary software in need of a technical owner.
+
+# Vision
+
+Corsis envisioned a transformation of their software project from a complex legacy codebase in need of improvements to a high-quality product that's easier to support.
+
+In addition, Corsis knew they were in need of more **experienced technical resources** and desired to **evolve their internal development processes** to meet industry best practices.
+
+# Problem
+
+After the original developer of this software moved on, Corsis had to assign new development resources to replace the creator and continue the project without any considerable disruptions.
+
+With little documentation for a legacy codebase with many redundancies, Corsis quickly realized that the junior developers they assigned to the project weren't equipped to handle the situation.
+
+# Solution
+
+## Fractional CTO Support
+
+JetThoughts provided **an experienced CTO resource** to help Corsis set strategy, organize plans, and guide the project to success.
+
+## Senior Software Architect for Development
+
+JetThoughts provided **1 senior-level full-time engineer** to act as Corsis' development team and support their development initiatives.
+
+## Dedicated Project Advisor
+
+In addition, we provided **a dedicated project advisor** to bring **real-time visibility** into progress and ensure alignment with the leadership team at Corsis.
+
+# Approach
+
+**From the very beginning of the engagement, JetThoughts provided Corsis' team with deep technical guidance based on decades of experience to help ensure a successful outcome.**
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Corsis to monitor budget & maximize the value delivered by our engineers.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that Corsis faced.
+
+# Outcome
+
+# Testimonials
+
+> 
+
+> \
+> \
+> \
+> paul@jetthoughts.com\
+> +1 754 216 9568\
+> \
+> \
+> [][15]‬ [][17]
+>
+> **www.jetthoughts.com**
+
+  [15]: https://de.linkedin.com/in/paul-keen
+
+  [17]: https://twitter.com/pftg?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor

--- a/docs/projects/2609-sales-collateral/editable-versions-credit-glory-case-study.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-credit-glory-case-study.md
@@ -1,0 +1,76 @@
+# Credit Glory - Case Study
+
+CASE STUDY
+
+See How JetThoughts Helped Credit Glory Accelerate Feature Development & Scale Engineering Operations
+
+# Technologies
+
+Tech stack or code bases that are implemented on the project comprise:
+
+# Client Overview
+
+Credit Glory is a consumer financial services company that provides credit repair services to help customers fix their credit and improve their financial situation.
+
+They initially reached out to JetThoughts to help:
+
+- Scale up their development team's capacity so they could develop features faster while maintaining best practices and code quality.
+
+# Vision
+
+Credit Glory envisioned scaling their development efforts while maintaining quality so they could outcompete in the marketplace and keep pace with the growth of their customer base.
+
+Their goals for the collaboration with JetThoughts was to **improve the technical capabilities** of their engineering team while **achieving better quality, more stability, and faster development**.
+
+# Problem
+
+While Credit Glory's software provided a good user experience, they decided it was time to upgrade their existing front-end and migrate over to a better tech stack.
+
+Unfortunately, much of their codebase was incredibly complex and driven by the intimate business knowledge that the leadership possessed about their industry.
+
+In addition, their user experience & functionality relied heavily on specific integrations with key technology partners.
+
+# Solution
+
+## Fractional CTO Support
+
+JetThoughts provided **an experienced CTO resource** to help Credit Glory set strategy, organize plans, and guide the project to success.
+
+## Full-time Engineers for Development
+
+JetThoughts provided **2 full-time engineers** to act as Credit Glory's development team and support their development initiatives.
+
+## Dedicated Project Advisor
+
+In addition, we provided **a dedicated project advisor** to bring **real-time visibility** into progress and ensure alignment with the leadership team at Credit Glory.
+
+# Approach
+
+**From the very beginning of the engagement, JetThoughts provided Credit Glory's team with deep technical guidance based on decades of experience to help ensure a successful outcome.**
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Credit Glory to monitor budget & maximize the value delivered by our engineers.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that Credit Glory faced.
+
+# Outcome
+
+# Testimonials
+
+> 
+
+> \
+> \
+> \
+> paul@jetthoughts.com\
+> +1 754 216 9568\
+> \
+> \
+> [][14]‬ [][16]
+>
+> **www.jetthoughts.com**
+
+  [14]: https://de.linkedin.com/in/paul-keen
+
+  [16]: https://twitter.com/pftg?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor

--- a/docs/projects/2609-sales-collateral/editable-versions-custom-development-service-2-pager.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-custom-development-service-2-pager.md
@@ -1,0 +1,41 @@
+# Custom Development - Service 2-Pager
+
+## HOW IT WORKS
+
+# Custom Software Development
+
+JetThoughts provides on-demand access to a team of pre-trained developers to help companies build high-quality technology at a fraction of the costs. As a fully-managed service, we can handle everything from research, scoping, & roadmap planning to product development, testing, & post-launch maintenance.
+
+  --------------------------------------------------------------------
+  Phase                                          Timeline
+  ---------------------------------------------- ---------------------
+  Discovery                                      1 - 2 Days
+
+  Scoping                                        3 - 5 Days
+
+  Strategy                                       2 - 4 Weeks
+
+  Onboarding                                     1 - 2 Weeks
+
+  Support                                        Ongoing
+  --------------------------------------------------------------------
+
+We first need to get a clear understanding of your situation. The goal is to understand your key business objectives and use that information to fine-tune our recommendations for a successful engagement.
+
+Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your project, identify your priorities, and understand any unique technical requirements.
+
+Once we get context on your situation, we do any necessary research, due diligence, and technical brainstorming to help create recommendations for a clear scope that aligns with your unique needs.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+We combine fractional CTO, UX/UI, product, & project management resources to conceptualize, design, plan, & outline a clear roadmap that can deliver a successful outcome for your project on-budget & on-time.
+
+At the end of this phase, we provide a detailed product strategy, Scope of Work (SOW), and set of milestones to keep track of our progress towards achieving your objectives.
+
+Once ready, we onboard the best engineering & technical resources available for the given scope of your project. From there, we integrate into your operations & begin delivering on our roadmap.
+
+Throughout the onboarding process, we will assist your team every step of the way to ensure a smooth launch from the very beginning.
+
+JetThoughts will act as a virtual extension of your team, helping to increase visibility, empower collaboration, and accelerate progress.
+
+A dedicated account manager and project manager will be provided to support communication, alignment, and efficiency throughout the entire engagement.

--- a/docs/projects/2609-sales-collateral/editable-versions-fractional-cpo-service-2-pager.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-fractional-cpo-service-2-pager.md
@@ -1,0 +1,41 @@
+# Fractional CPO - Service 2-Pager
+
+## HOW IT WORKS
+
+# Fractional Chief Product Officer
+
+JetThoughts provides on-demand access to product management leadership on a fractional, part-time, or full-time basis to help companies of any size accelerate development & improve user experiences. From roadmap planning & UX research to project & cycle management, we can provide the support needed to deliver better, faster technology outcomes.
+
+  --------------------------------------------------------------------
+  Phase                                          Timeline
+  ---------------------------------------------- ---------------------
+  Discovery                                      1 - 2 Days
+
+  Scoping                                        2 - 3 Days
+
+  Placement                                      2 - 4 Weeks
+
+  Onboarding                                     1 - 2 Weeks
+
+  Support                                        Ongoing
+  --------------------------------------------------------------------
+
+We first need to get a clear understanding of your situation. The goal is to understand your key business objectives and use that information to fine-tune our recommendations for the engagement.
+
+Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your technology operations, identify your priorities, and understand any unique requirements.
+
+Once we get context on your situation, we do any necessary research, due diligence, and technical brainstorming to help create recommendations for a clear scope that aligns with your unique needs.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+Once we're aligned around scope, we conduct a thorough search within our organization, talent pipeline, and general network to identify the best fractional CPO placement for your specific situation & budget.
+
+We use a proprietary recruiting & vetting process to find top-tier CPO talent that's optimized to the skill sets and technical experience you need.
+
+As soon as we come to an agreement about your placement, we begin the onboarding process & help facilitate every step of the way to ensure success at the very beginning.
+
+During the onboarding phase, our team works with the fractional CPO to bring them fully up to speed on your company and assists in any needed preparations to deliver a smooth launch.
+
+Even after a successful launch of your fractional CPO, JetThoughts continues to support the engagement & acts as a virtual extension of your team.
+
+We provide a dedicated account manager & project manager to help support alignment, communication, and efficiency throughout the entire engagement.

--- a/docs/projects/2609-sales-collateral/editable-versions-free-trial-getting-started.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-free-trial-getting-started.md
@@ -1,0 +1,29 @@
+# Free Trial - Getting Started
+
+## COLLABORATE WITH US
+
+# 2-Week Staffing Trial Guide
+
+  --------------------------------------------------------------------
+  Phase                                          Timeline
+  ---------------------------------------------- ---------------------
+  Kick-Off Call                                  1 - 2 Days
+
+  Recruiting & Placement                         1 - 2 Weeks
+
+  Training & Onboarding                          1 - 2 Weeks
+
+  Launch Free Trial                              2 Weeks
+
+  Feedback & Next Steps                          1 - 2 Days
+  --------------------------------------------------------------------
+
+We first setup a kick-off call to review the project and ensure alignment around scope, objectives, and deliverables. To finish the kick-off call, we'll overview the onboarding process & outline the immediate next steps required to get started with the free trial.
+
+Once we're aligned around scope, we conduct a thorough search within our organization, talent pipeline, and general network to identify the best developer resources for your specific situation & budget.
+
+Once aligned around the right developers, we use a robust proprietary training process to get them up to speed and ready to deliver value for your team as quickly as possible.
+
+From there, we onboard your new staff & assist your team every step of the way to ensure a smooth launch from the very beginning. Our team will act as a virtual extension of your team & provide support throughout the engagement.
+
+Before the trial ends, we ask for a call to get feedback and identify whether it makes sense to continue beyond the trial. In exchange for feedback, we provide recommendations to optimize your technology operations.

--- a/docs/projects/2609-sales-collateral/editable-versions-limeleads-case-study.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-limeleads-case-study.md
@@ -1,0 +1,72 @@
+# LimeLeads - Case Study
+
+CASE STUDY
+
+See How JetThoughts Helped LimeLeads Transform a Legacy Codebase & Stabilize the Product for Long-Term Performance
+
+# Technologies
+
+Tech stack or code bases that are implemented on the project comprise:
+
+# Client Overview
+
+LimeLeads is a searchable B2B database software that provides access to high-quality sales & marketing data with a do-it-yourself user experience and real-time validation.
+
+They initially reached out to JetThoughts to help:
+
+- Augment their on-site product development team to help increase the velocity of feature development and bug-fixing at minimal financial cost.
+
+# Vision
+
+LimeLeads envisioned a complete transformation of their software product, which was built on an out-of-date codebase years ago by the original founder.
+
+In addition to the development initiative, LimeLeads also desired to **optimize their technology operations and development processes** to be more effective.
+
+# Problem
+
+The codebase at LimeLeads had been touched by several people and service vendors, which made it difficult to understand, navigate, and maintain without a dedicated specialist.
+
+# Solution
+
+## Fractional CTO Support
+
+JetThoughts provided **an experienced CTO resource** to help LimeLeads set strategy, organize plans, and guide the project to success.
+
+## Full-time Engineers for Development
+
+JetThoughts provided **1 full-time engineer** to act as LimeLeads' development team and support their development initiatives.
+
+## Dedicated Project Advisor
+
+In addition, we provided **a dedicated project advisor** to bring **real-time visibility** into progress and ensure alignment with the leadership team at LimeLeads.
+
+# Approach
+
+**From the very beginning of the engagement, JetThoughts provided LimeLeads' team with deep technical guidance based on decades of experience to help ensure a successful outcome.**
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled LimeLeads to monitor budget & maximize the value delivered by our engineers.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that LimeLeads faced.
+
+# Outcome
+
+# Testimonials
+
+> 
+
+> \
+> \
+> \
+> paul@jetthoughts.com\
+> +1 754 216 9568\
+> \
+> \
+> [][16]‬ [][18]
+>
+> **www.jetthoughts.com**
+
+  [16]: https://de.linkedin.com/in/paul-keen
+
+  [18]: https://twitter.com/pftg?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor

--- a/docs/projects/2609-sales-collateral/editable-versions-mobile-coach-case-study.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-mobile-coach-case-study.md
@@ -1,0 +1,78 @@
+# Mobile Coach - Case Study
+
+CASE STUDY
+
+See How JetThoughts Helped Mobile Coach Launch a Game-Changing Product Feature & Scale Their Development Team
+
+# Technologies
+
+Tech stack or code bases that are implemented on the project comprise:
+
+# Client Overview
+
+Mobile Coach is a chatbot platform that's trying to change how enterprises influence employee engagement, learning, customer service, sales performance, and overall behavior change.
+
+They initially reached out to JetThoughts to help:
+
+- Support and build new features for a group of internal products related to the chatbot platform while eventually helping to scale their R&D team.
+
+# Vision
+
+Mobile Coach envisioned an enterprise-level authoring platform which would allow larger customers to:
+
+- **Set up complicated chatbot workflows with multiple channels**
+
+- **Multi-language compatibility**, and
+
+- **Seamless back-office integrations**.
+
+In addition to the development initiative, Mobile Coach also desired to scale their team in terms of both **development manpower** and **R&D expertise**.
+
+# Problem
+
+While Mobile Coach had reliable and skilled people internally to help develop this feature, they understood that this enterprise-level feature was a big project.
+
+# Solution
+
+## Fractional CTO Support
+
+JetThoughts provided **an experienced CTO resource** to help Mobile Coach set strategy, organize plans, and guide the project to success.
+
+## Full-time Engineers for Development
+
+JetThoughts provided **4 full-time engineers** to act as Mobile Coach's development team and support their development initiatives.
+
+## Dedicated Project Advisor
+
+In addition, we provided **a dedicated project advisor** to bring **real-time visibility** into progress and ensure alignment with the leadership team at Mobile Coach.
+
+# Approach
+
+**From the very beginning of the engagement, JetThoughts provided Mobile Coach's team with deep technical guidance based on decades of experience to help ensure a successful outcome.**
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Mobile Coach to monitor budget & maximize the value delivered by our engineers.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that Mobile Coach faced.
+
+# Outcome
+
+# Testimonials
+
+> 
+
+> \
+> \
+> \
+> paul@jetthoughts.com\
+> +1 754 216 9568\
+> \
+> \
+> [][16]‬ [][18]
+>
+> **www.jetthoughts.com**
+
+  [16]: https://de.linkedin.com/in/paul-keen
+
+  [18]: https://twitter.com/pftg?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor

--- a/docs/projects/2609-sales-collateral/editable-versions-mvp-development-service-2-pager.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-mvp-development-service-2-pager.md
@@ -1,0 +1,41 @@
+# MVP Development - Service 2-Pager
+
+## HOW IT WORKS
+
+# Startup MVP Software Development
+
+With more than a decade of experience in the software startup world, JetThoughts understands the critical steps that early-stage startups need to take to validate their business idea and go-to-market in a cost-efficient way. We can provide the technical expertise, product vision, and engineering manpower to make any software product a reality.
+
+  --------------------------------------------------------------------
+  Phase                                          Timeline
+  ---------------------------------------------- ---------------------
+  Discovery                                      1 - 2 Days
+
+  Scoping                                        3 - 5 Days
+
+  Strategy                                       2 - 4 Weeks
+
+  Onboarding                                     1 - 2 Weeks
+
+  Support                                        Ongoing
+  --------------------------------------------------------------------
+
+We first need to get a clear understanding of your situation. The goal is to understand your key business objectives and use that information to fine-tune our recommendations for a successful MVP launch.
+
+Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your project, identify your priorities, and understand any unique technical requirements.
+
+Once we get context on your situation, we do any necessary research, due diligence, and technical brainstorming to help create recommendations for a clear scope that aligns with your unique needs.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+We combine fractional CTO, UX/UI, product, & project management resources to conceptualize, design, plan, & outline a clear roadmap that can deliver a successful MVP launch while staying on-budget & on-time.
+
+At the end of this phase, we provide a detailed product strategy & Proof-of-Concept (POC) to ensure we're aligned around design, user experience, and overall MVP functionality.
+
+Once ready, we onboard the best engineering & technical resources available for the given scope of your project. From there, we integrate into your operations & begin building right away.
+
+Throughout the onboarding process, we will assist your team every step of the way to ensure a smooth launch from the very beginning.
+
+JetThoughts will act as a virtual extension of your team, helping to increase visibility, empower collaboration, and accelerate progress.
+
+A dedicated account manager and project manager will be provided to support communication, alignment, and efficiency throughout the entire engagement.

--- a/docs/projects/2609-sales-collateral/editable-versions-onboarding-getting-started.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-onboarding-getting-started.md
@@ -1,0 +1,29 @@
+# Onboarding - Getting Started
+
+## COLLABORATE WITH US
+
+# Kick-Off & Onboarding Guide
+
+  --------------------------------------------------------------------
+  Phase                                          Timeline
+  ---------------------------------------------- ---------------------
+  Finalize Strategy                              1 - 2 Weeks
+
+  Kick-Off Call                                  1 - 2 Days
+
+  Recruiting & Placement                         1 - 2 Weeks
+
+  Training & Onboarding                          2 - 4 Weeks
+
+  Launch Project                                 1 - 2 Days
+  --------------------------------------------------------------------
+
+Before getting started, we'll provide a proposal that outlines the scope, strategy, and deliverables for the project to ensure we have clear alignment around key goals, timelines, and budget expectations.
+
+From there, we setup a kick-off call to summarize the project strategy, review the onboarding process, and outline the immediate next steps required to get started.
+
+Once aligned, we conduct a thorough search within our organization, talent pipeline, and general network using a proprietary recruiting & vetting process to identify the best developer resources for your specific situation & budget.
+
+Once aligned, we begin onboarding the engineering resources selected for your project. Throughout the process, we will assist your team every step of the way to ensure launch is as smooth as possible.
+
+Finally, we onboard your engineering resources & assist your team every step of the way to ensure a smooth project launch. Our team will act as a virtual extension of your team & provide support throughout the entire engagement.

--- a/docs/projects/2609-sales-collateral/editable-versions-open-apply-case-study.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-open-apply-case-study.md
@@ -1,0 +1,80 @@
+# Open Apply - Case Study
+
+CASE STUDY
+
+See How JetThoughts Helped Stabilize Open Apply's Code & Transform Their Product's UX
+
+# Technologies
+
+Tech stack or code bases that are implemented on the project comprise:
+
+# Client Overview
+
+OpenApply is a fast-growing software platform to help simplify the admissions and enrollment processes for applicants around the world with a paperless, integrated online experience.
+
+They initially reached out to JetThoughts to help:
+
+- Stop regressions, revamp the user experience, scale feature development, and streamline internal development processes
+
+# Vision
+
+Open Apply envisioned an upgrade of their technology operations from end-to-end: fewer bugs, better UX/UI, faster development, and higher-quality releases..
+
+- **Fewer bugs**
+
+- **Better UX/UI**
+
+- **Faster development,** and
+
+- **Higher-quality releases**.
+
+Because Open Apply was growing so quickly, they needed to level up both their software and their **internal processes** in order to **maintain momentum**.
+
+# Problem
+
+Open Apply's initial launch was a huge success and customers grew rapidly.
+
+However, their product wasn't designed to properly address the level of scale they had already reached.
+
+# Solution
+
+## Fractional CTO Support
+
+JetThoughts provided **an experienced CTO resource** to help Open Apply set strategy, organize plans, and guide the project to success.
+
+## Full-time Engineers for Development
+
+JetThoughts provided **2 full-time engineers** to act as Open Apply's development team and support their development initiatives.
+
+## Dedicated Project Advisor
+
+In addition, we provided **a dedicated project advisor** to bring **real-time visibility** into progress and ensure alignment with the leadership team at Open Apply.
+
+# Approach
+
+**From the very beginning of the engagement, JetThoughts provided Open Apply's team with deep technical guidance based on decades of experience to help ensure a successful outcome.**
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Open Apply to monitor budget & maximize the value delivered by our engineers.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that Open Apply faced.
+
+# Outcome
+
+> 
+
+> \
+> \
+> \
+> paul@jetthoughts.com\
+> +1 754 216 9568\
+> \
+> \
+> [][14]‬ [][16]
+>
+> **www.jetthoughts.com**
+
+  [14]: https://de.linkedin.com/in/paul-keen
+
+  [16]: https://twitter.com/pftg?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor

--- a/docs/projects/2609-sales-collateral/editable-versions-orchestratecs-case-study.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-orchestratecs-case-study.md
@@ -1,0 +1,72 @@
+# OrchestrateCS - Case Study
+
+CASE STUDY
+
+See How JetThoughts Helped OrchestrateCS Go From an Idea to Software in Just 60 Days
+
+# Technologies
+
+Tech stack or code bases that are implemented on the project comprise:
+
+# Client Overview
+
+OrchestrateCS is a startup building software to help unify, simplify, and standardize both people and compliance operations.
+
+They initially reached out to JetThoughts to help:
+
+- Go from zero to revenue and go-to-market as soon as possible by making their first product idea a reality.
+
+# Vision
+
+OrchestrateCS envisioned a new software idea from scratch to pursue a new business opportunity that had emerged in their industry.
+
+Given the time-sensitive nature of this project, OrchestrateCS desired to develop a **Minimal Viable Product (MVP)** and go-to-market **as quickly as possible.**
+
+# Problem
+
+OrchestrateCS was driven by a group of business executives and growth experts. However, they lacked the technical knowledge & talent to make their software idea a reality.
+
+Because of the hasty timeline for delivering the MVP, OrchestrateCS knew it would be unrealistic to build any worthwhile development team internally.
+
+# Solution
+
+## Fractional CTO Support
+
+JetThoughts provided **an experienced CTO resource** to help OrchestrateCS set strategy, organize plans, and guide the project to success.
+
+## Full-time Engineers for Development
+
+JetThoughts provided **2 full-time engineers** to act as OrchestrateCS's development team and support their development initiatives.
+
+## Dedicated Project Advisor
+
+In addition, we provided **a dedicated project advisor** to bring **real-time visibility** into progress and ensure alignment with the leadership team at OrchestrateCS.
+
+# Approach
+
+**From the very beginning of the engagement, JetThoughts provided OrchestrateCS's team with deep technical guidance based on decades of experience to help ensure a successful outcome.**
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled OrchestrateCS to monitor budget & maximize the value delivered by our engineers.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that OrchestrateCS faced.
+
+# Outcome
+
+> 
+
+> \
+> \
+> \
+> paul@jetthoughts.com\
+> +1 754 216 9568\
+> \
+> \
+> [][14]‬ [][16]
+>
+> **www.jetthoughts.com**
+
+  [14]: https://de.linkedin.com/in/paul-keen
+
+  [16]: https://twitter.com/pftg?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor

--- a/docs/projects/2609-sales-collateral/editable-versions-recruiting-service-2-pager.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-recruiting-service-2-pager.md
@@ -1,0 +1,41 @@
+# Recruiting - Service 2-Pager
+
+## HOW IT WORKS
+
+# Developer Talent Recruiting
+
+JetThoughts provides on-demand access to a talent network of pre-vetted developers to help companies build a high-caliber software development team faster and at a fraction of the costs. As a fully-managed recruiting service, we can handle everything from researching and vetting candidates to interviewing, evaluating, and ranking developer talent.
+
+  --------------------------------------------------------------------
+  Phase                                          Timeline
+  ---------------------------------------------- ---------------------
+  Discovery                                      1 - 2 Days
+
+  Scoping                                        3 - 5 Days
+
+  Recruiting                                     1 - 2 Weeks
+
+  Placement                                      1 - 2 Weeks
+
+  Onboarding                                     1 - 2 Weeks
+  --------------------------------------------------------------------
+
+We first need to get a clear understanding of your situation. The goal is to understand your key business objectives and use that information to fine-tune our recommendations for the engagement.
+
+Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your technology operations, identify your priorities, and understand any unique requirements.
+
+Once we get context on your situation, we do any necessary research, due diligence, and technical brainstorming to help create recommendations for a clear scope that aligns with your unique needs.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+Once we're aligned around scope, we conduct a thorough search within our global talent network that's been developed over 20+ years in the space to find the best developers for your specific situation & budget.
+
+In addition, we deploy proprietary filtering & qualification processes that we use to optimize talent pools for the most skilled and driven developers available.
+
+We use a proprietary two-stage interviewing & vetting process to find top-tier engineering talent that's optimized to the skill sets and technical experience you need.
+
+Upon narrowing the candidates down to the top choices, we provide our recommendations and help assist you in making the best hiring decision for your organization.
+
+Once we've found the right developers for your project, we begin the process of acquiring these engineering resources for your team as soon as possible.
+
+In addition, our team is available to help integrate your new developers into your operations or assist in any needed preparations to ensure a smooth transition from hire to team member.

--- a/docs/projects/2609-sales-collateral/editable-versions-scoping-getting-started.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-scoping-getting-started.md
@@ -1,0 +1,29 @@
+# Scoping - Getting Started
+
+## COLLABORATE WITH US
+
+# Scoping & Planning Guide
+
+  --------------------------------------------------------------------
+  Phase                                          Timeline
+  ---------------------------------------------- ---------------------
+  Discovery Consultation                         1 - 2 Days
+
+  Research & Analysis                            2 - 3 Days
+
+  Recommendations & Scoping                      2 - 3 Days
+
+  Project Design & Planning                      1 - 2 Weeks
+
+  Strategy & Proposal                            1 - 2 Weeks
+  --------------------------------------------------------------------
+
+We first need to get a clear understanding of your situation. Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your situation, identify your priorities, and understand any unique technical requirements you have.
+
+Once we get context on your situation, we do any necessary research, due diligence, and technical brainstorming to help create recommendations for a clear scope that aligns with your unique needs.
+
+After the research phase, we setup a 60-minute meeting to discuss the technical implications of your project, identify any major technical challenges, and offer our recommendations.
+
+We combine fractional CTO, UX/UI, product, & project management resources to conceptualize, design, plan, & outline a clear roadmap that can deliver a successful outcome for your project on-budget & on-time.
+
+Finally, we provide a proposal that outlines the scope, strategy, and deliverables for your project. Once shared, we ask for a follow-up call to review the proposal together, get feedback on the strategy, and align around next steps.

--- a/docs/projects/2609-sales-collateral/editable-versions-staffing-service-2-pager.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-staffing-service-2-pager.md
@@ -1,0 +1,41 @@
+# Staffing - Service 2-Pager
+
+## HOW IT WORKS
+
+# Outsourced Developer Staffing
+
+With more than a decade of experience in the software startup world, JetThoughts understands the critical steps that early-stage startups need to take to validate their business idea and go-to-market in a cost-efficient way. We can provide the technical expertise, product vision, and engineering manpower to make any software product a reality.
+
+  --------------------------------------------------------------------
+  Phase                                          Timeline
+  ---------------------------------------------- ---------------------
+  Discovery                                      1 - 2 Days
+
+  Scoping                                        3 - 5 Days
+
+  Placement                                      1 - 2 Weeks
+
+  Onboarding                                     2 - 4 Weeks
+
+  Support                                        Ongoing
+  --------------------------------------------------------------------
+
+We first need to get a clear understanding of your situation. The goal is to understand your key business objectives and use that information to fine-tune our recommendations for the engagement.
+
+Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your technology operations, identify your priorities, and understand any unique requirements.
+
+Once we get context on your situation, we do any necessary research, due diligence, and technical brainstorming to help create recommendations for a clear scope that aligns with your unique needs.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+Once we're aligned around scope, we conduct a thorough search within our organization, talent pipeline, and general network to identify the best developer resources for your specific situation & budget.
+
+We use a proprietary recruiting & vetting process to find top-tier engineering talent that's optimized to the skill sets and technical experience you need.
+
+Once aligned around the right developers, we use a robust proprietary training process to get them up to speed and ready to deliver value for your team as quickly as possible.
+
+From there, we begin the onboarding process & assist your team every step of the way to ensure a smooth launch from the very beginning.
+
+Once your outsourced staff is successfully launched, JetThoughts continues to support the engagement & acts as a virtual extension of your team.
+
+We provide a dedicated account manager & project manager to help support alignment, communication, and efficiency throughout the entire engagement.

--- a/docs/projects/2609-sales-collateral/editable-versions-testing-service-2-pager.md
+++ b/docs/projects/2609-sales-collateral/editable-versions-testing-service-2-pager.md
@@ -1,0 +1,41 @@
+# Testing - Service 2-Pager
+
+## HOW IT WORKS
+
+# Fully-Managed Software QA & Testing Automation
+
+JetThoughts provides on-demand access to a team of pre-trained product testing experts to help companies build faster and worry less about costly mistakes. As a fully-managed service, we can handle everything from setting up testing automation and QA processes to troubleshooting potential issues.
+
+  --------------------------------------------------------------------
+  Phase                                          Timeline
+  ---------------------------------------------- ---------------------
+  Discovery                                      1 - 2 Days
+
+  Scoping                                        3 - 5 Days
+
+  Placement                                      1 - 2 Weeks
+
+  Onboarding                                     1 - 2 Weeks
+
+  Support                                        Ongoing
+  --------------------------------------------------------------------
+
+We first need to get a clear understanding of your situation. The goal is to understand your key business objectives and use that information to fine-tune our recommendations for the engagement.
+
+Discovery usually requires a 60-minute introductory meeting to get caught up on the state of your technology operations, identify your priorities, and understand any unique requirements.
+
+Once we get context on your situation, we do any necessary research, due diligence, and technical brainstorming to help create recommendations for a clear scope that aligns with your unique needs.
+
+Scoping usually requires a 60-minute meeting to discuss project complexity, identify any major technical challenges, and align around a game plan for the engagement.
+
+Once we're aligned around scope, we conduct a thorough search within our organization, talent pipeline, and general network to identify the best developer resources for your specific situation & budget.
+
+We use a proprietary recruiting & vetting process to find top-tier engineering talent that's optimized to the skill sets and technical experience you need.
+
+Once aligned around the right developers, we use a robust proprietary training process to get them up to speed and ready to deliver value for your team as quickly as possible.
+
+From there, we begin the onboarding process & assist your team every step of the way to ensure a smooth launch from the very beginning.
+
+JetThoughts will act as a virtual extension of your team, helping to increase visibility, empower collaboration, and accelerate progress.
+
+A dedicated account manager and project manager will be provided to support communication, alignment, and efficiency throughout the entire engagement.

--- a/docs/projects/2609-sales-collateral/templates-jetthoughts-pricing-plan.md
+++ b/docs/projects/2609-sales-collateral/templates-jetthoughts-pricing-plan.md
@@ -1,0 +1,34 @@
+# JetThoughts Pricing Plan
+
+## PRICING & PLANS
+
+# Stable Development Onboarding
+
+![fractional-cto.png]
+
+### Service Element #1
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam dolor sit consectetur adipiscing elit.
+
+### ![app-web-development.png]
+
+### Service Element #2
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam dolor sit consectetur adipiscing elit.
+
+### ![software-qa-cat.png]
+
+### Service Element #3
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam dolor sit consectetur adipiscing elit.
+
+#### Contact Us 
+
+[+1 754 216 9568‬][] <paul@jetthoughts.com> [**www.jetthoughts.com**]
+
+  [fractional-cto.png]: media/image5.png {width="0.3541666666666667in" height="0.4479166666666667in"}
+  [app-web-development.png]: media/image6.png {width="0.3125in" height="0.4479166666666667in"}
+  [software-qa-cat.png]: media/image4.png {width="0.3906255468066492in" height="0.4479166666666667in"}
+
+  [+1 754 216 9568‬]: tel:17542169568%E2%80%AC
+  [**www.jetthoughts.com**]: http://www.jetthoughts.com

--- a/docs/projects/2609-sales-collateral/templates-jetthoughts-proposal-template.md
+++ b/docs/projects/2609-sales-collateral/templates-jetthoughts-proposal-template.md
@@ -1,0 +1,150 @@
+# JetThoughts Proposal Template
+
+Project Proposal
+
+Stable Development Onboarding\
+For RGB Company
+
+Prepared For:
+
+John Doe\
++1 234 5678 9012
+
+November 4^th^, 2022
+
+**www.jetthoughts.com**
+
+# Overview
+
+OrchestrateCS is pivoting into the EHS market and seeking to **launch a software product** in the next **6 months**.
+
+However, the complexity of this project and lack of technical team members are challenging obstacles that have blocked progress and made it difficult to scope.
+
+To develop a competitive software product in the EHS space quickly and cost-efficiently, OrchestrateCS needs **reliable access** to **technical expertise** and **engineering manpower**.
+
+# Goals
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+1.  **Create Alignment Around Project Scope, Requirements, & Estimations**
+
+- Lorem ipsum dolor sit amet, consectetur adipiscing elit.**\**
+
+2.  **Launch a Fully-Functional MVP & Deliver on the 2023 Product Roadmap**
+
+- Lorem ipsum dolor sit amet, consectetur adipiscing elit.**\**
+
+3.  **Accelerate Release Cycles & Improve Visibility into Development Processes**
+
+- Lorem ipsum dolor sit amet, consectetur adipiscing elit.**\**
+
+4.  **Optimize Product Performance & Security**
+
+- Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+# Solution
+
+To meet the needs outlined above, JetThoughts will \[SERVICE DESCRIPTION\].
+
+- Lorem ipsum dolor sit amet, consectetur adipiscing elit
+
+- Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+## Research & Scoping
+
+As a first step, JetThoughts will collaborate with the \[COMPANY\] team to better understand the situation, gather all necessary requirements, and align around any desired goals of the project.
+
+From there, our team will use this information to conduct extensive research to identify the project's complexity, key hurdles, and any other details to help inform scoping & estimations.
+
+Once the research and analysis phase is completed, JetThoughts will provide \[COMPANY\] with a detailed product strategy and technical recommendations to help make the project successful.
+
+In addition to recommendations, we will include estimates for the cost, resources, and timeline required based on the suggested scope.
+
+## Kick-Off & Onboarding
+
+Before kicking off the project, we will collaborate with \[COMPANY\] to align around a clear Scope of Work (SOW), timeline, and budget that can achieve the goals above at a reasonable cost.
+
+At this stage, JetThoughts will create a custom-built team that's personalized to the specific needs, demands, and structure of \[COMPANY\]'s organization.
+
+In addition, we will create any needed product documentation, Proof-of-Concepts (POCs), or UX/UI prototypes needed to support the success of \[COMPANY\]'s project.
+
+## Fully-Managed \[SERVICE\]
+
+\[DETAILED SERVICE DESCRIPTION\]
+
+To ensure continuous alignment with \[COMPANY\]'s culture, management style, and project management methodologies, JetThoughts will reserve the same team members that were onboarded for the project throughout the entire collaboration.
+
+## Dedicated Account & Project Management
+
+JetThoughts will act as a virtual extension of \[COMPANY\]'s team, assisting in day-to-day technical operations while providing clear visibility into the progress of the project.
+
+To ensure alignment, accountability, and adaptability throughout the collaboration, a dedicated account manager will be provided to help support \[COMPANY\].
+
+In addition, JetThoughts will assist in any needed product management, project management, or team management required to ensure a smooth collaboration between both organizations.
+
+## Monthly Documentation & Reporting
+
+To provide clear visibility into project operations, JetThoughts will maintain detailed documentation and activity logs throughout the collaboration.
+
+In addition, we will provide \[COMPANY\] with a comprehensive monthly report that highlights key achievements, emerging obstacles, and recommendations for the next month.
+
+# Timeline
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+  --------------------------------------------------------------------
+  **Phase**                                      **Timeline**
+  ---------------------------------------------- ---------------------
+  Research & Scoping                             2 Weeks
+
+  Kick-Off & Onboarding                          2 Weeks
+
+  Ramp-Up & Launch                               2 Weeks
+
+  **Total**                                      **8 Weeks**
+  --------------------------------------------------------------------
+
+**Note:**
+
+- Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+- Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+- Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+# Resources Needed
+
+JetThoughts will provide \[COMPANY\] with an Account Manager and \[SERVICE RESOURCES\] for up to \[HOURS\] hours per month of \[SERVICE DETAILS\].
+
+## Team Members & Services
+
+Retainer: \$X,XXX / Month (Additional Full-Time Developers: \$XXX / Month)
+
+  --------------------------------------------------------------------
+  **Item**                                       **Cost**
+  ---------------------------------------------- ---------------------
+  Account Manager (20 Hours / Month)             \$X,XXX / Mo
+
+  Technical Project Manager (40 Hours / Month)   \$X,XXX / Mo
+
+  x2 Full-Time Developers (320 Hours / Month)    \$X,XXX / Mo
+
+  **Total**                                      **\$XX,XXX / Mo**
+  --------------------------------------------------------------------
+
+# Conclusion
+
+To develop a competitive EHS software product quickly and cost-efficiently, OrchestrateCS needs technical expertise and engineering manpower to help ensure a successful outcome.
+
+Despite the challenges associated with the project's complexity, JetThoughts is uniquely positioned with the talent, expertise and development processes to help OrchestrateCS launch a high-quality software product in the next 6 months.
+
+> 
+>
+> Let's Collaborate.
+>
+> \
+> Paul Keen\
+> paul@jetthoughts.com\
+> +1 754 216 9568‬
+>
+> **www.jetthoughts.com**

--- a/docs/projects/2609-sales-collateral/templates-template-case-studies.md
+++ b/docs/projects/2609-sales-collateral/templates-template-case-studies.md
@@ -1,0 +1,74 @@
+# Template - Case Studies
+
+CASE STUDY
+
+See How JetThoughts Helped Mobile Coach Launch a Game-Changing Product Feature & Scale Their Development Team
+
+# Technologies
+
+Tech stack or code bases that are implemented on the project comprise:
+
+# Client Overview
+
+Mobile Coach is a chatbot platform that's trying to change how enterprises influence employee engagement, learning, customer service, sales performance, and overall behavior change.
+
+They initially reached out to JetThoughts to help:
+
+- Support and build new features for a group of internal products related to the chatbot platform while eventually helping to scale their R&D team.
+
+# Vision
+
+Mobile Coach envisioned an enterprise-level authoring platform which would allow larger customers to:
+
+- **Set up complicated chatbot workflows with multiple channels**
+
+- **Multi-language compatibility**, and
+
+- **Seamless back-office integrations**.
+
+In addition to the development initiative, Mobile Coach also desired to scale their team in terms of both **development manpower** and **R&D expertise**.
+
+# Problem
+
+While Mobile Coach had reliable and skilled people internally to help develop this feature, they understood that this enterprise-level feature was a big project.
+
+# Solution
+
+## Full-time Engineers for Development
+
+JetThoughts provided **4 full-time engineers** to act as Mobile Coach's development team and support their development initiatives.
+
+## Dedicated Project Advisor
+
+In addition, we provided **a dedicated project advisor** to bring **real-time visibility** into progress and ensure alignment with the leadership team at Mobile Coach.
+
+# Approach
+
+**From the very beginning of the engagement, JetThoughts provided Mobile Coach's team with deep technical guidance based on decades of experience to help ensure a successful outcome.**
+
+We started the project with a kick-off meeting where we set expectations for the engagement, learned about the software, and aligned around a winning strategy.
+
+To provide clarity into process & outcomes, we aligned around a simple development framework that enabled Mobile Coach to monitor budget & maximize the value delivered by our engineers.
+
+Throughout the entirety of the engagement, we kept the team composition flexible to the specific needs and circumstances that Mobile Coach faced.
+
+# Outcome
+
+# Testimonials
+
+> 
+
+> \
+> \
+> \
+> paul@jetthoughts.com\
+> +1 754 216 9568\
+> \
+> \
+> [][16]‬ [][18]
+>
+> **www.jetthoughts.com**
+
+  [16]: https://de.linkedin.com/in/paul-keen
+
+  [18]: https://twitter.com/pftg?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor

--- a/docs/projects/2609-sales-collateral/templates-template-getting-started.md
+++ b/docs/projects/2609-sales-collateral/templates-template-getting-started.md
@@ -1,0 +1,27 @@
+# Template - Getting Started
+
+## COLLABORATE WITH US
+
+# Getting Started Guide
+
+  --------------------------------------------------------------------
+  Phase                                          Timeline
+  ---------------------------------------------- ---------------------
+  Comprehensive Analysis                         1 Week
+
+  UX Design                                      4 Weeks
+
+  WordPress Development                          2 Weeks
+
+  Comprehensive Analysis                         1 Week
+
+  UX Design                                      4 Weeks
+
+  WordPress Development                          2 Weeks
+  --------------------------------------------------------------------
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/docs/projects/2609-sales-collateral/templates-template-services-overview.md
+++ b/docs/projects/2609-sales-collateral/templates-template-services-overview.md
@@ -1,0 +1,47 @@
+# Template - Services Overview
+
+## HOW IT WORKS
+
+# Stable Development Onboarding
+
+  --------------------------------------------------------------------
+  Phase                                          Timeline
+  ---------------------------------------------- ---------------------
+  Comprehensive Analysis                         1 Week
+
+  UX Design                                      4 Weeks
+
+  WordPress Development                          2 Weeks
+
+  Comprehensive Analysis                         1 Week
+
+  UX Design                                      4 Weeks
+
+  WordPress Development                          2 Weeks
+
+  Comprehensive Analysis                         1 Week
+  --------------------------------------------------------------------
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident.


### PR DESCRIPTION
Both untracked trees reviewed and committed rather than deleted. Docs + one symlink only; cannot affect the app build.

## `data/skills/lighthouse-verification`

A symlink, not a directory. It was the only one of **31** skill symlinks not tracked; the other 30 are all committed while their `.agents/skills/*` targets are gitignored (`.gitignore:177`). Tracking the link and not the target is the existing convention, so this was a straightforward omission. Staged as mode `120000`, verified it committed as a link rather than a copy.

## `docs/projects/2609-sales-collateral` — 43 files

Marketing collateral imported from Drive (2026-07-30) and relocated out of the PKM vault (2026-08-26). **Committed, not deleted:** real work product, `docs/projects/` already carries 313 tracked files, and `marketing_copy_test.rb` globs `content/**` so none of this can fail the canon ratchet.

**But not committed silently.** A warning was added to its README:

- **24 of 43 files** sell a fractional CTO, fractional CPO, tech-lead or engineering-manager engagement. `.okf/content/claims-canon.md` has banned those title claims on any new or v2 surface since 2026-08-21, on factual grounds rather than stylistic ones.
- Lifting from an outreach kit is the **documented route** by which that claim returns — `PRODUCT.md` and `docs/business/` have each re-introduced it before, and four of eight published figures were wrong on 2026-08-14 for the same reason.
- This repository is **public** and these documents name **eight clients** (Agent Inbox, CampSyte, Corsi, Credit Glory, LimeLeads, Mobile Coach, OpenApply, OrchestrateCS).
- These case studies never went through the fabrication sweep that purged invented client stories from 14 blog posts.

The README now states plainly that this is a historical record, not approved copy, and that title claims must be stripped before anything is reused on a live surface.

## Gates

- `bin/hugo-build` clean
- Docs + symlink only, no `content/`, template, CSS or body HTML — visual suites do not apply
- No CI wait per the content/docs-only rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg