### PR TITLE
Wire test:links_external into the daily cron

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -98,3 +98,18 @@ jobs:
       # process, so the pair shares a single production build. Two steps
       # would build the whole site twice and blow the job timeout.
       - run: bundle exec rake test:links test:html_proofer
+
+      # test:links_external existed in the Rakefile and was wired into no
+      # workflow - the same dead-code-reading-as-coverage defect the comment
+      # above describes for html_proofer. It is what would have caught the dead
+      # LangChain cookbook link, the dead langchainai Twitter link and the 404
+      # blog.langchain.dev source, all of which shipped and were only found by
+      # hand on 2026-08-28.
+      #
+      # Scheduled and manual runs only. External URLs rate-limit and flap, so
+      # running this per-PR would train everyone to ignore a red check; the
+      # daily cron catches rot without blocking anyone. Non-blocking by design.
+      - name: External links (scheduled only, non-blocking)
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        continue-on-error: true
+        run: bundle exec rake test:links_external


### PR DESCRIPTION
Workflow-only. One step added.

## The gap

`test:links_external` has existed in the Rakefile all along and was **wired into no workflow, hook or script**. Dead code reading as coverage — the same defect this file's own comment records for `html_proofer` in the 2026-08-07 audit.

So every external URL across 624 posts went unchecked while a workflow named "Broken Internal Links" correctly reported green. `test:links` runs `lychee --offline`, which is internal-only by design.

## What it let through

Three dead outbound links, all found **by hand** on 2026-08-28 rather than by a gate:

- `github.com/langchain-ai/langchain/tree/master/cookbook` — 404
- `twitter.com/langchainai` — 404
- `blog.langchain.dev/langgraph-1-0/` — 404, and it was cited as the *evidence* for a named-company claim on our highest-impression page (36,098)

## Why cron and not per-PR

External URLs rate-limit and flap. A check that goes red on unrelated PRs trains everyone to ignore it, and an ignored gate is a dead gate — which is the same failure this PR is fixing. Daily cron catches rot without blocking anyone. Non-blocking by the task's own design.

## Verified rather than assumed

```
external step name : External links (scheduled only, non-blocking)
external condition : github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
external blocking  : False
internal unconditional: True
internal still blocking: True
```

The blocking internal check is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg