### PR TITLE
Drop the unfalsifiable claim that put the fabrication ratchet at 10

### DIFF
--- a/content/blog/should-you-build-it-in-rails/index.md
+++ b/content/blog/should-you-build-it-in-rails/index.md
@@ -111,7 +111,7 @@ Ruby also says things in less code, and that part has been measured: a [study of
 
 That same study also counted which languages produced programs that ran without failing, and the scripting languages came last, Ruby included. Which is why we will not tell you shorter code means fewer bugs: the paper we just used for the first half contradicts it in the second, and you should hold that against any vendor who quotes you only the flattering page.
 
-Dependency counts run the same way in our experience. Your team names the handful of outside libraries it wants; each of those quietly brings its own, and so on down the chain, until the number actually installed is far larger than the number anybody chose. Every one of them is maintained by a stranger on their own schedule, and can be abandoned without asking you.
+Dependency counts run the same way. Your team names the handful of outside libraries it wants; each of those quietly brings its own, and so on down the chain, until the number actually installed is far larger than the number anybody chose. Every one of them is maintained by a stranger on their own schedule, and can be abandoned without asking you.
 
 ![Diagram showing this website declares 19 Ruby libraries and installs 81, about four times, while it declares 15 JavaScript packages and installs 500, about thirty-three times](dependency-fan-out.svg)
 


### PR DESCRIPTION
`should-you-build-it-in-rails` line 114 carried "in our experience", a banned recurrence-generalisation (`marketing_copy_test.rb:215` — "unfalsifiable authority claim"). It pushed the fabrication ratchet to 10 against a baseline of 9.

**This is failing CI on master, so every open PR inherits it.** Verified by running the test on a detached `origin/master`: same single failure, same post, `Expected 10 to be <= 9`.

The phrase was doing no work. What follows it is checkable by the reader — a founder can run the dependency count — which is exactly why the appeal to unnamed experience was unnecessary.

Local: `marketing_copy_test` 5 runs, 13 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PUkwFTsiv7EB2DYKogbpg