### PR TITLE
Canon: fCTO is available, not advertised

### DIFF
--- a/.okf/content/claims-canon.md
+++ b/.okf/content/claims-canon.md
@@ -45,10 +45,13 @@ happened. Treat it as the same class as a fabricated testimonial, not as a style
 preference.
 
 **AMENDED (Paul, 2026-08-28).** The ban above is about MISDESCRIBING PAST
-ENGAGEMENTS, not about what we are willing to sell. We do sell technical
-advising in whatever role a client needs it, including fractional CTO and
-engineering manager, and we can deliver it. What is true is that it has found
-no clients and is not the main product.
+ENGAGEMENTS, not about what we are able to deliver.
+
+The accurate position, in Paul's words: we do not lead with fractional CTO and
+we do not claim it as a flagship, but we can provide it if a client turns up.
+It has not found clients and it is not the main service. So it is available
+rather than advertised - do not put it at the front of new positioning work,
+and do not delete it either.
 
 So: **do not flag existing posts or service pages for offering fCTO/EM
 advising, and do not "repair" them.** The `/services/fractional-cto`,

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -3643,10 +3643,13 @@ recalled process substituted for loaded process (the skill was never invoked),
 gate verdicts held as memory rather than bound to a sha, and cost-driven gate
 frequency that ran greps constantly and the browser gate once.
 
-## 2026-08-28 - fCTO/EM advising is sellable; canon wording was too broad
-Amended `content/claims-canon.md`. Paul: "We sell tech advising by any role
-like fCTO or EM... It's not our main product... We can handle such services."
-The 2026-08-21 ban read as prohibiting the OFFER; it was only ever about
-misdescribing a past engagement (Crosslake). A corpus sweep had flagged 36
-posts and 7 CTAs into /services/fractional-cto as canon violations - all false
-positives. Service pages stay, CTAs stay, no repairs.
+## 2026-08-28 - fCTO is available, not advertised; canon wording was too broad
+Amended `content/claims-canon.md` twice. The 2026-08-21 ban read as prohibiting
+the OFFER; it was only ever about misdescribing a past engagement (Crosslake).
+A corpus sweep had flagged 36 posts and 7 CTAs into /services/fractional-cto as
+canon violations - all false positives. Service pages stay, CTAs stay, no
+repairs. Second pass sharpened the wording: the first amendment read as an
+active offer, which overstates it. Paul's position is that we do not lead with
+fractional CTO or claim it as a flagship, but can provide it if a client turns
+up. Available rather than advertised - keep it off the front of new positioning
+work, and do not delete it either.


### PR DESCRIPTION
Docs-only. Second pass on this morning's amendment to `claims-canon.md`.

My first wording said *"we do sell technical advising in whatever role a client needs it"* — that overstates it as an active offer.

Paul's actual position: **we do not lead with fractional CTO and do not claim it as a flagship, but we can provide it if a client turns up.** It has found no clients and is not the main service.

So the rule is **available rather than advertised**:

- Keep it off the front of new positioning work
- Do not delete it either
- The instruction not to flag or repair existing posts and `/services/*` pages is unchanged

Context for why this needed two passes: the original 2026-08-21 ban read as prohibiting the offer itself. A corpus sweep took it that way and surfaced 36 posts plus 7 CTAs as apparent canon violations, against service pages serving HTTP 200. All false positives. The rule was only ever about the factual point underneath — not claiming we supplied a titled leader on an engagement where we did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg