### PR TITLE
Falcon benchmarks: say what the numbers can and cannot support

### DIFF
--- a/content/blog/falcon-web-server-async-ruby-production/index.md
+++ b/content/blog/falcon-web-server-async-ruby-production/index.md
@@ -145,7 +145,23 @@ end
 
 ## Performance Benchmarks
 
-Numbers below come from runs against Puma, Unicorn, and a couple of alternatives on identical hardware. Treat them as a starting point - your workload, gem stack, and database pool sizing will all shift the ratios.
+Numbers below come from runs against Puma, Unicorn and a couple of alternatives
+on identical hardware. Read them as indicative rather than reproducible: the load
+generator, the date and the app under test were not recorded alongside them, so
+you cannot re-run these exact figures and check us. What they are good for is the
+shape of the difference, not the absolute values.
+
+If you want numbers with a method attached, the
+[tuning post](/blog/falcon-web-server-production-tuning-benchmarks/) records its
+tooling and includes a rollback that did not go our way. Better still, measure
+your own: your workload, gem stack and database pool sizing move these ratios
+more than the server choice does.
+
+Worth noting what our own table says against us. Agoo beats Falcon on every
+column of the hello-world benchmark below - more requests per second, less
+memory, less CPU. We still reach for Falcon, because a bare hello-world is the
+workload where Falcon's advantage matters least and Rails compatibility matters
+most, but the row stays because deleting it would be dishonest.
 
 ### Hardware Configuration
 - **CPU**: Intel i7-4770 @ 3.40GHz (4 cores, 8 threads)
@@ -184,7 +200,7 @@ Numbers below come from runs against Puma, Unicorn, and a couple of alternatives
 |--------|----------------|----------------------|-----------------|
 | **Falcon** | **5,000** | **2KB** | **<1ms** |
 | Puma | 400 | 8KB | 5ms |
-| Action Cable | 200 | 12KB | 8ms |
+| Action Cable on Puma | 200 | 12KB | 8ms |
 
 ### Real-World Rails Application
 


### PR DESCRIPTION
Content-only, one post — our **#2 organic page** (31 clicks / 2,898 impressions via the alias).

## Verdict: not the same defect class, and here is why that matters

After removing fabricated figures from two posts today, the obvious move was to delete these tables too. That would have been wrong.

**Two things argue the numbers are real:**

1. **Internally coherent.** Falcon shows 102ms against a forced 100ms I/O delay — exactly what a working async server does. Puma's degradation is proportional to its worker-slot count (4 workers × 5 threads = 20 slots) against 400 concurrent users.
2. **The hello-world table shows Agoo beating Falcon on every column** — 7,000 req/s vs 6,000, less memory, less CPU. Nobody fabricates a competitor beating their own recommendation.

Deleting numbers on suspicion is as bad as inventing them.

## What is actually wrong

| Defect | Evidence |
|---|---|
| No load generator named | 0 hits for wrk/ab/k6/oha/autocannon anywhere in 5,375 words |
| No date recorded | 0 hits |
| App under test not described | — |
| `Action Cable` listed as a **web server** | It is a Rails component that runs *on* one |

The sibling post `falcon-web-server-production-tuning-benchmarks` **names its tooling and has a Sources section**. The standard exists in this repo; this post missed it.

## The fix

Numbers reframed as **indicative rather than reproducible**, with the gap named explicitly rather than papered over, and readers pointed at the tuning post for figures that carry a method.

The Agoo row is now called out in prose as running against us — leaving it unremarked reads as an oversight rather than a disclosure.

`Action Cable` → `Action Cable on Puma`, which makes the row mean something.

## Why not just delete the tables

They are the post's substance and there is no positive evidence they are false. The honest repair is to state what they can support. That is a different judgement from the Solid Queue table, which was arithmetically impossible, and the 450/120/73 triple, which appeared verbatim across two unrelated stacks.

## Gates

`bin/hugo-build` clean · `bin/rake test:links` 0 errors · post in the crawl · 0 em dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg