### PR TITLE
Remove a fabricated benchmark triple that spanned two unrelated stacks

### DIFF
--- a/content/blog/django-5-enterprise-migration-guide-production-strategies/index.md
+++ b/content/blog/django-5-enterprise-migration-guide-production-strategies/index.md
@@ -1357,10 +1357,10 @@ class DashboardView(View):
             )
             return response.json()
 
-# Performance comparison:
-# Synchronous: 450ms (sequential operations)
-# Async: 120ms (concurrent operations)
-# Improvement: 73% faster
+# The win here is concurrency, not raw speed: three independent awaits that
+# used to run one after another now overlap, so the view costs roughly the
+# slowest call instead of their sum. Measure your own - it depends entirely on
+# how many external calls you make and how slow they are.
 ```
 
 ### Database Connection Pool Optimization
@@ -1655,9 +1655,8 @@ A: Performance gains depend on I/O-bound operations:
 
 ```python
 # Scenario 1: Heavy I/O (database + external APIs)
-# Django 4.2 sync view: 450ms average
-# Django 5.0 async view: 120ms average
-# Improvement: 73% faster
+# This is where async pays. The more independent I/O a view does, the more
+# there is to overlap. A view making one query gains nothing.
 
 # Scenario 2: CPU-bound operations
 # Django 4.2 sync view: 180ms average


### PR DESCRIPTION
Content-only, one post. Direct follow-on from #638.

## The pattern

The figures deleted from the Solid Queue post yesterday — **450ms → 120ms → 73%** — appear twice more in the Django migration guide, describing *async views* rather than background jobs:

| Post | Context | Claim |
|---|---|---|
| solid-queue (removed #638) | Rails background jobs | P95 450ms → 120ms, 73% reduction |
| django-5-enterprise:1361 | Sequential vs concurrent ops | 450ms → 120ms, 73% faster |
| django-5-enterprise:1658 | Django 4.2 vs 5.0 async view | 450ms → 120ms, 73% faster |

Three appearances of one triple across Rails background jobs and Django request handling is not coincidence.

**The Django post gives itself away without any external check:** it uses the identical three numbers for two *different* scenarios — "sequential operations" and "heavy I/O (database + external APIs)". Two different measurements do not land on the same figures.

## What replaced them

The mechanism, which was the true part and the part a reader can act on:

> async overlaps independent awaits, so the view costs roughly its slowest call instead of their sum — and a view making one query gains nothing

No invented numbers substituted for the removed ones.

## Corpus state

The `450/120/73` template no longer appears anywhere. Two unrelated `450ms` figures remain and are **not** the same defect — a Puma row in falcon's benchmark table, and a full-page-refresh figure in hotwire. Single uses, different contexts.

## Next target, named rather than half-done

`falcon-web-server-async-ruby-production` is our #2 organic page, 5,375 words, **24 benchmark tables and no Sources section**. It passes the uncited ratchet because that gate counts *any* external link (it has 17) rather than whether the numbers are attributed. Verifying those tables is real work, not an edit.

## Gates

`bin/hugo-build` clean · `bin/rake test:links` 0 errors · post in the crawl

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg