### PR TITLE
Give the two founder posts something to rest on

### DIFF
--- a/bin/check-post-visuals
+++ b/bin/check-post-visuals
@@ -13,7 +13,7 @@
 # Usage: bin/check-post-visuals [dir]   (default: content/blog)
 #        POST_VISUALS_LIST=1 to print the full burn-down list.
 
-FLOOR = 71
+FLOOR = 69
 MIN_WORDS = 800
 root = ARGV[0] || "content/blog"
 

--- a/content/blog/5-warning-signs-your-startup-needs-technical-leadership/five-warning-signs.svg
+++ b/content/blog/5-warning-signs-your-startup-needs-technical-leadership/five-warning-signs.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="420" viewBox="0 0 640 420" role="img" aria-label="Five warning signs a startup needs technical leadership, ordered from easiest to spot to most serious: simple changes take longer, the team avoids parts of the codebase, technical decisions need multiple meetings, developers start talking about rewriting everything, and team confidence visibly drops">
+  <rect width="640" height="420" fill="#0e0e14"/>
+  <text x="24" y="38" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="21" font-weight="600">Five signs, in the order you notice them</text>
+  <text x="24" y="61" fill="#8b90a0" font-family="Inter,Helvetica,sans-serif" font-size="14">None of these needs you to read code</text>
+
+  <g font-family="Inter,Helvetica,sans-serif" font-size="15">
+    <rect x="24" y="82" width="592" height="52" rx="7" fill="#1c2026" stroke="#7dd0fe" stroke-width="2"/>
+    <text x="44" y="106" fill="#bfe5ff" font-size="14" font-weight="700">1</text>
+    <text x="70" y="106" fill="#dfe2eb">Simple changes take longer and longer</text>
+    <text x="70" y="126" fill="#8b90a0" font-size="13">A one-line fix becomes a two-day estimate</text>
+
+    <rect x="24" y="146" width="592" height="52" rx="7" fill="#1c2026" stroke="#7dd0fe" stroke-width="2"/>
+    <text x="44" y="170" fill="#bfe5ff" font-size="14" font-weight="700">2</text>
+    <text x="70" y="170" fill="#dfe2eb">The team avoids parts of the codebase</text>
+    <text x="70" y="190" fill="#8b90a0" font-size="13">You hear "nobody wants to touch that"</text>
+
+    <rect x="24" y="210" width="592" height="52" rx="7" fill="#1c2026" stroke="#a855f7" stroke-width="2"/>
+    <text x="44" y="234" fill="#c9a2fb" font-size="14" font-weight="700">3</text>
+    <text x="70" y="234" fill="#dfe2eb">Every technical decision needs another meeting</text>
+    <text x="70" y="254" fill="#8b90a0" font-size="13">Nobody is authorised to decide</text>
+
+    <rect x="24" y="274" width="592" height="52" rx="7" fill="#1c2026" stroke="#cc342d" stroke-width="2"/>
+    <text x="44" y="298" fill="#ff8a7a" font-size="14" font-weight="700">4</text>
+    <text x="70" y="298" fill="#dfe2eb">Developers start saying "rewrite everything"</text>
+    <text x="70" y="318" fill="#8b90a0" font-size="13">The codebase is now scarier than a blank page</text>
+
+    <rect x="24" y="338" width="592" height="52" rx="7" fill="#1c2026" stroke="#cc342d" stroke-width="2"/>
+    <text x="44" y="362" fill="#ff8a7a" font-size="14" font-weight="700">5</text>
+    <text x="70" y="362" fill="#dfe2eb">Confidence visibly drops</text>
+    <text x="70" y="382" fill="#8b90a0" font-size="13">Estimates get vague, demos get postponed</text>
+  </g>
+
+  <text x="24" y="410" fill="#8b90a0" font-family="Inter,Helvetica,sans-serif" font-size="13">Blue you can live with for a while. Red is where the cost compounds.</text>
+</svg>

--- a/content/blog/5-warning-signs-your-startup-needs-technical-leadership/index.md
+++ b/content/blog/5-warning-signs-your-startup-needs-technical-leadership/index.md
@@ -37,6 +37,8 @@ The CTO had been working 90-hour weeks for eight months, the engineering team wa
 
 Here's the thing: **every single warning sign was visible six months earlier**. I've helped startups navigate technical leadership challenges, and the patterns are eerily consistent. The companies that thrive are the ones that recognize these warning signs early and act on them. The ones that don't... well, you probably never heard of them.
 
+![Five warning signs a startup needs technical leadership, ordered from easiest to spot to most serious: simple changes taking longer, the team avoiding parts of the codebase, technical decisions needing multiple meetings, developers proposing a full rewrite, and team confidence visibly dropping](five-warning-signs.svg)
+
 ## Warning Sign #1: Simple Changes Take Exponentially Longer
 
 **The Pattern**: What used to take hours now takes days. What used to take days now takes weeks. Your developers are spending more time figuring out *how* to make changes than actually making them.

--- a/content/blog/when-your-startup-needs-emergency-cto-leadership/first-three-weeks.svg
+++ b/content/blog/when-your-startup-needs-emergency-cto-leadership/first-three-weeks.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="330" viewBox="0 0 640 330" role="img" aria-label="The first three weeks of emergency technical leadership: week one is listening and diagnosis with no changes shipped, week two is small visible wins to rebuild confidence, week three onward is building systems that outlast the crisis">
+  <rect width="640" height="330" fill="#0e0e14"/>
+  <text x="24" y="38" fill="#dfe2eb" font-family="Inter,Helvetica,sans-serif" font-size="21" font-weight="600">The first three weeks</text>
+  <text x="24" y="61" fill="#8b90a0" font-family="Inter,Helvetica,sans-serif" font-size="14">What good looks like when someone steps into a technical crisis</text>
+
+  <line x1="40" y1="120" x2="600" y2="120" stroke="#2a2f3a" stroke-width="2"/>
+  <circle cx="110" cy="120" r="9" fill="#cc342d"/>
+  <circle cx="320" cy="120" r="9" fill="#a855f7"/>
+  <circle cx="530" cy="120" r="9" fill="#7dd0fe"/>
+
+  <g font-family="Inter,Helvetica,sans-serif">
+    <text x="110" y="100" fill="#ff8a7a" font-size="15" font-weight="700" text-anchor="middle">WEEK 1</text>
+    <text x="320" y="100" fill="#c9a2fb" font-size="15" font-weight="700" text-anchor="middle">WEEK 2</text>
+    <text x="530" y="100" fill="#bfe5ff" font-size="15" font-weight="700" text-anchor="middle">WEEK 3+</text>
+
+    <text x="110" y="158" fill="#dfe2eb" font-size="16" font-weight="600" text-anchor="middle">Listen</text>
+    <text x="320" y="158" fill="#dfe2eb" font-size="16" font-weight="600" text-anchor="middle">Small wins</text>
+    <text x="530" y="158" fill="#dfe2eb" font-size="16" font-weight="600" text-anchor="middle">Systems</text>
+
+    <text x="110" y="184" fill="#8b90a0" font-size="13" text-anchor="middle">Diagnose before</text>
+    <text x="110" y="202" fill="#8b90a0" font-size="13" text-anchor="middle">changing anything</text>
+    <text x="320" y="184" fill="#8b90a0" font-size="13" text-anchor="middle">Visible progress</text>
+    <text x="320" y="202" fill="#8b90a0" font-size="13" text-anchor="middle">rebuilds trust</text>
+    <text x="530" y="184" fill="#8b90a0" font-size="13" text-anchor="middle">Outlast the</text>
+    <text x="530" y="202" fill="#8b90a0" font-size="13" text-anchor="middle">crisis</text>
+  </g>
+
+  <line x1="24" y1="238" x2="616" y2="238" stroke="#2a2f3a" stroke-width="1"/>
+  <text x="24" y="268" fill="#ffb4ab" font-family="Inter,Helvetica,sans-serif" font-size="15" font-weight="700">The tell that it is going wrong</text>
+  <text x="24" y="294" fill="#8b90a0" font-family="Inter,Helvetica,sans-serif" font-size="14">Somebody starts rewriting in week one, before anyone has worked out</text>
+  <text x="24" y="314" fill="#8b90a0" font-family="Inter,Helvetica,sans-serif" font-size="14">which part is actually broken.</text>
+</svg>

--- a/content/blog/when-your-startup-needs-emergency-cto-leadership/index.md
+++ b/content/blog/when-your-startup-needs-emergency-cto-leadership/index.md
@@ -93,6 +93,8 @@ Here's the kicker: these problems are like a three-legged stool. You can't fix t
 
 Walking into these situations has taught me that effective crisis leadership isn't about being the smartest person in the room—it's about creating clarity when everything feels chaotic.
 
+![Timeline of the first three weeks: week one listening and diagnosis before changing anything, week two small visible wins that rebuild trust, week three onward building systems that outlast the crisis](first-three-weeks.svg)
+
 ### Week One: Listen Before You Leap
 
 My first week in any crisis situation follows the same playbook, and it's probably not what you'd expect. I don't immediately dive into the codebase or start whiteboarding new architectures. Instead, I become a professional listener.


### PR DESCRIPTION
Content-only, two posts, two SVGs.

## Why these two

Measured in the browser during the reader-experience pass. Both were **2,500 words of unbroken prose** — no image, no code block, no table — across 12 and 13 headings:

| Post | Words | Img | Code | Table | Longest prose run |
|---|---|---|---|---|---|
| 5-warning-signs | 2,542 | 0 | 0 | 0 | 1,454 |
| emergency-cto | 2,574 | 0 | 0 | 0 | **1,798** |

These are the ICP's own pages — a non-technical founder, often on a phone, with nothing to anchor on.

## What each diagram does

**5-warning-signs** — the five signs as a scannable ladder, colour-graded from "you can live with this" (blue) to "the cost compounds here" (red), placed before the first warning-sign section so a skimmer gets the whole list in one look. Nothing in it requires reading code, which is the post's own promise.

**emergency-cto** — the week-by-week plan as a timeline, placed before Week One. It carries the failure mode as well as the shape: *somebody starts rewriting in week one, before anyone has worked out which part is actually broken.*

Neither is decoration; each states something the surrounding prose makes the reader assemble for themselves.

## Verified, not eyeballed

Both checked in the browser at mobile width: natural 640, rendered 464, no body overflow, labels legible, no collisions. Screenshotted and read — the measurement would not have caught overlapping text, which is how a label collision shipped into a PR earlier today.

## Ratchet

`bin/check-post-visuals` **71 → 69**. `FLOOR` tightened to 69 to lock the gain. Fault-injected: a new image-less long post still fails at the tighter floor (exit 1), and removing it returns exit 0.

## Gates

- `bin/hugo-build` clean
- `bin/rake test:links` 0 errors / 150,619, both posts live-dated and in the crawl
- `ruby bin/check-post-visuals` exit 0 at floor 69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg