### PR TITLE
Sweep the corpus for dead models and dead code repos

### DIFF
--- a/content/blog/building-rag-applications-rails-pgvector/index.md
+++ b/content/blog/building-rag-applications-rails-pgvector/index.md
@@ -32,7 +32,6 @@ This tutorial assumes intermediate Rails knowledge. If you're new to AI concepts
 
 We're building a document Q&A system where users can ask questions in natural language and receive AI-generated answers based on your documentation. Think of it as ChatGPT trained specifically on your company's knowledge base.
 
-The complete code examples are available on [GitHub](https://github.com/jetthoughts/rails-rag-pgvector-example).
 
 ## Part 1: Setup & Fundamentals 🟢
 
@@ -753,4 +752,3 @@ What matters most in practice:
 
 ---
 
-**Source code**: Complete working examples available at [github.com/jetthoughts/rails-rag-pgvector-example](https://github.com/jetthoughts/rails-rag-pgvector-example)

--- a/content/blog/elixir-ai-integration-tutorial-complete-guide/index.md
+++ b/content/blog/elixir-ai-integration-tutorial-complete-guide/index.md
@@ -17,7 +17,6 @@ This comprehensive tutorial walks you through everything you need to build your 
 
 **Note**: Complete working code examples are available in this tutorial. All 15 examples can be copy-pasted directly from the sections below.
 
-<!-- GitHub repository coming soon at https://github.com/jetthoughts/elixir-ai-examples -->
 
 ## Table of Contents
 
@@ -257,7 +256,7 @@ defmodule ElixirAiApp.AI.OpenAIClient do
   @behaviour ElixirAiApp.AI.AIClientBehaviour
 
   @base_url "https://api.openai.com/v1"
-  @default_model "gpt-4-turbo-preview"
+  @default_model "gpt-4.1"
   @default_temperature 0.7
   @default_max_tokens 1000
 
@@ -485,7 +484,7 @@ defmodule ElixirAiApp.AI.Assistant do
   @impl true
   def init(opts) do
     max_history = Keyword.get(opts, :max_history, 10)
-    model = Keyword.get(opts, :model, "gpt-4-turbo-preview")
+    model = Keyword.get(opts, :model, "gpt-4.1")
 
     state = %{
       history: [],
@@ -800,7 +799,7 @@ defmodule ElixirAiApp.AI.BatchProcessor do
   Process questions with different AI models concurrently.
   """
   def multi_model_consensus(question) do
-    models = ["gpt-4-turbo-preview", "gpt-3.5-turbo", "gpt-4"]
+    models = ["gpt-4.1", "gpt-3.5-turbo", "gpt-4"]
 
     tasks =
       Enum.map(models, fn model ->

--- a/content/blog/getting-started-langchain-ruby-complete-guide/index.md
+++ b/content/blog/getting-started-langchain-ruby-complete-guide/index.md
@@ -165,7 +165,7 @@ openai_llm = Langchain::LLM::OpenAI.new(
 anthropic_llm = Langchain::LLM::Anthropic.new(
   api_key: ENV['ANTHROPIC_API_KEY'],
   default_options: {
-    model: 'claude-3-sonnet-20240229',
+    model: 'claude-sonnet-4-6',
     max_tokens: 1024,
     temperature: 0.5
   }

--- a/content/blog/laravel-ai-integration-tutorial-complete-guide/index.md
+++ b/content/blog/laravel-ai-integration-tutorial-complete-guide/index.md
@@ -196,7 +196,7 @@ use OpenAI\Laravel\Facades\OpenAI;
 Route::get('/ai/test', function () {
     try {
         $result = OpenAI::chat()->create([
-            'model' => 'gpt-4-turbo-preview',
+            'model' => 'gpt-4.1',
             'messages' => [
                 ['role' => 'system', 'content' => 'You are a helpful Laravel assistant.'],
                 ['role' => 'user', 'content' => 'Explain Laravel in exactly 3 sentences. Be encouraging!'],
@@ -452,7 +452,7 @@ use Illuminate\Support\Facades\Log;
 
 class OpenAIService
 {
-    private string $model = 'gpt-4-turbo-preview';
+    private string $model = 'gpt-4.1';
     private float $temperature = 0.7;
     private int $maxTokens = 1000;
 
@@ -1002,7 +1002,7 @@ class BlogPost extends Model
         }
 
         $result = OpenAI::chat()->create([
-            'model' => 'gpt-4-turbo-preview',
+            'model' => 'gpt-4.1',
             'messages' => [
                 [
                     'role' => 'system',
@@ -1026,7 +1026,7 @@ class BlogPost extends Model
     public function generateTags(): void
     {
         $result = OpenAI::chat()->create([
-            'model' => 'gpt-4-turbo-preview',
+            'model' => 'gpt-4.1',
             'messages' => [
                 [
                     'role' => 'system',
@@ -1915,10 +1915,10 @@ class ModelSelector
     public static function selectForTask(string $taskComplexity): string
     {
         return match($taskComplexity) {
-            'simple' => 'gpt-3.5-turbo',      // Grammar, simple classification ($0.0005/1K tokens)
-            'moderate' => 'gpt-4-turbo-preview', // Summaries, reasoning ($0.01/1K tokens)
-            'complex' => 'gpt-4',             // Advanced reasoning ($0.03/1K tokens)
-            default => 'gpt-4-turbo-preview',
+            'simple' => 'gpt-5.6-terra',   // Grammar, simple classification - cheapest tier
+            'moderate' => 'gpt-4.1',       // Summaries, reasoning - mid tier
+            'complex' => 'gpt-5.6-sol',    // Advanced reasoning - most capable tier
+            default => 'gpt-4.1',
         };
     }
 }
@@ -1979,7 +1979,7 @@ use Illuminate\Support\Facades\Log;
 class RobustOpenAIService
 {
     private array $fallbackModels = [
-        'gpt-4-turbo-preview',  // Primary
+        'gpt-4.1',  // Primary
         'gpt-3.5-turbo',        // Fallback
     ];
 
@@ -2249,7 +2249,7 @@ $result = Retry::times(3)
     ->throw()
     ->run(function () use ($messages) {
         return OpenAI::chat()->create([
-            'model' => 'gpt-4-turbo-preview',
+            'model' => 'gpt-4.1',
             'messages' => $messages,
         ]);
     });
@@ -2330,7 +2330,7 @@ public function failed(\Throwable $exception): void
 
 **Q: How much does Laravel AI integration cost?**
 
-A: OpenAI API costs vary by model. GPT-3.5-Turbo costs $0.0005 per 1K tokens (20x cheaper than GPT-4 at $0.03 per 1K tokens). Implementing proper caching can reduce costs by 40-60%.
+A: OpenAI API costs vary by model, and the per-token rates change often enough that any figure printed here would be wrong within months. Check [OpenAI's pricing page](https://openai.com/api/pricing/) for current rates; the point that matters for architecture is that the cheap tier runs roughly an order of magnitude below the capable one, so routing simple work away from the expensive model is where the saving is. Implementing proper caching can reduce costs by 40-60%.
 
 **Q: Can I use Laravel AI integration with existing Laravel apps?**
 

--- a/content/blog/ruby-langchain-testing-complete-rspec-guide/index.md
+++ b/content/blog/ruby-langchain-testing-complete-rspec-guide/index.md
@@ -674,7 +674,7 @@ FactoryBot.define do
         text: Faker::Lorem.paragraph(sentence_count: 3)
       }]
     end
-    model { 'claude-3-sonnet-20240229' }
+    model { 'claude-sonnet-4-6' }
     stop_reason { 'end_turn' }
     usage do
       {


### PR DESCRIPTION
Content-only, five posts. Follow-on from #632 — both defects it found turned out to be **classes, not one-offs**. The corpus is now clean on each.

## Dead models — 13 references, four posts

Every one calls a model that no longer exists, verified at the vendors' own deprecation pages:

| Model | Where | Status |
|---|---|---|
| `gpt-4-turbo-preview` | laravel ×8, elixir ×3 | **Shut down 26 Mar 2026** |
| `claude-3-sonnet-20240229` | langchain-ruby, langchain-testing | **Retired 21 Jul 2025** |

These are quiet failures. An import error is loud; a dead model name fails later at the API call with a `model_not_found` that a reader takes for a billing or key problem — which is why they sat here unnoticed.

## Dead code repositories

`building-rag-applications-rails-pgvector` told readers **twice** that "complete working examples" live at `jetthoughts/rails-rag-pgvector-example`. That repository 404s. Both references removed rather than replaced — there is nothing to point at.

I checked **all eleven** `jetthoughts/*` repos referenced anywhere in `content/blog`. Only two are dead:

```
elixir-ai-examples             ** 404 **   (already inside an HTML comment)
rails-rag-pgvector-example     ** 404 **   (live, visible, twice)
```

The other nine resolve. The elixir one never reached readers; removed anyway.

## Stale pricing rode along

The laravel task-routing example hardcoded `$0.0005`, `$0.01` and `$0.03` per 1K tokens against models that are now gone, and the FAQ repeated the figures. Replaced with the tiering logic plus a link to OpenAI's live pricing page.

Printing per-token rates in a tutorial is its own rot source — the architectural point (route cheap work away from the expensive model) survives without numbers that expire.

## Gates

- `bin/hugo-build` clean
- `bin/rake test:links` **0 errors / 150,617** — and all five posts are live-dated, so they are **in** the crawl and the result covers them
- `ruby bin/check-post-visuals` exit 0
- Corpus re-sweep after the fix: **0** posts with dead models, **0** posts referencing a 404 repo

## Not done

All five posts have zero visuals and sit in the ratchet's 71. Adding diagrams would burn that backlog down but is a separate, larger piece of work — flagged rather than half-done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg