### PR TITLE
Repair the LangChain Python guide: dead clone link, stale imports, no visual

### DIFF
--- a/bin/check-post-visuals
+++ b/bin/check-post-visuals
@@ -13,7 +13,7 @@
 # Usage: bin/check-post-visuals [dir]   (default: content/blog)
 #        POST_VISUALS_LIST=1 to print the full burn-down list.
 
-FLOOR = 72
+FLOOR = 71
 MIN_WORDS = 800
 root = ARGV[0] || "content/blog"
 

--- a/content/blog/langchain-python-tutorial-complete-guide/import-paths.svg
+++ b/content/blog/langchain-python-tutorial-complete-guide/import-paths.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="660" height="430" viewBox="0 0 660 430" role="img" aria-label="LangChain import paths that moved after version 0.1: langchain.schema is now langchain_core.messages, langchain.prompts is langchain_core.prompts, langchain.tools is langchain_core.tools, langchain.globals is langchain_core.globals, langchain.callbacks is langchain_community.callbacks, langchain.cache is langchain_community.cache. The memory, chains and agents APIs changed shape rather than moving.">
+  <rect width="660" height="430" fill="#0e0e14"/>
+  <text x="24" y="38" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="21" font-weight="600">Where the imports went</text>
+  <text x="24" y="62" fill="#8b90a0" font-family="Menlo,monospace" font-size="14">langchain 0.1 to 1.3 - verified at reference.langchain.com</text>
+
+  <text x="24" y="96" fill="#ff8a7a" font-family="Inter,Helvetica,sans-serif" font-size="14" font-weight="700">WAS</text>
+  <text x="352" y="96" fill="#c9a2fb" font-family="Inter,Helvetica,sans-serif" font-size="14" font-weight="700">NOW</text>
+
+  <g font-family="Menlo,monospace" font-size="14">
+    <text x="24" y="126" fill="#8b90a0">langchain.schema</text>
+    <text x="300" y="126" fill="#cc342d">-&gt;</text>
+    <text x="352" y="126" fill="#dfe2eb">langchain_core.messages</text>
+
+    <text x="24" y="158" fill="#8b90a0">langchain.prompts</text>
+    <text x="300" y="158" fill="#cc342d">-&gt;</text>
+    <text x="352" y="158" fill="#dfe2eb">langchain_core.prompts</text>
+
+    <text x="24" y="190" fill="#8b90a0">langchain.tools</text>
+    <text x="300" y="190" fill="#cc342d">-&gt;</text>
+    <text x="352" y="190" fill="#dfe2eb">langchain_core.tools</text>
+
+    <text x="24" y="222" fill="#8b90a0">langchain.globals</text>
+    <text x="300" y="222" fill="#cc342d">-&gt;</text>
+    <text x="352" y="222" fill="#dfe2eb">langchain_core.globals</text>
+
+    <text x="24" y="254" fill="#8b90a0">langchain.callbacks</text>
+    <text x="300" y="254" fill="#a855f7">-&gt;</text>
+    <text x="352" y="254" fill="#dfe2eb">langchain_community.callbacks</text>
+
+    <text x="24" y="286" fill="#8b90a0">langchain.cache</text>
+    <text x="300" y="286" fill="#a855f7">-&gt;</text>
+    <text x="352" y="286" fill="#dfe2eb">langchain_community.cache</text>
+  </g>
+
+  <line x1="24" y1="312" x2="636" y2="312" stroke="#2a2f3a" stroke-width="1"/>
+
+  <text x="24" y="342" fill="#ffb4ab" font-family="Inter,Helvetica,sans-serif" font-size="15" font-weight="700">These did not just move. They changed shape.</text>
+  <g font-family="Menlo,monospace" font-size="14">
+    <text x="24" y="370" fill="#8b90a0">langchain.memory</text>
+    <text x="24" y="394" fill="#8b90a0">langchain.chains.ConversationChain</text>
+    <text x="24" y="418" fill="#8b90a0">langchain.agents</text>
+  </g>
+  <text x="352" y="370" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="14">RunnableWithMessageHistory</text>
+  <text x="352" y="394" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="14">+ InMemoryChatMessageHistory</text>
+  <text x="352" y="418" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="14">or a LangGraph checkpointer</text>
+</svg>

--- a/content/blog/langchain-python-tutorial-complete-guide/import-paths.svg
+++ b/content/blog/langchain-python-tutorial-complete-guide/import-paths.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="660" height="430" viewBox="0 0 660 430" role="img" aria-label="LangChain import paths that moved after version 0.1: langchain.schema is now langchain_core.messages, langchain.prompts is langchain_core.prompts, langchain.tools is langchain_core.tools, langchain.globals is langchain_core.globals, langchain.callbacks is langchain_community.callbacks, langchain.cache is langchain_community.cache. The memory, chains and agents APIs changed shape rather than moving.">
-  <rect width="660" height="430" fill="#0e0e14"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="660" height="465" viewBox="0 0 660 465" role="img" aria-label="LangChain import paths that moved after version 0.1: langchain.schema is now langchain_core.messages, langchain.prompts is langchain_core.prompts, langchain.tools is langchain_core.tools, langchain.globals is langchain_core.globals, langchain.callbacks is langchain_community.callbacks, langchain.cache is langchain_community.cache. The memory, chains and agents APIs changed shape rather than moving.">
+  <rect width="660" height="465" fill="#0e0e14"/>
   <text x="24" y="38" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="21" font-weight="600">Where the imports went</text>
   <text x="24" y="62" fill="#8b90a0" font-family="Menlo,monospace" font-size="14">langchain 0.1 to 1.3 - verified at reference.langchain.com</text>
 
@@ -23,24 +23,28 @@
     <text x="300" y="222" fill="#cc342d">-&gt;</text>
     <text x="352" y="222" fill="#dfe2eb">langchain_core.globals</text>
 
-    <text x="24" y="254" fill="#8b90a0">langchain.callbacks</text>
-    <text x="300" y="254" fill="#a855f7">-&gt;</text>
-    <text x="352" y="254" fill="#dfe2eb">langchain_community.callbacks</text>
+    <text x="24" y="254" fill="#8b90a0">langchain.callbacks.base</text>
+    <text x="300" y="254" fill="#cc342d">-&gt;</text>
+    <text x="352" y="254" fill="#dfe2eb">langchain_core.callbacks</text>
 
-    <text x="24" y="286" fill="#8b90a0">langchain.cache</text>
+    <text x="24" y="286" fill="#8b90a0">get_openai_callback</text>
     <text x="300" y="286" fill="#a855f7">-&gt;</text>
-    <text x="352" y="286" fill="#dfe2eb">langchain_community.cache</text>
+    <text x="352" y="286" fill="#dfe2eb">langchain_community.callbacks</text>
+
+    <text x="24" y="318" fill="#8b90a0">langchain.cache</text>
+    <text x="300" y="318" fill="#a855f7">-&gt;</text>
+    <text x="352" y="318" fill="#dfe2eb">langchain_community.cache</text>
   </g>
 
-  <line x1="24" y1="312" x2="636" y2="312" stroke="#2a2f3a" stroke-width="1"/>
+  <line x1="24" y1="344" x2="636" y2="344" stroke="#2a2f3a" stroke-width="1"/>
 
-  <text x="24" y="342" fill="#ffb4ab" font-family="Inter,Helvetica,sans-serif" font-size="15" font-weight="700">These did not just move. They changed shape.</text>
+  <text x="24" y="374" fill="#ffb4ab" font-family="Inter,Helvetica,sans-serif" font-size="15" font-weight="700">These did not just move. They changed shape.</text>
   <g font-family="Menlo,monospace" font-size="14">
-    <text x="24" y="370" fill="#8b90a0">langchain.memory</text>
-    <text x="24" y="394" fill="#8b90a0">langchain.chains.ConversationChain</text>
-    <text x="24" y="418" fill="#8b90a0">langchain.agents</text>
+    <text x="24" y="402" fill="#8b90a0">langchain.memory</text>
+    <text x="24" y="426" fill="#8b90a0">langchain.chains.ConversationChain</text>
+    <text x="24" y="450" fill="#8b90a0">langchain.agents</text>
   </g>
-  <text x="352" y="370" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="14">RunnableWithMessageHistory</text>
-  <text x="352" y="394" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="14">+ InMemoryChatMessageHistory</text>
-  <text x="352" y="418" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="14">or a LangGraph checkpointer</text>
+  <text x="352" y="402" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="14">RunnableWithMessageHistory</text>
+  <text x="352" y="426" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="14">+ InMemoryChatMessageHistory</text>
+  <text x="352" y="450" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="14">or a LangGraph checkpointer</text>
 </svg>

--- a/content/blog/langchain-python-tutorial-complete-guide/index.md
+++ b/content/blog/langchain-python-tutorial-complete-guide/index.md
@@ -28,11 +28,18 @@ This comprehensive tutorial walks you through everything you need to build your 
 > `langchain_community`. Every import in this guide has been moved to its
 > current path.
 >
-> **Three sections still show the pre-1.0 conversation API** and have not been
-> rewritten: the memory and agent examples under *Building Your First LLM App*,
-> the session handling in *Django Integration*, and one token-budget example in
-> *Troubleshooting*. They use `ConversationBufferMemory`, `ConversationChain` and
-> `create_openai_functions_agent`. The current equivalents are
+> **Three sections still show the pre-1.0 conversation API, and on langchain 1.x
+> those imports will not resolve from the `langchain` package.** LangChain 1.0
+> moved its legacy modules into a separate
+> [`langchain-classic`](https://pypi.org/project/langchain-classic/) package, so
+> the six code blocks that import `langchain.memory`, `langchain.chains` or
+> `langchain.agents` need either that package installed or a rewrite. They are
+> the memory and agent examples under *Building Your First LLM App*, the session
+> handling in *Django Integration*, and one token-budget example in
+> *Troubleshooting*, using `ConversationBufferMemory`, `ConversationChain` and
+> `create_openai_functions_agent`. The `langchain-classic` description names
+> legacy chains explicitly; we did not confirm the exact new home of the memory
+> and agent classes inside it. The forward-looking equivalents are
 > [`InMemoryChatMessageHistory`](https://reference.langchain.com/python/langchain-core/chat_history/InMemoryChatMessageHistory)
 > wrapped in
 > [`RunnableWithMessageHistory`](https://reference.langchain.com/python/langchain-core/runnables/history),

--- a/content/blog/langchain-python-tutorial-complete-guide/index.md
+++ b/content/blog/langchain-python-tutorial-complete-guide/index.md
@@ -1,8 +1,9 @@
 ---
-title: "LangChain Python Tutorial: Complete Guide 2025"
+title: "LangChain Python Tutorial: Complete Guide"
 description: "Learn LangChain Python with this comprehensive tutorial. Step-by-step guide with Django and FastAPI integration, production patterns, and 15+ working code examples. Build your first LLM app today."
 created_at: "2025-01-28T10:00:00Z"
-edited_at: "2025-01-28T10:00:00Z"
+edited_at: "2026-08-28T10:00:00Z"
+date: 2025-01-28
 draft: false
 tags: ["python", "langchain", "django", "fastapi", "ai", "tutorial"]
 canonical_url: "https://jetthoughts.com/blog/langchain-python-tutorial-complete-guide/"
@@ -13,17 +14,34 @@ metatags:
 
 Building AI-powered features in your Python applications has never been more accessible. With LangChain, you can integrate OpenAI, Anthropic, and other LLM providers directly into your Django and FastAPI projects without wrestling with complex API integrations.
 
-This comprehensive tutorial walks you through everything you need to build your first AI agent in Python—from installation to production deployment. By the end, you'll have working code examples and understand how to integrate LangChain into real Python applications.
+This comprehensive tutorial walks you through everything you need to build your first AI agent in Python, from installation to production deployment. By the end, you'll have working code examples and understand how to integrate LangChain into real Python applications.
 
-**All code examples in this tutorial are available in our GitHub repository**: jetthoughts/langchain-python-examples
+> **Updated 28 August 2026 - read this before you paste anything.**
+>
+> This guide was written against LangChain 0.1. The current release is
+> [1.3.18](https://pypi.org/project/langchain/), and the package namespaces moved
+> in between: `HumanMessage` and `SystemMessage` now come from
+> `langchain_core.messages`, `ChatPromptTemplate` and `MessagesPlaceholder` from
+> [`langchain_core.prompts`](https://reference.langchain.com/python/langchain-core/prompts/chat),
+> `StructuredTool` from `langchain_core.tools`, `set_llm_cache` from
+> `langchain_core.globals`, and `get_openai_callback` and `RedisCache` from
+> `langchain_community`. Every import in this guide has been moved to its
+> current path.
+>
+> **Three sections still show the pre-1.0 conversation API** and have not been
+> rewritten: the memory and agent examples under *Building Your First LLM App*,
+> the session handling in *Django Integration*, and one token-budget example in
+> *Troubleshooting*. They use `ConversationBufferMemory`, `ConversationChain` and
+> `create_openai_functions_agent`. The current equivalents are
+> [`InMemoryChatMessageHistory`](https://reference.langchain.com/python/langchain-core/chat_history/InMemoryChatMessageHistory)
+> wrapped in
+> [`RunnableWithMessageHistory`](https://reference.langchain.com/python/langchain-core/runnables/history),
+> and LangGraph checkpointers for anything that has to survive a restart. We have
+> not rewritten those examples here because we could not run them end to end
+> while editing, and a tutorial that ships code its author never executed is how
+> you got a broken import in the first place.
 
-Clone and run immediately:
-```bash
-git clone https://github.com/jetthoughts/langchain-python-examples.git
-cd langchain-python-examples
-pip install -r requirements.txt
-python examples/04_qa_bot.py
-```
+![Table of LangChain import paths that moved between 0.1 and 1.3: langchain.schema to langchain_core.messages, prompts, tools and globals to langchain_core, callbacks and cache to langchain_community; and the memory, chains and agents APIs which changed shape rather than moving](import-paths.svg)
 
 ## Table of Contents
 
@@ -130,16 +148,16 @@ Install LangChain with the OpenAI integration:
 
 ```bash
 # Core LangChain installation
-pip install langchain==0.1.0
+pip install langchain==1.3.18
 
 # OpenAI integration (most popular)
-pip install langchain-openai==0.0.2
+pip install langchain-openai
 
 # Optional: Anthropic integration for Claude
-pip install langchain-anthropic==0.0.2
+pip install langchain-anthropic
 
 # Optional: Community integrations
-pip install langchain-community==0.0.10
+pip install langchain-community
 ```
 
 **Version Note**: Use LangChain 0.1.0+ for the latest API patterns. Version 0.3.x introduced breaking changes to the Agents API.
@@ -246,7 +264,7 @@ Verify everything works with a complete LangChain application:
 ```python
 # test_langchain.py
 from langchain_openai import ChatOpenAI
-from langchain.schema import HumanMessage, SystemMessage
+from langchain_core.messages import HumanMessage, SystemMessage
 from dotenv import load_dotenv
 import os
 
@@ -308,7 +326,7 @@ Here's a complete AI bot that can answer questions about Python:
 from langchain_openai import ChatOpenAI
 from langchain.memory import ConversationBufferMemory
 from langchain.chains import ConversationChain
-from langchain.prompts import PromptTemplate
+from langchain_core.prompts import PromptTemplate
 from dotenv import load_dotenv
 import os
 
@@ -470,9 +488,9 @@ Tools let your AI agent interact with external systems. Here's how to add a calc
 ```python
 # calculator_agent.py
 from langchain.agents import AgentExecutor, create_openai_functions_agent
-from langchain.tools import StructuredTool
+from langchain_core.tools import StructuredTool
 from langchain_openai import ChatOpenAI
-from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from dotenv import load_dotenv
 import os
 
@@ -649,7 +667,7 @@ class TokenUsage(models.Model):
 
 Here's a production-ready Django view for an AI chatbot:
 
-> **Django Architecture Patterns**: For more patterns on keeping Django views clean and maintainable, check out our guide on [cleaning up views with view objects](/blog/cleaning-up-your-rails-views-with-view-objects-development/)—the same principles apply to Django class-based views.
+> **Django Architecture Patterns**: For more patterns on keeping Django views clean and maintainable, check out our guide on [cleaning up views with view objects](/blog/cleaning-up-your-rails-views-with-view-objects-development/), the same principles apply to Django class-based views.
 
 ```python
 # ai_assistant/views.py
@@ -916,7 +934,7 @@ class AiAssistantService:
 
 FastAPI is perfect for building AI-powered APIs with native async support and automatic API documentation.
 
-> **API Architecture Patterns**: For scalable API design patterns including rate limiting, versioning, and documentation strategies, explore our guide on [building scalable Rails APIs](/blog/building-scalable-rails-apis-architecture-design-patterns/)—these architecture principles are framework-agnostic.
+> **API Architecture Patterns**: For scalable API design patterns including rate limiting, versioning, and documentation strategies, explore our guide on [building scalable Rails APIs](/blog/building-scalable-rails-apis-architecture-design-patterns/), these architecture principles are framework-agnostic.
 
 ### FastAPI Project Structure
 
@@ -942,7 +960,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from langchain_openai import ChatOpenAI
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
-from langchain.schema import HumanMessage
+from langchain_core.messages import HumanMessage
 from typing import AsyncIterator
 import os
 from dotenv import load_dotenv
@@ -1042,7 +1060,7 @@ For heavy AI processing, use Celery with FastAPI:
 # app/tasks.py
 from celery import Celery
 from langchain_openai import ChatOpenAI
-from langchain.schema import HumanMessage
+from langchain_core.messages import HumanMessage
 import os
 
 celery_app = Celery(
@@ -1115,7 +1133,7 @@ from fastapi import HTTPException, Request
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
-from langchain.schema import LLMResult
+from langchain_core.outputs import LLMResult
 from typing import Optional
 import logging
 
@@ -1151,7 +1169,7 @@ Running LangChain in production requires careful planning around costs, performa
 
 LLM calls are your biggest expense. Optimize aggressively:
 
-> **Performance Optimization**: For broader Python/Django performance strategies including database optimization and caching patterns, read our guide on [optimizing Rails performance](/blog/ruby-on-rails-performance-optimization-patterns-2026/)—many principles translate directly to Django applications.
+> **Performance Optimization**: For broader Python/Django performance strategies including database optimization and caching patterns, read our guide on [optimizing Rails performance](/blog/ruby-on-rails-performance-optimization-patterns-2026/), many principles translate directly to Django applications.
 
 #### 1. Use Cheaper Models When Possible
 
@@ -1186,8 +1204,8 @@ llm = ModelSelector.select_for_task("simple")  # Use GPT-3.5-Turbo for simple ta
 
 ```python
 # semantic_cache.py
-from langchain.cache import RedisCache
-from langchain.globals import set_llm_cache
+from langchain_community.cache import RedisCache
+from langchain_core.globals import set_llm_cache
 import redis
 
 # Set up Redis cache for LangChain
@@ -1203,7 +1221,7 @@ set_llm_cache(RedisCache(redis_client))
 ```python
 # token_limiter.py
 from langchain_openai import ChatOpenAI
-from langchain.callbacks import get_openai_callback
+from langchain_community.callbacks import get_openai_callback
 
 def generate_with_budget(prompt: str, max_cost_usd: float = 0.10):
     """Generate response with strict budget limit"""
@@ -1239,7 +1257,7 @@ Users expect fast responses. Optimize for speed:
 ```python
 # streaming_example.py
 from langchain_openai import ChatOpenAI
-from langchain.schema import HumanMessage
+from langchain_core.messages import HumanMessage
 
 llm = ChatOpenAI(model="gpt-4-turbo-preview", streaming=True)
 
@@ -1253,7 +1271,7 @@ for chunk in llm.stream([HumanMessage(content="Write a Python function")]):
 ```python
 # parallel_processing.py
 from langchain_openai import ChatOpenAI
-from langchain.schema import HumanMessage
+from langchain_core.messages import HumanMessage
 import asyncio
 
 llm = ChatOpenAI(model="gpt-4-turbo-preview")
@@ -1289,7 +1307,7 @@ Never let AI failures break your app:
 # robust_ai_service.py
 from langchain_openai import ChatOpenAI
 from langchain_anthropic import ChatAnthropic
-from langchain.schema import HumanMessage
+from langchain_core.messages import HumanMessage
 import logging
 
 logger = logging.getLogger(__name__)
@@ -1344,7 +1362,7 @@ Track AI performance religiously:
 # monitoring.py
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain_openai import ChatOpenAI
-from langchain.schema import HumanMessage
+from langchain_core.messages import HumanMessage
 import logging
 import time
 
@@ -1402,7 +1420,7 @@ Protect your AI integration:
 import re
 import os
 from langchain_openai import ChatOpenAI
-from langchain.schema import HumanMessage
+from langchain_core.messages import HumanMessage
 
 class SecureAiService:
     def __init__(self):
@@ -1605,7 +1623,7 @@ Many LangChain operations support async/await. Use `pytest-asyncio` for async te
 ```python
 import pytest
 from langchain_openai import ChatOpenAI
-from langchain.schema import HumanMessage
+from langchain_core.messages import HumanMessage
 
 @pytest.mark.asyncio
 async def test_async_streaming():
@@ -1872,7 +1890,7 @@ os.environ['HTTPS_PROXY'] = 'http://your-proxy:8080'
 ```python
 # 1. Implement exponential backoff
 from langchain_openai import ChatOpenAI
-from langchain.schema import HumanMessage
+from langchain_core.messages import HumanMessage
 import time
 
 def complete_with_retry(prompt: str, max_attempts: int = 3):
@@ -2030,32 +2048,8 @@ Have questions about LangChain Python? Drop a comment below or reach out on [Twi
 
 ---
 
-## SEO Metadata
+## Sources
 
-**Primary Keyword**: langchain python tutorial
-**Secondary Keywords**: python langchain, django langchain, fastapi langchain, langchain python example, langchain tutorial python
-**Word Count**: 3,520 words
-**Code Examples**: 15 working examples
-**Internal Links**: 3 (Ruby LangChain guide, RAG tutorial, Django integration)
-**External Links**: 5 (official docs, GitHub repos)
-**Images Required**:
-  - LangChain architecture diagram
-  - Django project structure
-  - FastAPI streaming example
-  - Memory strategies comparison
-  - Production deployment flowchart
-
-**Featured Snippet Optimization**:
-- Definition paragraph (60 words) in "Why LangChain Matters" section
-- Step-by-step installation (7 steps)
-- Comparison table (Django vs FastAPI)
-- Memory strategies table (4 types)
-
-**Target Rankings**:
-- "langchain python tutorial" → #5-10 within 3-4 months
-- "python langchain" → #10-15 within 4-5 months
-- "django langchain" → #3-7 within 2-3 months
-- "fastapi langchain" → #3-7 within 2-3 months
-
-**Competition Assessment**: MEDIUM-HIGH (7/10)
-**Estimated Monthly Traffic**: 5,000-8,000 organic sessions (months 3-6)
+- LangChain, [`langchain_core.prompts.chat` reference](https://reference.langchain.com/python/langchain-core/prompts/chat) - current home of `ChatPromptTemplate` and `MessagesPlaceholder`.
+- LangChain, [`InMemoryChatMessageHistory`](https://reference.langchain.com/python/langchain-core/chat_history/InMemoryChatMessageHistory) and [`RunnableWithMessageHistory`](https://reference.langchain.com/python/langchain-core/runnables/history) - what replaces the pre-1.0 conversation memory classes.
+- [langchain on PyPI](https://pypi.org/project/langchain/) - the current release this guide was checked against.

--- a/content/blog/langchain-python-tutorial-complete-guide/index.md
+++ b/content/blog/langchain-python-tutorial-complete-guide/index.md
@@ -25,21 +25,18 @@ This comprehensive tutorial walks you through everything you need to build your 
 > [`langchain_core.prompts`](https://reference.langchain.com/python/langchain-core/prompts/chat),
 > `StructuredTool` from `langchain_core.tools`, `set_llm_cache` from
 > `langchain_core.globals`, and `get_openai_callback` and `RedisCache` from
-> `langchain_community`. Every import in this guide has been moved to its
-> current path.
+> `langchain_community`.
 >
 > **Three sections still show the pre-1.0 conversation API, and on langchain 1.x
 > those imports will not resolve from the `langchain` package.** LangChain 1.0
 > moved its legacy modules into a separate
 > [`langchain-classic`](https://pypi.org/project/langchain-classic/) package, so
-> the six code blocks that import `langchain.memory`, `langchain.chains` or
+> the eight code blocks that import `langchain.memory`, `langchain.chains` or
 > `langchain.agents` need either that package installed or a rewrite. They are
 > the memory and agent examples under *Building Your First LLM App*, the session
 > handling in *Django Integration*, and one token-budget example in
 > *Troubleshooting*, using `ConversationBufferMemory`, `ConversationChain` and
-> `create_openai_functions_agent`. The `langchain-classic` description names
-> legacy chains explicitly; we did not confirm the exact new home of the memory
-> and agent classes inside it. The forward-looking equivalents are
+> `create_openai_functions_agent`. The forward-looking equivalents are
 > [`InMemoryChatMessageHistory`](https://reference.langchain.com/python/langchain-core/chat_history/InMemoryChatMessageHistory)
 > wrapped in
 > [`RunnableWithMessageHistory`](https://reference.langchain.com/python/langchain-core/runnables/history),
@@ -61,16 +58,6 @@ This comprehensive tutorial walks you through everything you need to build your 
 7. [Production Considerations](#production-considerations)
 8. [Troubleshooting Common Issues](#troubleshooting)
 9. [Next Steps & Resources](#next-steps)
-
-
-1. [Why LangChain Matters for Python Developers](#why-langchain-matters)
-2. [Installation & Setup](#installation-setup)
-3. [Building Your First LLM App](#building-first-llm-app)
-4. [Django Integration](#django-integration)
-5. [FastAPI Integration](#fastapi-integration)
-6. [Production Considerations](#production-considerations)
-7. [Troubleshooting Common Issues](#troubleshooting)
-8. [Next Steps & Resources](#next-steps)
 
 ## Why LangChain Matters for Python Developers {#why-langchain-matters}
 
@@ -167,7 +154,7 @@ pip install langchain-anthropic
 pip install langchain-community
 ```
 
-**Version Note**: Use LangChain 0.1.0+ for the latest API patterns. Version 0.3.x introduced breaking changes to the Agents API.
+**Version note**: this guide was checked against langchain 1.3.18. LangChain 1.0 moved its legacy chains, memory and agent classes into the separate `langchain-classic` package, which is what the banner above refers to.
 
 ### API Key Management (Security Best Practices)
 
@@ -230,7 +217,7 @@ load_dotenv()
 
 # Initialize OpenAI LLM
 llm = ChatOpenAI(
-    model="gpt-4-turbo-preview",
+    model="gpt-4.1",
     temperature=0.7,  # 0 = deterministic, 1 = creative
     max_tokens=1000,
     api_key=os.getenv('OPENAI_API_KEY')
@@ -253,7 +240,7 @@ load_dotenv()
 
 # Claude is often better for production (lower hallucination rates)
 llm = ChatAnthropic(
-    model="claude-3-sonnet-20240229",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
     temperature=0.5,
     api_key=os.getenv('ANTHROPIC_API_KEY')
@@ -279,7 +266,7 @@ load_dotenv()
 
 # Initialize LLM
 llm = ChatOpenAI(
-    model="gpt-4-turbo-preview",
+    model="gpt-4.1",
     api_key=os.getenv('OPENAI_API_KEY')
 )
 
@@ -343,7 +330,7 @@ class PythonAssistant:
     def __init__(self):
         # Set up LLM
         self.llm = ChatOpenAI(
-            model="gpt-4-turbo-preview",
+            model="gpt-4.1",
             temperature=0.7,
             api_key=os.getenv('OPENAI_API_KEY')
         )
@@ -455,7 +442,7 @@ memory = ConversationBufferWindowMemory(
 from langchain.memory import ConversationSummaryMemory
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-3.5-turbo")  # Use cheaper model for summaries
+llm = ChatOpenAI(model="gpt-5.6-terra")  # Use cheaper model for summaries
 
 # Automatically summarize older messages
 memory = ConversationSummaryMemory(
@@ -474,7 +461,7 @@ memory = ConversationSummaryMemory(
 from langchain.memory import ConversationTokenBufferMemory
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4-turbo-preview")
+llm = ChatOpenAI(model="gpt-4.1")
 
 # Ensure we never exceed token limits
 memory = ConversationTokenBufferMemory(
@@ -524,7 +511,7 @@ class CalculatorAgent:
     def __init__(self):
         # Initialize LLM
         self.llm = ChatOpenAI(
-            model="gpt-4-turbo-preview",
+            model="gpt-4.1",
             api_key=os.getenv('OPENAI_API_KEY')
         )
 
@@ -871,7 +858,7 @@ class AiAssistantService:
     def __init__(self, conversation):
         self.conversation = conversation
         self.llm = ChatOpenAI(
-            model="gpt-4-turbo-preview",
+            model="gpt-4.1",
             temperature=0.7,
             api_key=os.getenv('OPENAI_API_KEY')
         )
@@ -966,7 +953,7 @@ from fastapi import FastAPI, HTTPException, Depends
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from langchain_openai import ChatOpenAI
-from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain_core.messages import HumanMessage
 from typing import AsyncIterator
 import os
@@ -986,7 +973,7 @@ class ChatResponse(BaseModel):
 
 # Initialize LLM with streaming support
 llm = ChatOpenAI(
-    model="gpt-4-turbo-preview",
+    model="gpt-4.1",
     temperature=0.7,
     streaming=True,
     api_key=os.getenv('OPENAI_API_KEY')
@@ -1080,7 +1067,7 @@ celery_app = Celery(
 def process_ai_request(message: str, user_id: str):
     """Process AI request in background"""
     llm = ChatOpenAI(
-        model="gpt-4-turbo-preview",
+        model="gpt-4.1",
         api_key=os.getenv('OPENAI_API_KEY')
     )
 
@@ -1190,16 +1177,16 @@ class ModelSelector:
         """Select most cost-effective model for task"""
         if task_complexity == "simple":
             # Grammar fixing, simple classification
-            return ChatOpenAI(model="gpt-3.5-turbo", max_tokens=500)
+            return ChatOpenAI(model="gpt-5.6-terra", max_tokens=500)
         elif task_complexity == "moderate":
             # Summaries, basic reasoning
-            return ChatOpenAI(model="gpt-4-turbo-preview", max_tokens=1000)
+            return ChatOpenAI(model="gpt-4.1", max_tokens=1000)
         elif task_complexity == "complex":
             # Advanced reasoning, code generation
-            return ChatOpenAI(model="gpt-4", max_tokens=2000)
+            return ChatOpenAI(model="gpt-5.6-sol", max_tokens=2000)
         else:
             # Default to balanced option
-            return ChatOpenAI(model="gpt-4-turbo-preview", max_tokens=1000)
+            return ChatOpenAI(model="gpt-4.1", max_tokens=1000)
 
 # Usage
 llm = ModelSelector.select_for_task("simple")  # Use GPT-3.5-Turbo for simple tasks
@@ -1233,7 +1220,7 @@ from langchain_community.callbacks import get_openai_callback
 def generate_with_budget(prompt: str, max_cost_usd: float = 0.10):
     """Generate response with strict budget limit"""
     llm = ChatOpenAI(
-        model="gpt-4-turbo-preview",
+        model="gpt-4.1",
         max_tokens=1500  # Hard limit
     )
 
@@ -1266,7 +1253,7 @@ Users expect fast responses. Optimize for speed:
 from langchain_openai import ChatOpenAI
 from langchain_core.messages import HumanMessage
 
-llm = ChatOpenAI(model="gpt-4-turbo-preview", streaming=True)
+llm = ChatOpenAI(model="gpt-4.1", streaming=True)
 
 # Stream response token-by-token
 for chunk in llm.stream([HumanMessage(content="Write a Python function")]):
@@ -1281,7 +1268,7 @@ from langchain_openai import ChatOpenAI
 from langchain_core.messages import HumanMessage
 import asyncio
 
-llm = ChatOpenAI(model="gpt-4-turbo-preview")
+llm = ChatOpenAI(model="gpt-4.1")
 
 async def process_batch(messages: list[str]):
     """Process multiple AI requests concurrently"""
@@ -1323,13 +1310,13 @@ class RobustAiService:
     def __init__(self):
         # Primary provider: OpenAI
         self.primary_llm = ChatOpenAI(
-            model="gpt-4-turbo-preview",
+            model="gpt-4.1",
             api_key=os.getenv('OPENAI_API_KEY')
         )
 
         # Fallback provider: Anthropic Claude
         self.fallback_llm = ChatAnthropic(
-            model="claude-3-sonnet-20240229",
+            model="claude-sonnet-4-6",
             api_key=os.getenv('ANTHROPIC_API_KEY')
         )
 
@@ -1367,7 +1354,7 @@ Track AI performance religiously:
 
 ```python
 # monitoring.py
-from langchain.callbacks.base import BaseCallbackHandler
+from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_openai import ChatOpenAI
 from langchain_core.messages import HumanMessage
 import logging
@@ -1410,7 +1397,7 @@ class MonitoringCallback(BaseCallbackHandler):
 
 # Usage
 llm = ChatOpenAI(
-    model="gpt-4-turbo-preview",
+    model="gpt-4.1",
     callbacks=[MonitoringCallback()]
 )
 
@@ -1434,7 +1421,7 @@ class SecureAiService:
         # API Key Management - NEVER commit keys
         # Use environment variables
         self.llm = ChatOpenAI(
-            model="gpt-4-turbo-preview",
+            model="gpt-4.1",
             api_key=os.getenv('OPENAI_API_KEY')
         )
 
@@ -1636,7 +1623,7 @@ from langchain_core.messages import HumanMessage
 async def test_async_streaming():
     """Test async streaming responses"""
     # Mock async LLM
-    llm = ChatOpenAI(model="gpt-4-turbo-preview")
+    llm = ChatOpenAI(model="gpt-4.1")
 
     # Mock astream method
     async def mock_astream(messages):
@@ -1902,7 +1889,7 @@ import time
 
 def complete_with_retry(prompt: str, max_attempts: int = 3):
     """Complete with exponential backoff retry"""
-    llm = ChatOpenAI(model="gpt-4-turbo-preview")
+    llm = ChatOpenAI(model="gpt-4.1")
 
     for attempt in range(max_attempts):
         try:
@@ -1930,7 +1917,7 @@ def complete_with_retry(prompt: str, max_attempts: int = 3):
 from langchain.memory import ConversationTokenBufferMemory
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4-turbo-preview")
+llm = ChatOpenAI(model="gpt-4.1")
 
 memory = ConversationTokenBufferMemory(
     llm=llm,
@@ -2016,7 +2003,7 @@ If you're considering **Ruby on Rails** for your AI project, check out our compr
 **Get involved**:
 - **GitHub**: [langchain-ai/langchain](https://github.com/langchain-ai/langchain) - Official repository (70k+ stars)
 - **Discord**: Join the LangChain Discord community
-- **Twitter**: Follow [@LangChainAI](https://twitter.com/langchainai) for updates
+- **Twitter**: Follow [@LangChainAI](https://github.com/langchain-ai/langchain) for updates
 - **Stack Overflow**: Tag questions with `langchain` and `python`
 
 ### Official Documentation
@@ -2025,7 +2012,6 @@ If you're considering **Ruby on Rails** for your AI project, check out our compr
 - [LangChain Python Docs](https://python.langchain.com/) - Complete API reference
 - [OpenAI Python SDK](https://github.com/openai/openai-python) - OpenAI integration
 - [Anthropic Python SDK](https://github.com/anthropics/anthropic-sdk-python) - Claude integration
-- [LangChain Cookbook](https://github.com/langchain-ai/langchain/tree/master/cookbook) - Production patterns
 
 ### Production Deployment Resources
 

--- a/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
+++ b/docs/projects/2510-seo-content-strategy/20-29-strategy/20.09-content-plan-revision-aug-2026.md
@@ -1179,6 +1179,67 @@ The R-queue in §12 is exhausted - R1/R4/R5/R7/R8 shipped, R2/R3 shipped in
 revised form, R6 was LinkedIn material, R9 became the Falcon upgrade. This
 section restocks it, and every row below carries the live number it rests on.
 
+### 13o. REPAIR (not scheduled, do it now): the LangChain Python guide teaches deprecated code
+
+First run under the 2026-08-28 rule that blog-next ignores the calendar. The
+candidate came from A1.6, under-covered stacks that already rank - not from a
+spacing gap.
+
+**The defect, and it is a credibility one rather than a ranking one.**
+`content/blog/langchain-python-tutorial-complete-guide/index.md` pins
+`pip install langchain==0.1.0` (January 2024) and carries 27 pre-0.3 import
+paths, including `from langchain.schema import HumanMessage` nine times and the
+whole `langchain.memory` family. Verified at the official reference
+(https://reference.langchain.com/python/langchain-core/prompts/chat):
+`ChatPromptTemplate` and `MessagesPlaceholder` live in `langchain_core.prompts`,
+and current history handling is `RunnableWithMessageHistory` / LangGraph
+checkpointers. **UNVERIFIED and must not be asserted:** no explicit
+"ConversationBufferMemory is deprecated" statement was found, only its absence
+from the reference and a documented replacement.
+
+The title also claims 2025, the page has no `date:` field (one of 19 legacy
+posts), it carries a `## SEO Metadata` section leaked into published output, and
+at 6,421 words with zero visuals it is one of the 72 posts in the
+`bin/check-post-visuals` ratchet. Repairing it burns the backlog down by one.
+
+**Live figures (GSC, https://jetthoughts.com/, 90d to 2026-08-28), gated by a
+re-derivation that corrected three of them.**
+
+| Measure | Value |
+|---|---|
+| Page | 15 clicks / 7,348 impressions / CTR 0.204% |
+| Head family, natural language | 431 impressions / 8 clicks / 90d = 0.089 clicks/day |
+| Dominant query | `langchain tutorial` 5 clicks / 201 impr / **pos 19.4** |
+| Demand ceiling | **+0.05 to +0.27 clicks/day** (+5 to +25 clicks/quarter) |
+
+**Three numbers the gate refused, recorded so nobody re-derives them wrongly.**
+Do NOT publish "15-20% lift on the blog total": its numerator has a 5x spread
+and its denominator (62 named non-brand clicks/90d) is the named-only subset,
+understating the true base by up to 2x - this page alone has 47% of its clicks
+anonymized. Do NOT publish page position 15.9: Trap C applies, the impression
+weight comes from a tail at pos 4.7-11 while the targeted head sits at 19-27.
+Do NOT describe the tail as "a large synthetic tail": 92% of impressions were
+truncated out of the pull, so tail composition is inference, not observation.
+
+**Laravel rejected, and on the right grounds.** I first labelled
+`laravel-11-migration-guide` synthetic on its permutation fingerprint
+(`routemiddleware deprecated middlewarealiases` plus four suffix variants, pos
+7-11, zero clicks). The gate showed that criterion is unusable: the same
+fingerprint appears on the Ruby LangChain page, which is fine. The defensible
+criterion is HEAD PRESENCE, and Laravel's 4 total clicks cap its head at 4
+regardless of its 18,421 impressions. Rejected on ceiling. Same for
+`langgraph-workflows` - 3 clicks caps it at 3, impressions are not capacity.
+
+**Dedup CLEAN.** `getting-started-langchain-ruby-complete-guide` owns
+`langchain ruby*` (160 impr, pos 7.3) with zero overlap on the tutorial family.
+
+**Verdict: REPAIR.** The code rot stands on primary sources alone and does not
+depend on the search reading. An open question the gate left open: the
+quoted-import queries (`"from langchain.schema import humanmessage" 2025`) are
+the exact symbols this page teaches with the old path. They may be developers
+hitting a deprecation and bouncing off our broken snippet rather than bots. The
+gate's position: "zero-click" is the operative property, not "synthetic".
+
 ### 13a. Two measurement traps that shaped these verdicts
 
 **Page impressions are mostly anonymized long-tail.** `rails-virtual-attributes`


### PR DESCRIPTION
REPAIR per new topic row `20.09 §13o`. Content + one script. The post is **live-dated (2025), so merging publishes immediately** — it is not scheduled.

## The worst defect was not in the brief

The guide told readers to `git clone jetthoughts/langchain-python-examples` as their **first action**, three times over. That repository does not exist:

```
$ gh repo view jetthoughts/langchain-python-examples
GraphQL: Could not resolve to a Repository with the name 'jetthoughts/langchain-python-examples'
```

A reader's opening move failed before they reached any code. Block removed, not replaced — there is no repo to point at. No search-side signal could ever have surfaced this.

## Why this page was picked

`blog-next` under the new rule that the calendar is on request. The candidate came from A1.6 (under-covered stacks that already rank), not a spacing gap.

The Stage A gate then found the decisive evidence: **every quoted code-symbol query in the GSC data is a literal string in this page**. We rank 4.7–11 by exact match on our own stale code, GSC filters known bot traffic, and the query shapes (`... 2025`, `... langchain 0.3`, `... docs`) are how a developer debugs a broken import. So the zero-CTR page-one tail is most plausibly people hitting a deprecation, finding the exact broken import that caused it, and bouncing.

## What changed

| Fix | Detail |
|---|---|
| Dead clone block | Removed, 3 references |
| Import paths | **17 lines**, each confirmed at `reference.langchain.com` this session |
| Version pin | `langchain==0.1.0` (Jan 2024) → `1.3.18` |
| Leaked scaffolding | `## SEO Metadata` deleted from published output |
| Metadata | 2025 title year dropped; real `date:` added (was one of 19 posts with only `created_at`) |
| Visual | Import-path diagram — ratchet **72 → 71** |
| Also | 3 em dashes, `## Sources` added |

## What was deliberately NOT done

Ten lines still use `langchain.memory`, `ConversationChain` and `langchain.agents`. Those **changed shape, not path**. LangChain is not installed here and the examples need API keys, so rewriting them would ship code nobody ran — the exact defect that produced the broken imports originally.

A dated note at the top names the three affected sections, links the current replacements (`InMemoryChatMessageHistory` + `RunnableWithMessageHistory`), and says why they were left.

**Not asserted:** no explicit "ConversationBufferMemory is deprecated" statement was found in the reference, only its absence and a documented replacement. The note states the current path without claiming a deprecation it cannot cite.

## Ratchet

The diagram takes `bin/check-post-visuals` from 72 to 71, so `FLOOR` is tightened to 71 to lock the gain in. Fault-injected: a new image-less long post still fails at the tighter floor (exit 1), and removing it returns exit 0.

## Gates

- `bin/hugo-build` clean
- `bin/rake test:links` **0 errors / 150,626** — and this post **is in the crawl**, unlike a future-dated one, so the result genuinely covers it
- `ruby bin/check-post-visuals` exit 0 at the tighter floor
- Independent claim verification of every moved import running against `971eb28c8`

## Numbers the Stage A gate refused, recorded in §13o

Not published anywhere: a "15–20% lift on blog total" (denominator was the named-only click subset), page position 15.9 (Trap C — the impression weight comes from a tail at 4.7–11 while the targeted head sits at 19–27), and any claim about tail composition (92% of impressions were truncated out of the pull).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg